### PR TITLE
Add `"contributes"` block

### DIFF
--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -28,5 +28,20 @@
     },
     "dependencies": {
         "langium": "1.2.0"
+    },
+    "contributes": {
+      "languages": [
+        { 
+          "id": "zmodel",
+          "extensions": [".zmodel"]
+        }
+      ],
+      "grammars": [
+        {
+          "language": "zmodel",
+          "scopeName": "source.zmodel",
+          "path": "./syntaxes/zmodel.tmLanguage.json"
+        }
+      ]
     }
 }


### PR DESCRIPTION
The `"contributes"` block allows the `language` package to be imported by text editors and IDEs as a TextMate Bundle, providing rudimentary ZenStack support to unsupported IDEs. 