### PR TITLE
refactor: avoid post-read checking for non-nullable to-one relation

### DIFF
--- a/packages/runtime/src/constants.ts
+++ b/packages/runtime/src/constants.ts
@@ -49,3 +49,8 @@ export const PRISIMA_TX_FLAG = '$__zenstack_tx';
  * Field name for getting current enhancer
  */
 export const PRISMA_PROXY_ENHANCER = '$__zenstack_enhancer';
+
+/**
+ * Minimum Prisma version supported
+ */
+export const PRISMA_MINIMUM_VERSION = '4.8.0';

--- a/packages/runtime/src/enhancements/policy/handler.ts
+++ b/packages/runtime/src/enhancements/policy/handler.ts
@@ -118,7 +118,7 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
         // entity fails access policies
         const result: any = await this.utils.processWrite(this.model, 'create', args, (dbOps, writeArgs) => {
             if (this.shouldLogQuery) {
-                this.logger.info(`[withPolicy] \`create\`: ${formatObject(writeArgs)}`);
+                this.logger.info(`[withPolicy] \`create\` ${this.model}: ${formatObject(writeArgs)}`);
             }
             return dbOps.create(writeArgs);
         });
@@ -147,7 +147,7 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
         // entity fails access policies
         const result = await this.utils.processWrite(this.model, 'create', args, (dbOps, writeArgs) => {
             if (this.shouldLogQuery) {
-                this.logger.info(`[withPolicy] \`createMany\`: ${formatObject(writeArgs)}`);
+                this.logger.info(`[withPolicy] \`createMany\` ${this.model}: ${formatObject(writeArgs)}`);
             }
             return dbOps.createMany(writeArgs, skipDuplicates);
         });
@@ -175,7 +175,7 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
         // create fails access policies
         const result: any = await this.utils.processWrite(this.model, 'update', args, (dbOps, writeArgs) => {
             if (this.shouldLogQuery) {
-                this.logger.info(`[withPolicy] \`update\`: ${formatObject(writeArgs)}`);
+                this.logger.info(`[withPolicy] \`update\` ${this.model}: ${formatObject(writeArgs)}`);
             }
             return dbOps.update(writeArgs);
         });
@@ -203,7 +203,7 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
         // create fails access policies
         const result = await this.utils.processWrite(this.model, 'updateMany', args, (dbOps, writeArgs) => {
             if (this.shouldLogQuery) {
-                this.logger.info(`[withPolicy] \`updateMany\`: ${formatObject(writeArgs)}`);
+                this.logger.info(`[withPolicy] \`updateMany\` ${this.model}: ${formatObject(writeArgs)}`);
             }
             return dbOps.updateMany(writeArgs);
         });
@@ -235,7 +235,7 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
         // create fails access policies
         const result: any = await this.utils.processWrite(this.model, 'upsert', args, (dbOps, writeArgs) => {
             if (this.shouldLogQuery) {
-                this.logger.info(`[withPolicy] \`upsert\`: ${formatObject(writeArgs)}`);
+                this.logger.info(`[withPolicy] \`upsert\` ${this.model}: ${formatObject(writeArgs)}`);
             }
             return dbOps.upsert(writeArgs);
         });
@@ -273,7 +273,7 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
 
         // conduct the deletion
         if (this.shouldLogQuery) {
-            this.logger.info(`[withPolicy] \`delete\`:\n${formatObject(args)}`);
+            this.logger.info(`[withPolicy] \`delete\` ${this.model}:\n${formatObject(args)}`);
         }
         await this.modelClient.delete(args);
 
@@ -298,7 +298,7 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
 
         // conduct the deletion
         if (this.shouldLogQuery) {
-            this.logger.info(`[withPolicy] \`deleteMany\`:\n${formatObject(args)}`);
+            this.logger.info(`[withPolicy] \`deleteMany\` ${this.model}:\n${formatObject(args)}`);
         }
         return this.modelClient.deleteMany(args);
     }
@@ -314,7 +314,7 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
         await this.utils.injectAuthGuard(args, this.model, 'read');
 
         if (this.shouldLogQuery) {
-            this.logger.info(`[withPolicy] \`aggregate\`:\n${formatObject(args)}`);
+            this.logger.info(`[withPolicy] \`aggregate\` ${this.model}:\n${formatObject(args)}`);
         }
         return this.modelClient.aggregate(args);
     }
@@ -330,7 +330,7 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
         await this.utils.injectAuthGuard(args, this.model, 'read');
 
         if (this.shouldLogQuery) {
-            this.logger.info(`[withPolicy] \`groupBy\`:\n${formatObject(args)}`);
+            this.logger.info(`[withPolicy] \`groupBy\` ${this.model}:\n${formatObject(args)}`);
         }
         return this.modelClient.groupBy(args);
     }
@@ -343,7 +343,7 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
         await this.utils.injectAuthGuard(args, this.model, 'read');
 
         if (this.shouldLogQuery) {
-            this.logger.info(`[withPolicy] \`count\`:\n${formatObject(args)}`);
+            this.logger.info(`[withPolicy] \`count\` ${this.model}:\n${formatObject(args)}`);
         }
         return this.modelClient.count(args);
     }

--- a/packages/runtime/src/enhancements/policy/index.ts
+++ b/packages/runtime/src/enhancements/policy/index.ts
@@ -2,6 +2,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import path from 'path';
+import semver from 'semver';
+import { PRISMA_MINIMUM_VERSION } from '../../constants';
 import { AuthUser, DbClientContract } from '../../types';
 import { getDefaultModelMeta } from '../model-meta';
 import { makeProxy } from '../proxy';
@@ -53,6 +55,17 @@ export function withPolicy<DbClient extends object>(
     context?: WithPolicyContext,
     options?: WithPolicyOptions
 ): DbClient {
+    if (!prisma) {
+        throw new Error('Invalid prisma instance');
+    }
+
+    const prismaVer = (prisma as any)._clientVersion;
+    if (prismaVer && semver.lt(prismaVer, PRISMA_MINIMUM_VERSION)) {
+        console.warn(
+            `ZenStack requires Prisma version "${PRISMA_MINIMUM_VERSION}" or higher. Detected version is "${prismaVer}".`
+        );
+    }
+
     const _policy = options?.policy ?? getDefaultPolicy();
     const _modelMeta = options?.modelMeta ?? getDefaultModelMeta();
     const _zodSchemas = options?.zodSchemas ?? getDefaultZodSchemas();

--- a/tests/integration/tests/enhancements/with-policy/deep-nested.test.ts
+++ b/tests/integration/tests/enhancements/with-policy/deep-nested.test.ts
@@ -10,10 +10,12 @@ describe('With Policy:deep nested', () => {
     model M1 {
         myId String @id @default(cuid())
         m2 M2?
+        value Int @default(0)
 
         @@allow('all', true)
         @@deny('create', m2.m4?[value == 100])
         @@deny('update', m2.m4?[value == 101])
+        @@deny('read', value == 100)
     }
 
     model M2 {
@@ -59,18 +61,90 @@ describe('With Policy:deep nested', () => {
     `;
 
     let db: WeakDbClientContract;
+    let prisma: WeakDbClientContract;
 
     beforeAll(async () => {
         origDir = path.resolve('.');
     });
 
     beforeEach(async () => {
-        const { withPolicy } = await loadSchema(model);
-        db = withPolicy();
+        const params = await loadSchema(model, { logPrismaQuery: true });
+        db = params.withPolicy();
+        prisma = params.prisma;
     });
 
     afterEach(() => {
         process.chdir(origDir);
+    });
+
+    it('read', async () => {
+        await prisma.m1.create({
+            data: {
+                myId: '1',
+                m2: {
+                    create: {
+                        value: 1,
+                        m3: {
+                            create: { id: '3-1', value: 31 },
+                        },
+                        m4: {
+                            create: [{ value: 41 }, { value: 42 }],
+                        },
+                    },
+                },
+            },
+        });
+        // all readable
+        let r = await db.m1.findUnique({
+            where: { myId: '1' },
+            include: { m2: { include: { m3: true, m4: true } } },
+        });
+        expect(r.m2.m3).toBeTruthy();
+        expect(r.m2.m4).toHaveLength(2);
+        r = await db.m3.findUnique({ where: { id: '3-1' }, include: { m2: { include: { m1: true } } } });
+        expect(r.m2.m1).toBeTruthy();
+
+        await prisma.m1.create({
+            data: {
+                myId: '2',
+                m2: {
+                    create: {
+                        value: 1,
+                        m3: {
+                            create: { value: 200 },
+                        },
+                        m4: {
+                            create: [{ value: 22 }, { value: 200 }],
+                        },
+                    },
+                },
+            },
+        });
+        // check filtered
+        r = await db.m1.findUnique({
+            where: { myId: '2' },
+            include: { m2: { include: { m3: true, m4: true } } },
+        });
+        expect(r.m2.m3).toBeNull();
+        expect(r.m2.m4).toHaveLength(1);
+
+        await prisma.m1.create({
+            data: {
+                myId: '3',
+                value: 100,
+                m2: {
+                    create: {
+                        value: 1,
+                        m3: {
+                            create: { id: '3-2', value: 31 },
+                        },
+                    },
+                },
+            },
+        });
+        // check hoisted filtering, due to m1 is not readable
+        r = await db.m3.findUnique({ where: { id: '3-2' }, include: { m2: { include: { m1: true } } } });
+        expect(r).toBeNull();
     });
 
     it('create', async () => {

--- a/tests/integration/tests/enhancements/with-policy/nested-to-one.test.ts
+++ b/tests/integration/tests/enhancements/with-policy/nested-to-one.test.ts
@@ -92,8 +92,8 @@ describe('With Policy:nested to-one', () => {
         });
 
         const db = withPolicy();
-        await expect(db.m2.findUnique({ where: { id: '1' }, include: { m1: true } })).toBeRejectedByPolicy();
-        await expect(db.m2.findMany({ include: { m1: true } })).toBeRejectedByPolicy();
+        await expect(db.m2.findUnique({ where: { id: '1' }, include: { m1: true } })).toResolveFalsy();
+        await expect(db.m2.findMany({ include: { m1: true } })).resolves.toHaveLength(0);
 
         await prisma.m1.update({ where: { id: '1' }, data: { value: 1 } });
         await expect(db.m2.findMany({ include: { m1: true } })).toResolveTruthy();

--- a/tests/integration/tests/enhancements/with-policy/view.test.ts
+++ b/tests/integration/tests/enhancements/with-policy/view.test.ts
@@ -100,6 +100,6 @@ describe('View Policy Test', () => {
         expect(r1.user).toBeTruthy();
 
         // user not readable
-        await expect(db.userInfo.findFirst({ include: { user: true } })).toBeRejectedByPolicy();
+        await expect(db.userInfo.findFirst({ include: { user: true } })).toResolveFalsy();
     });
 });


### PR DESCRIPTION
- Require minimum Prisma version 4.8.0
- Hoist non-nullable to-one read filter to toplevel