### PR TITLE
chore: rename rest-api's option from manageCustomResponse to sendResponse

### DIFF
--- a/packages/server/tests/adapter/express.test.ts
+++ b/packages/server/tests/adapter/express.test.ts
@@ -265,7 +265,7 @@ describe('Express adapter tests - rest handler with customMiddleware', () => {
                 modelMeta,
                 zodSchemas,
                 handler: RESTAPIHandler({ endpoint: 'http://localhost/api' }),
-                manageCustomResponse: true,
+                sendResponse: false,
             })
         );
 


### PR DESCRIPTION
@chemitaxis I'm thinking of renaming the option for better clarity. Do you mind taking a look?