### PR TITLE
fix: add missing parameters to `@db.Decimal`

### DIFF
--- a/packages/schema/src/res/stdlib.zmodel
+++ b/packages/schema/src/res/stdlib.zmodel
@@ -281,7 +281,7 @@ attribute @db.Int8() @@@targetField([BigIntField]) @@@prisma
 attribute @db.DoublePrecision() @@@targetField([FloatField, DecimalField]) @@@prisma
 attribute @db.Real() @@@targetField([FloatField, DecimalField]) @@@prisma
 attribute @db.Float() @@@targetField([FloatField, DecimalField]) @@@prisma
-attribute @db.Decimal(_ p: Int?, s: Int?) @@@targetField([FloatField, DecimalField]) @@@prisma
+attribute @db.Decimal(_ p: Int?, _ s: Int?) @@@targetField([FloatField, DecimalField]) @@@prisma
 attribute @db.Double() @@@targetField([FloatField, DecimalField]) @@@prisma
 attribute @db.Money() @@@targetField([FloatField, DecimalField]) @@@prisma
 attribute @db.SmallMoney() @@@targetField([FloatField, DecimalField]) @@@prisma
@@ -290,7 +290,7 @@ attribute @db.Float4() @@@targetField([FloatField, DecimalField]) @@@prisma
 
 // DateTime type modifiers
 
-attribute @db.DateTime(x: Int?) @@@targetField([DateTimeField]) @@@prisma
+attribute @db.DateTime(_ x: Int?) @@@targetField([DateTimeField]) @@@prisma
 attribute @db.DateTime2() @@@targetField([DateTimeField]) @@@prisma
 attribute @db.SmallDateTime() @@@targetField([DateTimeField]) @@@prisma
 attribute @db.DateTimeOffset() @@@targetField([DateTimeField]) @@@prisma

--- a/packages/schema/src/res/stdlib.zmodel
+++ b/packages/schema/src/res/stdlib.zmodel
@@ -281,7 +281,7 @@ attribute @db.Int8() @@@targetField([BigIntField]) @@@prisma
 attribute @db.DoublePrecision() @@@targetField([FloatField, DecimalField]) @@@prisma
 attribute @db.Real() @@@targetField([FloatField, DecimalField]) @@@prisma
 attribute @db.Float() @@@targetField([FloatField, DecimalField]) @@@prisma
-attribute @db.Decimal() @@@targetField([FloatField, DecimalField]) @@@prisma
+attribute @db.Decimal(_ p: Int?, s: Int?) @@@targetField([FloatField, DecimalField]) @@@prisma
 attribute @db.Double() @@@targetField([FloatField, DecimalField]) @@@prisma
 attribute @db.Money() @@@targetField([FloatField, DecimalField]) @@@prisma
 attribute @db.SmallMoney() @@@targetField([FloatField, DecimalField]) @@@prisma

--- a/packages/schema/tests/schema/validation/attribute-validation.test.ts
+++ b/packages/schema/tests/schema/validation/attribute-validation.test.ts
@@ -304,6 +304,7 @@ describe('Attribute tests', () => {
             model _FloatDecimal {
                 _float Float @db.Float
                 _decimal Decimal @db.Decimal
+                _decimal1 Decimal @db.Decimal(10, 2)
                 _doublePrecision Float @db.DoublePrecision
                 _real Float @db.Real
                 _double Float @db.Double

--- a/packages/schema/tests/schema/validation/attribute-validation.test.ts
+++ b/packages/schema/tests/schema/validation/attribute-validation.test.ts
@@ -1,3 +1,5 @@
+/// <reference types="@types/jest" />
+
 import { loadModel, loadModelWithError } from '../../utils';
 
 describe('Attribute tests', () => {


### PR DESCRIPTION
Fix #472 