### PR TITLE
fix: number literal precision issue

### DIFF
--- a/packages/language/src/generated/ast.ts
+++ b/packages/language/src/generated/ast.ts
@@ -64,6 +64,14 @@ export function isInternalAttributeName(item: unknown): item is InternalAttribut
     return typeof item === 'string';
 }
 
+export type LiteralExpr = BooleanLiteral | NumberLiteral | StringLiteral;
+
+export const LiteralExpr = 'LiteralExpr';
+
+export function isLiteralExpr(item: unknown): item is LiteralExpr {
+    return reflection.isInstance(item, LiteralExpr);
+}
+
 export type QualifiedName = string;
 
 export function isQualifiedName(item: unknown): item is QualifiedName {
@@ -185,6 +193,18 @@ export const BinaryExpr = 'BinaryExpr';
 
 export function isBinaryExpr(item: unknown): item is BinaryExpr {
     return reflection.isInstance(item, BinaryExpr);
+}
+
+export interface BooleanLiteral extends AstNode {
+    readonly $container: Argument | ArrayExpr | AttributeArg | BinaryExpr | DataSourceField | FieldInitializer | FunctionDecl | GeneratorField | MemberAccessExpr | PluginField | UnaryExpr | UnsupportedFieldType;
+    readonly $type: 'BooleanLiteral';
+    value: Boolean
+}
+
+export const BooleanLiteral = 'BooleanLiteral';
+
+export function isBooleanLiteral(item: unknown): item is BooleanLiteral {
+    return reflection.isInstance(item, BooleanLiteral);
 }
 
 export interface DataModel extends AstNode {
@@ -426,18 +446,6 @@ export function isInvocationExpr(item: unknown): item is InvocationExpr {
     return reflection.isInstance(item, InvocationExpr);
 }
 
-export interface LiteralExpr extends AstNode {
-    readonly $container: Argument | ArrayExpr | AttributeArg | BinaryExpr | DataSourceField | FieldInitializer | FunctionDecl | GeneratorField | MemberAccessExpr | PluginField | UnaryExpr | UnsupportedFieldType;
-    readonly $type: 'LiteralExpr';
-    value: Boolean | number | string
-}
-
-export const LiteralExpr = 'LiteralExpr';
-
-export function isLiteralExpr(item: unknown): item is LiteralExpr {
-    return reflection.isInstance(item, LiteralExpr);
-}
-
 export interface MemberAccessExpr extends AstNode {
     readonly $container: Argument | ArrayExpr | AttributeArg | BinaryExpr | DataSourceField | FieldInitializer | FunctionDecl | GeneratorField | MemberAccessExpr | PluginField | UnaryExpr | UnsupportedFieldType;
     readonly $type: 'MemberAccessExpr';
@@ -485,6 +493,18 @@ export const NullExpr = 'NullExpr';
 
 export function isNullExpr(item: unknown): item is NullExpr {
     return reflection.isInstance(item, NullExpr);
+}
+
+export interface NumberLiteral extends AstNode {
+    readonly $container: Argument | ArrayExpr | AttributeArg | BinaryExpr | DataSourceField | FieldInitializer | FunctionDecl | GeneratorField | MemberAccessExpr | PluginField | UnaryExpr | UnsupportedFieldType;
+    readonly $type: 'NumberLiteral';
+    value: string
+}
+
+export const NumberLiteral = 'NumberLiteral';
+
+export function isNumberLiteral(item: unknown): item is NumberLiteral {
+    return reflection.isInstance(item, NumberLiteral);
 }
 
 export interface ObjectExpr extends AstNode {
@@ -551,6 +571,18 @@ export function isReferenceExpr(item: unknown): item is ReferenceExpr {
     return reflection.isInstance(item, ReferenceExpr);
 }
 
+export interface StringLiteral extends AstNode {
+    readonly $container: Argument | ArrayExpr | AttributeArg | BinaryExpr | DataSourceField | FieldInitializer | FunctionDecl | GeneratorField | MemberAccessExpr | PluginField | UnaryExpr | UnsupportedFieldType;
+    readonly $type: 'StringLiteral';
+    value: string
+}
+
+export const StringLiteral = 'StringLiteral';
+
+export function isStringLiteral(item: unknown): item is StringLiteral {
+    return reflection.isInstance(item, StringLiteral);
+}
+
 export interface ThisExpr extends AstNode {
     readonly $container: Argument | ArrayExpr | AttributeArg | BinaryExpr | DataSourceField | FieldInitializer | FunctionDecl | GeneratorField | MemberAccessExpr | PluginField | UnaryExpr | UnsupportedFieldType;
     readonly $type: 'ThisExpr';
@@ -597,6 +629,7 @@ export type ZModelAstType = {
     AttributeParam: AttributeParam
     AttributeParamType: AttributeParamType
     BinaryExpr: BinaryExpr
+    BooleanLiteral: BooleanLiteral
     DataModel: DataModel
     DataModelAttribute: DataModelAttribute
     DataModelField: DataModelField
@@ -620,12 +653,14 @@ export type ZModelAstType = {
     Model: Model
     ModelImport: ModelImport
     NullExpr: NullExpr
+    NumberLiteral: NumberLiteral
     ObjectExpr: ObjectExpr
     Plugin: Plugin
     PluginField: PluginField
     ReferenceArg: ReferenceArg
     ReferenceExpr: ReferenceExpr
     ReferenceTarget: ReferenceTarget
+    StringLiteral: StringLiteral
     ThisExpr: ThisExpr
     TypeDeclaration: TypeDeclaration
     UnaryExpr: UnaryExpr
@@ -635,7 +670,7 @@ export type ZModelAstType = {
 export class ZModelAstReflection extends AbstractAstReflection {
 
     getAllTypes(): string[] {
-        return ['AbstractDeclaration', 'Argument', 'ArrayExpr', 'Attribute', 'AttributeArg', 'AttributeParam', 'AttributeParamType', 'BinaryExpr', 'DataModel', 'DataModelAttribute', 'DataModelField', 'DataModelFieldAttribute', 'DataModelFieldType', 'DataSource', 'DataSourceField', 'Enum', 'EnumField', 'Expression', 'FieldInitializer', 'FunctionDecl', 'FunctionParam', 'FunctionParamType', 'GeneratorDecl', 'GeneratorField', 'InternalAttribute', 'InvocationExpr', 'LiteralExpr', 'MemberAccessExpr', 'Model', 'ModelImport', 'NullExpr', 'ObjectExpr', 'Plugin', 'PluginField', 'ReferenceArg', 'ReferenceExpr', 'ReferenceTarget', 'ThisExpr', 'TypeDeclaration', 'UnaryExpr', 'UnsupportedFieldType'];
+        return ['AbstractDeclaration', 'Argument', 'ArrayExpr', 'Attribute', 'AttributeArg', 'AttributeParam', 'AttributeParamType', 'BinaryExpr', 'BooleanLiteral', 'DataModel', 'DataModelAttribute', 'DataModelField', 'DataModelFieldAttribute', 'DataModelFieldType', 'DataSource', 'DataSourceField', 'Enum', 'EnumField', 'Expression', 'FieldInitializer', 'FunctionDecl', 'FunctionParam', 'FunctionParamType', 'GeneratorDecl', 'GeneratorField', 'InternalAttribute', 'InvocationExpr', 'LiteralExpr', 'MemberAccessExpr', 'Model', 'ModelImport', 'NullExpr', 'NumberLiteral', 'ObjectExpr', 'Plugin', 'PluginField', 'ReferenceArg', 'ReferenceExpr', 'ReferenceTarget', 'StringLiteral', 'ThisExpr', 'TypeDeclaration', 'UnaryExpr', 'UnsupportedFieldType'];
     }
 
     protected override computeIsSubtype(subtype: string, supertype: string): boolean {
@@ -658,6 +693,11 @@ export class ZModelAstReflection extends AbstractAstReflection {
             case GeneratorDecl:
             case Plugin: {
                 return this.isSubtype(AbstractDeclaration, supertype);
+            }
+            case BooleanLiteral:
+            case NumberLiteral:
+            case StringLiteral: {
+                return this.isSubtype(LiteralExpr, supertype);
             }
             case DataModel:
             case Enum: {

--- a/packages/language/src/generated/grammar.ts
+++ b/packages/language/src/generated/grammar.ts
@@ -69,7 +69,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@60"
+                "$ref": "#/rules@63"
               },
               "arguments": []
             }
@@ -118,28 +118,28 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@30"
+              "$ref": "#/rules@33"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@34"
+              "$ref": "#/rules@37"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@36"
+              "$ref": "#/rules@39"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@45"
+              "$ref": "#/rules@48"
             },
             "arguments": []
           }
@@ -161,7 +161,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@62"
+              "$ref": "#/rules@65"
             },
             "arguments": [],
             "cardinality": "*"
@@ -177,7 +177,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -221,7 +221,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@62"
+              "$ref": "#/rules@65"
             },
             "arguments": [],
             "cardinality": "*"
@@ -233,7 +233,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -252,21 +252,21 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@10"
+                    "$ref": "#/rules@13"
                   },
                   "arguments": []
                 },
                 {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@19"
+                    "$ref": "#/rules@22"
                   },
                   "arguments": []
                 },
                 {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@11"
+                    "$ref": "#/rules@14"
                   },
                   "arguments": []
                 }
@@ -291,7 +291,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@62"
+              "$ref": "#/rules@65"
             },
             "arguments": [],
             "cardinality": "*"
@@ -307,7 +307,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -351,7 +351,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@62"
+              "$ref": "#/rules@65"
             },
             "arguments": [],
             "cardinality": "*"
@@ -363,7 +363,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -382,14 +382,14 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@10"
+                    "$ref": "#/rules@13"
                   },
                   "arguments": []
                 },
                 {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@11"
+                    "$ref": "#/rules@14"
                   },
                   "arguments": []
                 }
@@ -414,7 +414,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@62"
+              "$ref": "#/rules@65"
             },
             "arguments": [],
             "cardinality": "*"
@@ -430,7 +430,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -474,7 +474,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@62"
+              "$ref": "#/rules@65"
             },
             "arguments": [],
             "cardinality": "*"
@@ -486,7 +486,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -505,21 +505,21 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@10"
+                    "$ref": "#/rules@13"
                   },
                   "arguments": []
                 },
                 {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@11"
+                    "$ref": "#/rules@14"
                   },
                   "arguments": []
                 },
                 {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@17"
+                    "$ref": "#/rules@20"
                   },
                   "arguments": []
                 }
@@ -541,7 +541,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
       "definition": {
         "$type": "RuleCall",
         "rule": {
-          "$ref": "#/rules@26"
+          "$ref": "#/rules@29"
         },
         "arguments": []
       },
@@ -554,37 +554,98 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
     },
     {
       "$type": "ParserRule",
-      "name": "LiteralExpr",
+      "name": "NumberLiteral",
       "definition": {
         "$type": "Assignment",
         "feature": "value",
         "operator": "=",
         "terminal": {
-          "$type": "Alternatives",
-          "elements": [
-            {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@55"
-              },
-              "arguments": []
-            },
-            {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@61"
-              },
-              "arguments": []
-            },
-            {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@60"
-              },
-              "arguments": []
-            }
-          ]
+          "$type": "RuleCall",
+          "rule": {
+            "$ref": "#/rules@64"
+          },
+          "arguments": []
         }
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "StringLiteral",
+      "definition": {
+        "$type": "Assignment",
+        "feature": "value",
+        "operator": "=",
+        "terminal": {
+          "$type": "RuleCall",
+          "rule": {
+            "$ref": "#/rules@63"
+          },
+          "arguments": []
+        }
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "BooleanLiteral",
+      "definition": {
+        "$type": "Assignment",
+        "feature": "value",
+        "operator": "=",
+        "terminal": {
+          "$type": "RuleCall",
+          "rule": {
+            "$ref": "#/rules@58"
+          },
+          "arguments": []
+        }
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "LiteralExpr",
+      "definition": {
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@10"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@11"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@12"
+            },
+            "arguments": []
+          }
+        ]
       },
       "definesHiddenTokens": false,
       "entry": false,
@@ -666,7 +727,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@58"
+            "$ref": "#/rules@61"
           },
           "arguments": []
         }
@@ -688,7 +749,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@57"
+            "$ref": "#/rules@60"
           },
           "arguments": []
         }
@@ -718,7 +779,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@40"
+                  "$ref": "#/rules@43"
                 },
                 "arguments": []
               },
@@ -735,7 +796,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@15"
+                  "$ref": "#/rules@18"
                 },
                 "arguments": []
               },
@@ -769,7 +830,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@16"
+                "$ref": "#/rules@19"
               },
               "arguments": []
             }
@@ -788,7 +849,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@16"
+                    "$ref": "#/rules@19"
                   },
                   "arguments": []
                 }
@@ -870,7 +931,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@18"
+                    "$ref": "#/rules@21"
                   },
                   "arguments": []
                 }
@@ -889,7 +950,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@18"
+                        "$ref": "#/rules@21"
                       },
                       "arguments": []
                     }
@@ -931,7 +992,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -974,7 +1035,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@36"
+                "$ref": "#/rules@39"
               },
               "deprecatedSyntax": false
             }
@@ -986,7 +1047,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@28"
+              "$ref": "#/rules@31"
             },
             "arguments": [],
             "cardinality": "?"
@@ -1017,7 +1078,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@27"
+              "$ref": "#/rules@30"
             },
             "arguments": []
           },
@@ -1047,7 +1108,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                     "terminal": {
                       "$type": "CrossReference",
                       "type": {
-                        "$ref": "#/rules@31"
+                        "$ref": "#/rules@34"
                       },
                       "deprecatedSyntax": false
                     }
@@ -1088,7 +1149,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@20"
+                "$ref": "#/rules@23"
               },
               "arguments": []
             }
@@ -1115,7 +1176,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@20"
+              "$ref": "#/rules@23"
             },
             "arguments": []
           },
@@ -1198,7 +1259,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@22"
+              "$ref": "#/rules@25"
             },
             "arguments": []
           },
@@ -1230,7 +1291,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@22"
+                    "$ref": "#/rules@25"
                   },
                   "arguments": []
                 }
@@ -1260,7 +1321,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@23"
+              "$ref": "#/rules@26"
             },
             "arguments": []
           },
@@ -1309,7 +1370,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@23"
+                    "$ref": "#/rules@26"
                   },
                   "arguments": []
                 }
@@ -1339,7 +1400,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@24"
+              "$ref": "#/rules@27"
             },
             "arguments": []
           },
@@ -1380,7 +1441,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@24"
+                    "$ref": "#/rules@27"
                   },
                   "arguments": []
                 }
@@ -1410,7 +1471,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@25"
+              "$ref": "#/rules@28"
             },
             "arguments": []
           },
@@ -1451,7 +1512,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@25"
+                    "$ref": "#/rules@28"
                   },
                   "arguments": []
                 }
@@ -1501,7 +1562,14 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@12"
+              "$ref": "#/rules@15"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@16"
             },
             "arguments": []
           },
@@ -1515,28 +1583,14 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@10"
+              "$ref": "#/rules@24"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@21"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@19"
-            },
-            "arguments": []
-          },
-          {
-            "$type": "RuleCall",
-            "rule": {
-              "$ref": "#/rules@11"
+              "$ref": "#/rules@22"
             },
             "arguments": []
           },
@@ -1551,6 +1605,13 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "$type": "RuleCall",
             "rule": {
               "$ref": "#/rules@17"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@20"
             },
             "arguments": []
           }
@@ -1577,7 +1638,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@29"
+                "$ref": "#/rules@32"
               },
               "arguments": []
             }
@@ -1596,7 +1657,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@29"
+                    "$ref": "#/rules@32"
                   },
                   "arguments": []
                 }
@@ -1628,7 +1689,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@40"
+                    "$ref": "#/rules@43"
                   },
                   "arguments": []
                 }
@@ -1674,7 +1735,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@62"
+                "$ref": "#/rules@65"
               },
               "arguments": []
             },
@@ -1707,7 +1768,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@40"
+                        "$ref": "#/rules@43"
                       },
                       "arguments": []
                     }
@@ -1726,7 +1787,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                         "terminal": {
                           "$type": "CrossReference",
                           "type": {
-                            "$ref": "#/rules@30"
+                            "$ref": "#/rules@33"
                           },
                           "deprecatedSyntax": false
                         }
@@ -1745,7 +1806,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                             "terminal": {
                               "$type": "CrossReference",
                               "type": {
-                                "$ref": "#/rules@30"
+                                "$ref": "#/rules@33"
                               },
                               "deprecatedSyntax": false
                             }
@@ -1777,7 +1838,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@40"
+                        "$ref": "#/rules@43"
                       },
                       "arguments": []
                     }
@@ -1800,7 +1861,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@31"
+                    "$ref": "#/rules@34"
                   },
                   "arguments": []
                 }
@@ -1812,7 +1873,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@49"
+                    "$ref": "#/rules@52"
                   },
                   "arguments": []
                 }
@@ -1846,7 +1907,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@62"
+                "$ref": "#/rules@65"
               },
               "arguments": []
             },
@@ -1859,7 +1920,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -1871,7 +1932,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@32"
+                "$ref": "#/rules@35"
               },
               "arguments": []
             }
@@ -1883,7 +1944,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@48"
+                "$ref": "#/rules@51"
               },
               "arguments": []
             },
@@ -1914,7 +1975,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@54"
+                    "$ref": "#/rules@57"
                   },
                   "arguments": []
                 }
@@ -1926,7 +1987,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@33"
+                    "$ref": "#/rules@36"
                   },
                   "arguments": []
                 }
@@ -1943,7 +2004,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@40"
+                      "$ref": "#/rules@43"
                     },
                     "arguments": []
                   },
@@ -2011,7 +2072,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@10"
+                "$ref": "#/rules@13"
               },
               "arguments": []
             }
@@ -2042,7 +2103,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@62"
+                "$ref": "#/rules@65"
               },
               "arguments": []
             },
@@ -2059,7 +2120,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -2078,7 +2139,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@35"
+                    "$ref": "#/rules@38"
                   },
                   "arguments": []
                 }
@@ -2090,7 +2151,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@49"
+                    "$ref": "#/rules@52"
                   },
                   "arguments": []
                 }
@@ -2124,7 +2185,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@62"
+                "$ref": "#/rules@65"
               },
               "arguments": []
             },
@@ -2137,7 +2198,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -2149,7 +2210,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@48"
+                "$ref": "#/rules@51"
               },
               "arguments": []
             },
@@ -2173,7 +2234,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@62"
+              "$ref": "#/rules@65"
             },
             "arguments": [],
             "cardinality": "*"
@@ -2189,7 +2250,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -2208,7 +2269,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@37"
+                    "$ref": "#/rules@40"
                   },
                   "arguments": []
                 }
@@ -2227,7 +2288,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@37"
+                        "$ref": "#/rules@40"
                       },
                       "arguments": []
                     }
@@ -2253,7 +2314,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@38"
+                "$ref": "#/rules@41"
               },
               "arguments": []
             }
@@ -2286,7 +2347,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@50"
+                "$ref": "#/rules@53"
               },
               "arguments": []
             },
@@ -2310,7 +2371,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@62"
+              "$ref": "#/rules@65"
             },
             "arguments": [],
             "cardinality": "*"
@@ -2322,7 +2383,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -2338,7 +2399,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@38"
+                "$ref": "#/rules@41"
               },
               "arguments": []
             }
@@ -2378,7 +2439,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@53"
+                    "$ref": "#/rules@56"
                   },
                   "arguments": []
                 }
@@ -2395,7 +2456,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@40"
+                      "$ref": "#/rules@43"
                     },
                     "arguments": []
                   },
@@ -2442,7 +2503,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@59"
+              "$ref": "#/rules@62"
             },
             "arguments": []
           },
@@ -2459,14 +2520,14 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@59"
+                      "$ref": "#/rules@62"
                     },
                     "arguments": []
                   },
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@54"
+                      "$ref": "#/rules@57"
                     },
                     "arguments": []
                   }
@@ -2494,7 +2555,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@59"
+              "$ref": "#/rules@62"
             },
             "arguments": []
           },
@@ -2553,7 +2614,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@39"
+              "$ref": "#/rules@42"
             },
             "arguments": []
           }
@@ -2580,7 +2641,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@39"
+              "$ref": "#/rules@42"
             },
             "arguments": []
           }
@@ -2607,7 +2668,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@39"
+              "$ref": "#/rules@42"
             },
             "arguments": []
           }
@@ -2630,21 +2691,21 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@42"
+              "$ref": "#/rules@45"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@43"
+              "$ref": "#/rules@46"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@41"
+              "$ref": "#/rules@44"
             },
             "arguments": []
           }
@@ -2666,7 +2727,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@62"
+              "$ref": "#/rules@65"
             },
             "arguments": [],
             "cardinality": "*"
@@ -2682,7 +2743,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@44"
+                "$ref": "#/rules@47"
               },
               "arguments": []
             }
@@ -2701,7 +2762,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@46"
+                    "$ref": "#/rules@49"
                   },
                   "arguments": []
                 }
@@ -2720,7 +2781,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@46"
+                        "$ref": "#/rules@49"
                       },
                       "arguments": []
                     }
@@ -2742,7 +2803,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@50"
+                "$ref": "#/rules@53"
               },
               "arguments": []
             },
@@ -2766,7 +2827,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@62"
+              "$ref": "#/rules@65"
             },
             "arguments": [],
             "cardinality": "*"
@@ -2788,7 +2849,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@40"
+                "$ref": "#/rules@43"
               },
               "arguments": []
             }
@@ -2804,7 +2865,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@47"
+                "$ref": "#/rules@50"
               },
               "arguments": []
             }
@@ -2837,7 +2898,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                     {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@53"
+                        "$ref": "#/rules@56"
                       },
                       "arguments": []
                     },
@@ -2868,7 +2929,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@40"
+                      "$ref": "#/rules@43"
                     },
                     "arguments": []
                   },
@@ -2928,12 +2989,12 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@45"
+                "$ref": "#/rules@48"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@43"
+                  "$ref": "#/rules@46"
                 },
                 "arguments": []
               },
@@ -2950,7 +3011,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@51"
+                  "$ref": "#/rules@54"
                 },
                 "arguments": [],
                 "cardinality": "?"
@@ -2980,7 +3041,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@62"
+              "$ref": "#/rules@65"
             },
             "arguments": [],
             "cardinality": "*"
@@ -2992,12 +3053,12 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@45"
+                "$ref": "#/rules@48"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@42"
+                  "$ref": "#/rules@45"
                 },
                 "arguments": []
               },
@@ -3014,7 +3075,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@51"
+                  "$ref": "#/rules@54"
                 },
                 "arguments": [],
                 "cardinality": "?"
@@ -3048,12 +3109,12 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@45"
+                "$ref": "#/rules@48"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@41"
+                  "$ref": "#/rules@44"
                 },
                 "arguments": []
               },
@@ -3070,7 +3131,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@51"
+                  "$ref": "#/rules@54"
                 },
                 "arguments": [],
                 "cardinality": "?"
@@ -3105,7 +3166,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@52"
+                "$ref": "#/rules@55"
               },
               "arguments": []
             }
@@ -3124,7 +3185,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@52"
+                    "$ref": "#/rules@55"
                   },
                   "arguments": []
                 }
@@ -3156,7 +3217,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@40"
+                    "$ref": "#/rules@43"
                   },
                   "arguments": []
                 }
@@ -3376,10 +3437,6 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
     {
       "$type": "TerminalRule",
       "name": "NUMBER",
-      "type": {
-        "$type": "ReturnType",
-        "name": "number"
-      },
       "definition": {
         "$type": "RegexToken",
         "regex": "[+-]?[0-9]+(\\\\.[0-9]+)?"
@@ -3428,19 +3485,19 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@37"
+              "$ref": "#/rules@40"
             }
           },
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@31"
+              "$ref": "#/rules@34"
             }
           },
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@35"
+              "$ref": "#/rules@38"
             }
           }
         ]
@@ -3455,13 +3512,13 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@30"
+              "$ref": "#/rules@33"
             }
           },
           {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@34"
+              "$ref": "#/rules@37"
             }
           }
         ]

--- a/packages/language/src/zmodel.langium
+++ b/packages/language/src/zmodel.langium
@@ -38,8 +38,17 @@ PluginField:
 Expression:
     LogicalExpr;
 
+NumberLiteral:
+    value=NUMBER;
+
+StringLiteral:
+    value=STRING;
+
+BooleanLiteral:
+    value=Boolean;
+
 LiteralExpr:
-    value=(Boolean | NUMBER | STRING);
+    NumberLiteral | StringLiteral | BooleanLiteral;
 
 ArrayExpr:
     '[' (items+=Expression (',' items+=Expression)*)? ']';
@@ -267,7 +276,7 @@ terminal NULL: 'null';
 terminal THIS: 'this';
 terminal ID: /[_a-zA-Z][\w_]*/;
 terminal STRING: /"[^"]*"|'[^']*'/;
-terminal NUMBER returns number: /[+-]?[0-9]+(\.[0-9]+)?/;
+terminal NUMBER: /[+-]?[0-9]+(\.[0-9]+)?/;
 terminal TRIPLE_SLASH_COMMENT: /\/\/\/[^\n\r]*/;
 hidden terminal ML_COMMENT: /\/\*[\s\S]*?\*\//;
 hidden terminal SL_COMMENT: /\/\/[^\n\r]*/;

--- a/packages/schema/src/language-server/validator/datamodel-validator.ts
+++ b/packages/schema/src/language-server/validator/datamodel-validator.ts
@@ -3,7 +3,7 @@ import {
     DataModel,
     DataModelField,
     isDataModel,
-    isLiteralExpr,
+    isStringLiteral,
     ReferenceExpr,
 } from '@zenstackhq/language/ast';
 import { analyzePolicies, getLiteral, getModelIdFields, getModelUniqueFields } from '@zenstackhq/sdk';
@@ -112,7 +112,7 @@ export default class DataModelValidator implements AstValidator<DataModel> {
 
         for (const arg of relAttr.args) {
             if (!arg.name || arg.name === 'name') {
-                if (isLiteralExpr(arg.value)) {
+                if (isStringLiteral(arg.value)) {
                     name = arg.value.value as string;
                 }
             } else if (arg.name === 'fields') {

--- a/packages/schema/src/language-server/validator/datamodel-validator.ts
+++ b/packages/schema/src/language-server/validator/datamodel-validator.ts
@@ -87,7 +87,7 @@ export default class DataModelValidator implements AstValidator<DataModel> {
             accept('error', 'Optional lists are not supported. Use either `Type[]` or `Type?`', { node: field.type });
         }
 
-        if (field.type.unsupported && typeof field.type.unsupported.value.value !== 'string') {
+        if (field.type.unsupported && !isStringLiteral(field.type.unsupported.value)) {
             accept('error', 'Unsupported type argument must be a string literal', { node: field.type.unsupported });
         }
 

--- a/packages/schema/src/language-server/validator/utils.ts
+++ b/packages/schema/src/language-server/validator/utils.ts
@@ -11,8 +11,8 @@ import {
     isArrayExpr,
     isDataModelField,
     isEnum,
-    isLiteralExpr,
     isReferenceExpr,
+    isStringLiteral,
 } from '@zenstackhq/language/ast';
 import { resolved } from '@zenstackhq/sdk';
 import { AstNode, ValidationAcceptor } from 'langium';
@@ -51,11 +51,7 @@ export function validateDuplicatedDeclarations(
  * Try getting string value from a potential string literal expression
  */
 export function getStringLiteral(node: AstNode | undefined): string | undefined {
-    if (isLiteralExpr(node) && typeof node.value === 'string') {
-        return node.value;
-    } else {
-        return undefined;
-    }
+    return isStringLiteral(node) ? node.value : undefined;
 }
 
 const isoDateTimeRegex = /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?$/i;
@@ -65,7 +61,7 @@ const isoDateTimeRegex = /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\
  */
 export function typeAssignable(destType: ExpressionType, sourceType: ExpressionType, sourceExpr?: Expression): boolean {
     // implicit conversion from ISO datetime string to datetime
-    if (destType === 'DateTime' && sourceType === 'String' && sourceExpr && isLiteralExpr(sourceExpr)) {
+    if (destType === 'DateTime' && sourceType === 'String' && sourceExpr && isStringLiteral(sourceExpr)) {
         const literal = getStringLiteral(sourceExpr);
         if (literal && isoDateTimeRegex.test(literal)) {
             // implicitly convert to DateTime

--- a/packages/schema/src/plugins/access-policy/expression-writer.ts
+++ b/packages/schema/src/plugins/access-policy/expression-writer.ts
@@ -1,5 +1,6 @@
 import {
     BinaryExpr,
+    BooleanLiteral,
     DataModel,
     Expression,
     InvocationExpr,
@@ -10,7 +11,9 @@ import {
     isThisExpr,
     LiteralExpr,
     MemberAccessExpr,
+    NumberLiteral,
     ReferenceExpr,
+    StringLiteral,
     UnaryExpr,
 } from '@zenstackhq/language/ast';
 import {
@@ -75,7 +78,9 @@ export class ExpressionWriter {
      */
     write(expr: Expression): void {
         switch (expr.$type) {
-            case LiteralExpr:
+            case StringLiteral:
+            case NumberLiteral:
+            case BooleanLiteral:
                 this.writeLiteral(expr as LiteralExpr);
                 break;
 
@@ -628,14 +633,14 @@ export class ExpressionWriter {
 
             // isEmpty function is zero arity, it's mapped to a boolean literal
             if (funcDecl.name === 'isEmpty') {
-                valueArg = { $type: LiteralExpr, value: true } as LiteralExpr;
+                valueArg = { $type: BooleanLiteral, value: true } as LiteralExpr;
             }
 
             // contains function has a 3rd argument that indicates whether the comparison should be case-insensitive
             let extraArgs: Record<string, Expression> | undefined = undefined;
             if (funcDecl.name === 'contains') {
                 if (getLiteral<boolean>(expr.args[2]?.value) === true) {
-                    extraArgs = { mode: { $type: LiteralExpr, value: 'insensitive' } as LiteralExpr };
+                    extraArgs = { mode: { $type: StringLiteral, value: 'insensitive' } as LiteralExpr };
                 }
             }
 

--- a/packages/schema/src/plugins/prisma/prisma-builder.ts
+++ b/packages/schema/src/plugins/prisma/prisma-builder.ts
@@ -267,7 +267,8 @@ export class AttributeArgValue {
                 if (typeof value !== 'string') throw new Error('Value must be string');
                 break;
             case 'Number':
-                if (typeof value !== 'number') throw new Error('Value must be number');
+                if (typeof value !== 'number' && typeof value !== 'string')
+                    throw new Error('Value must be number or string');
                 break;
             case 'Boolean':
                 if (typeof value !== 'boolean') throw new Error('Value must be boolean');

--- a/packages/schema/src/plugins/prisma/zmodel-code-generator.ts
+++ b/packages/schema/src/plugins/prisma/zmodel-code-generator.ts
@@ -4,6 +4,7 @@ import {
     AttributeArg,
     BinaryExpr,
     BinaryExprOperatorPriority,
+    BooleanLiteral,
     DataModelAttribute,
     DataModelFieldAttribute,
     Expression,
@@ -12,9 +13,11 @@ import {
     LiteralExpr,
     MemberAccessExpr,
     NullExpr,
+    NumberLiteral,
     ObjectExpr,
     ReferenceArg,
     ReferenceExpr,
+    StringLiteral,
     ThisExpr,
     UnaryExpr,
 } from '@zenstackhq/language/ast';
@@ -51,7 +54,9 @@ export default class ZModelCodeGenerator {
 
     generateExpression(ast: Expression): string {
         switch (ast.$type) {
-            case LiteralExpr:
+            case StringLiteral:
+            case NumberLiteral:
+            case BooleanLiteral:
                 return this.generateLiteralExpr(ast as LiteralExpr);
             case UnaryExpr:
                 return this.generateUnaryExpr(ast as UnaryExpr);
@@ -88,7 +93,7 @@ export default class ZModelCodeGenerator {
     }
 
     generateLiteralExpr(ast: LiteralExpr) {
-        return typeof ast.value === 'string' ? `'${ast.value}'` : ast.value.toString();
+        return ast.$type === StringLiteral ? `'${ast.value}'` : ast.value.toString();
     }
 
     generateUnaryExpr(ast: UnaryExpr) {

--- a/packages/schema/src/utils/typescript-expression-transformer.ts
+++ b/packages/schema/src/utils/typescript-expression-transformer.ts
@@ -1,6 +1,7 @@
 import {
     ArrayExpr,
     BinaryExpr,
+    BooleanLiteral,
     Expression,
     InvocationExpr,
     isEnumField,
@@ -8,7 +9,9 @@ import {
     LiteralExpr,
     MemberAccessExpr,
     NullExpr,
+    NumberLiteral,
     ReferenceExpr,
+    StringLiteral,
     ThisExpr,
     UnaryExpr,
 } from '@zenstackhq/language/ast';
@@ -57,7 +60,9 @@ export class TypeScriptExpressionTransformer {
      */
     transform(expr: Expression, normalizeUndefined = true): string {
         switch (expr.$type) {
-            case LiteralExpr:
+            case StringLiteral:
+            case NumberLiteral:
+            case BooleanLiteral:
                 return this.literal(expr as LiteralExpr);
 
             case ArrayExpr:
@@ -284,7 +289,7 @@ export class TypeScriptExpressionTransformer {
     }
 
     private literal(expr: LiteralExpr) {
-        if (typeof expr.value === 'string') {
+        if (expr.$type === StringLiteral) {
             return `'${expr.value}'`;
         } else {
             return expr.value.toString();

--- a/packages/schema/tests/schema/parser.test.ts
+++ b/packages/schema/tests/schema/parser.test.ts
@@ -10,10 +10,12 @@ import {
     Enum,
     FunctionDecl,
     InvocationExpr,
-    LiteralExpr,
     ReferenceExpr,
     UnaryExpr,
     MemberAccessExpr,
+    StringLiteral,
+    BooleanLiteral,
+    NumberLiteral,
 } from '@zenstackhq/language/ast';
 import { loadModel } from '../utils';
 
@@ -40,7 +42,7 @@ describe('Parsing Tests', () => {
         );
         expect(ds.fields[1].name).toBe('url');
         expect((ds.fields[1].value as InvocationExpr).function.ref?.name).toBe('env');
-        expect((ds.fields[1].value as InvocationExpr).args[0].value.$type).toBe(LiteralExpr);
+        expect((ds.fields[1].value as InvocationExpr).args[0].value.$type).toBe(StringLiteral);
     });
 
     it('enum simple', async () => {
@@ -158,7 +160,7 @@ describe('Parsing Tests', () => {
         const doc = await loadModel(content, false);
         const model = doc.declarations[0] as DataModel;
         expect(model.fields[0].attributes[0].decl.ref?.name).toBe('@id');
-        expect(model.fields[1].attributes[0].args[0].value.$type).toBe(LiteralExpr);
+        expect(model.fields[1].attributes[0].args[0].value.$type).toBe(BooleanLiteral);
         expect(model.fields[1].attributes[1].decl.ref?.name).toBe('@unique');
     });
 
@@ -239,11 +241,7 @@ describe('Parsing Tests', () => {
 
         expect(attrs[1].args[1].value.$type).toBe(BinaryExpr);
         expect((attrs[1].args[1].value as BinaryExpr).left.$type).toBe(ReferenceExpr);
-        expect((attrs[1].args[1].value as BinaryExpr).right.$type).toBe(LiteralExpr);
-
-        expect(attrs[1].args[1].value.$type).toBe(BinaryExpr);
-        expect((attrs[1].args[1].value as BinaryExpr).left.$type).toBe(ReferenceExpr);
-        expect((attrs[1].args[1].value as BinaryExpr).right.$type).toBe(LiteralExpr);
+        expect((attrs[1].args[1].value as BinaryExpr).right.$type).toBe(NumberLiteral);
 
         // expect(attrs[2].args[0].value.$type).toBe(BinaryExpr);
         // expect((attrs[2].args[0].value as BinaryExpr).left.$type).toBe(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,7 +124,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.22.9)(esbuild@0.18.13)(jest@29.5.0)(typescript@4.9.5)
+        version: 29.0.5(@babel/core@7.22.5)(esbuild@0.18.13)(jest@29.5.0)(typescript@4.9.5)
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
@@ -201,7 +201,7 @@ importers:
         version: 2.0.3(react@18.2.0)
       ts-jest:
         specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.22.5)(esbuild@0.18.13)(jest@29.5.0)(typescript@4.9.4)
+        version: 29.0.5(@babel/core@7.22.9)(esbuild@0.18.13)(jest@29.5.0)(typescript@4.9.4)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -10800,7 +10800,7 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-jest@29.0.5(@babel/core@7.22.5)(esbuild@0.18.13)(jest@29.5.0)(typescript@4.9.4):
+  /ts-jest@29.0.5(@babel/core@7.22.5)(esbuild@0.18.13)(jest@29.5.0)(typescript@4.9.5):
     resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -10831,7 +10831,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.3
-      typescript: 4.9.4
+      typescript: 4.9.5
       yargs-parser: 21.1.1
     dev: true
 
@@ -10867,41 +10867,6 @@ packages:
       make-error: 1.3.6
       semver: 7.5.3
       typescript: 4.9.4
-      yargs-parser: 21.1.1
-    dev: true
-
-  /ts-jest@29.0.5(@babel/core@7.22.9)(esbuild@0.18.13)(jest@29.5.0)(typescript@4.9.5):
-    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@jest/types': ^29.0.0
-      babel-jest: ^29.0.0
-      esbuild: '*'
-      jest: ^29.0.0
-      typescript: '>=4.3'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@jest/types':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@babel/core': 7.22.9
-      bs-logger: 0.2.6
-      esbuild: 0.18.13
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.5.0(@types/node@18.0.0)
-      jest-util: 29.5.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.3
-      typescript: 4.9.5
       yargs-parser: 21.1.1
     dev: true
 

--- a/tests/integration/tests/regression/issue-646.test.ts
+++ b/tests/integration/tests/regression/issue-646.test.ts
@@ -1,0 +1,12 @@
+import { loadSchema } from '@zenstackhq/testtools';
+
+describe('Regression: issue 646', () => {
+    it('regression', async () => {
+        await loadSchema(`
+model Example {
+    id Int @id
+    epsilon Decimal @default(0.00000001)
+}
+        `);
+    });
+});


### PR DESCRIPTION
Parse number literal into string value to preserve its original representation.

Fixes #646 