### PR TITLE
Update `zod` dependency to latest (`v3.22.4`)

### DIFF
--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -20,7 +20,9 @@
     "test": "ZENSTACK_TEST=1 jest",
     "prepublishOnly": "pnpm build"
   },
-  "keywords": ["openapi"],
+  "keywords": [
+    "openapi"
+  ],
   "author": "ZenStack Team",
   "license": "MIT",
   "dependencies": {
@@ -33,8 +35,8 @@
     "tiny-invariant": "^1.3.1",
     "upper-case-first": "^2.0.2",
     "yaml": "^2.2.1",
-    "zod": "3.21.1",
-    "zod-validation-error": "^0.2.1"
+    "zod": "^3.22.4",
+    "zod-validation-error": "^1.5.0"
   },
   "devDependencies": {
     "@readme/openapi-parser": "^2.4.0",

--- a/packages/plugins/trpc/package.json
+++ b/packages/plugins/trpc/package.json
@@ -33,7 +33,7 @@
         "ts-morph": "^16.0.0",
         "tslib": "^2.4.1",
         "upper-case-first": "^2.0.2",
-        "zod": "3.21.1"
+        "zod": "^3.22.4"
     },
     "devDependencies": {
         "@trpc/next": "^10.32.0",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -61,8 +61,8 @@
         "superjson": "^1.11.0",
         "tslib": "^2.4.1",
         "upper-case-first": "^2.0.2",
-        "zod": "3.21.1",
-        "zod-validation-error": "^0.2.1"
+        "zod": "^3.22.4",
+        "zod-validation-error": "^1.5.0"
     },
     "author": {
         "name": "ZenStack Team"

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -108,7 +108,7 @@
         "vscode-languageserver": "^8.0.2",
         "vscode-languageserver-textdocument": "^1.0.7",
         "vscode-uri": "^3.0.6",
-        "zod": "3.21.1",
+        "zod": "3.22.4",
         "zod-validation-error": "^0.2.1"
     },
     "devDependencies": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -108,8 +108,8 @@
         "vscode-languageserver": "^8.0.2",
         "vscode-languageserver-textdocument": "^1.0.7",
         "vscode-uri": "^3.0.6",
-        "zod": "3.22.4",
-        "zod-validation-error": "^0.2.1"
+        "zod": "^3.22.4",
+        "zod-validation-error": "^1.5.0"
     },
     "devDependencies": {
         "@prisma/client": "^4.8.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,8 +36,8 @@
         "ts-japi": "^1.8.0",
         "upper-case-first": "^2.0.2",
         "url-pattern": "^1.0.3",
-        "zod": "3.21.1",
-        "zod-validation-error": "^0.2.1"
+        "zod": "^3.22.4",
+        "zod-validation-error": "^1.5.0"
     },
     "devDependencies": {
         "@sveltejs/kit": "1.21.0",

--- a/packages/testtools/src/package.template.json
+++ b/packages/testtools/src/package.template.json
@@ -15,7 +15,7 @@
         "prisma": "^4.8.0",
         "typescript": "^4.9.3",
         "zenstack": "file:<root>/packages/schema/dist",
-        "zod": "3.21.1",
+        "zod": "^3.22.4",
         "decimal.js": "^10.4.2"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,11 +74,11 @@ importers:
         specifier: ^2.2.1
         version: 2.2.1
       zod:
-        specifier: 3.21.1
-        version: 3.21.1
+        specifier: ^3.22.4
+        version: 3.22.4
       zod-validation-error:
-        specifier: ^0.2.1
-        version: 0.2.1(zod@3.21.1)
+        specifier: ^1.5.0
+        version: 1.5.0(zod@3.22.4)
     devDependencies:
       '@readme/openapi-parser':
         specifier: ^2.4.0
@@ -314,8 +314,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       zod:
-        specifier: 3.21.1
-        version: 3.21.1
+        specifier: ^3.22.4
+        version: 3.22.4
     devDependencies:
       '@trpc/next':
         specifier: ^10.32.0
@@ -400,11 +400,11 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       zod:
-        specifier: 3.21.1
-        version: 3.21.1
+        specifier: ^3.22.4
+        version: 3.22.4
       zod-validation-error:
-        specifier: ^0.2.1
-        version: 0.2.1(zod@3.21.1)
+        specifier: ^1.5.0
+        version: 1.5.0(zod@3.22.4)
     devDependencies:
       '@types/jest':
         specifier: ^29.5.0
@@ -519,11 +519,11 @@ importers:
         specifier: ^3.0.6
         version: 3.0.6
       zod:
-        specifier: 3.21.1
-        version: 3.21.1
+        specifier: ^3.22.4
+        version: 3.22.4
       zod-validation-error:
-        specifier: ^0.2.1
-        version: 0.2.1(zod@3.21.1)
+        specifier: ^1.5.0
+        version: 1.5.0(zod@3.22.4)
     devDependencies:
       '@prisma/client':
         specifier: ^4.8.0
@@ -602,7 +602,7 @@ importers:
         version: 0.2.1
       ts-jest:
         specifier: ^29.0.3
-        version: 29.0.3(@babel/core@7.22.5)(esbuild@0.15.12)(jest@29.5.0)(typescript@4.8.4)
+        version: 29.0.3(@babel/core@7.22.9)(esbuild@0.15.12)(jest@29.5.0)(typescript@4.8.4)
       ts-node:
         specifier: ^10.9.1
         version: 10.9.1(@types/node@18.0.0)(typescript@4.8.4)
@@ -694,11 +694,11 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       zod:
-        specifier: 3.21.1
-        version: 3.21.1
+        specifier: ^3.22.4
+        version: 3.22.4
       zod-validation-error:
-        specifier: ^0.2.1
-        version: 0.2.1(zod@3.21.1)
+        specifier: ^1.5.0
+        version: 1.5.0(zod@3.22.4)
     devDependencies:
       '@sveltejs/kit':
         specifier: 1.21.0
@@ -747,7 +747,7 @@ importers:
         version: 29.5.0(@types/node@18.0.0)(ts-node@10.9.1)
       next:
         specifier: ^13.4.5
-        version: 13.4.5(@babel/core@7.22.9)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.5(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0)
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -756,7 +756,7 @@ importers:
         version: 6.3.3
       ts-jest:
         specifier: ^29.0.5
-        version: 29.0.5(@babel/core@7.22.9)(esbuild@0.18.13)(jest@29.5.0)(typescript@4.9.4)
+        version: 29.0.5(@babel/core@7.22.5)(esbuild@0.18.13)(jest@29.5.0)(typescript@4.9.4)
       typescript:
         specifier: ^4.9.4
         version: 4.9.4
@@ -3348,12 +3348,6 @@ packages:
     dependencies:
       tslib: 2.6.0
     dev: true
-
-  /@swc/helpers@0.4.14:
-    resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
-    dependencies:
-      tslib: 2.6.0
-    dev: false
 
   /@swc/helpers@0.5.1:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
@@ -8493,7 +8487,7 @@ packages:
       - babel-plugin-macros
     dev: true
 
-  /next@13.4.5(@babel/core@7.22.9)(react-dom@18.2.0)(react@18.2.0):
+  /next@13.4.5(@babel/core@7.22.5)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-pfNsRLVM9e5Y1/z02VakJRfD6hMQkr24FaN2xc9GbcZDBxoOgiNAViSg5cXwlWCoMhtm4U315D7XYhgOr96Q3Q==}
     engines: {node: '>=16.8.0'}
     hasBin: true
@@ -8518,7 +8512,7 @@ packages:
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.22.9)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.22.5)(react@18.2.0)
       watchpack: 2.4.0
       zod: 3.21.4
     optionalDependencies:
@@ -10217,6 +10211,24 @@ packages:
       react: 18.2.0
     dev: true
 
+  /styled-jsx@5.1.1(@babel/core@7.22.5)(react@18.2.0):
+    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.5
+      client-only: 0.0.1
+      react: 18.2.0
+    dev: true
+
   /styled-jsx@5.1.1(@babel/core@7.22.9)(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
@@ -10596,8 +10608,43 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-jest@29.0.3(@babel/core@7.22.5)(esbuild@0.15.12)(jest@29.5.0)(typescript@4.8.4):
+  /ts-jest@29.0.3(@babel/core@7.22.9)(esbuild@0.15.12)(jest@29.5.0)(typescript@4.8.4):
     resolution: {integrity: sha512-Ibygvmuyq1qp/z3yTh9QTwVVAbFdDy/+4BtIQR2sp6baF2SJU/8CKK/hhnGIDY2L90Az2jIqTwZPnN2p+BweiQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.9
+      bs-logger: 0.2.6
+      esbuild: 0.15.12
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.5.0(@types/node@18.0.0)(ts-node@10.9.1)
+      jest-util: 29.5.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.5.3
+      typescript: 4.8.4
+      yargs-parser: 21.1.1
+    dev: true
+
+  /ts-jest@29.0.5(@babel/core@7.22.5)(esbuild@0.18.13)(jest@29.5.0)(typescript@4.9.4):
+    resolution: {integrity: sha512-PL3UciSgIpQ7f6XjVOmbi96vmDHUqAyqDr8YxzopDqX3kfgYtX1cuNeBjP+L9sFXi6nzsGGA6R3fP3DDDJyrxA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
     peerDependencies:
@@ -10619,7 +10666,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.5
       bs-logger: 0.2.6
-      esbuild: 0.15.12
+      esbuild: 0.18.13
       fast-json-stable-stringify: 2.1.0
       jest: 29.5.0(@types/node@18.0.0)(ts-node@10.9.1)
       jest-util: 29.5.0
@@ -10627,7 +10674,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.3
-      typescript: 4.8.4
+      typescript: 4.9.4
       yargs-parser: 21.1.1
     dev: true
 
@@ -11619,20 +11666,19 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
-  /zod-validation-error@0.2.1(zod@3.21.1):
-    resolution: {integrity: sha512-zGg6P5EHi5V0dvyEeC8HBZd2pzp7QDKTngkSWgWunljrY+0SHkHyjI519D+u8/37BHkGHAFseWgnZ2Uq8LNFKg==}
-    engines: {node: ^14.17 || >=16.0.0}
+  /zod-validation-error@1.5.0(zod@3.22.4):
+    resolution: {integrity: sha512-/7eFkAI4qV0tcxMBB/3+d2c1P6jzzZYdYSlBuAklzMuCrJu5bzJfHS0yVAS87dRHVlhftd6RFJDIvv03JgkSbw==}
+    engines: {node: '>=16.0.0'}
     peerDependencies:
       zod: ^3.18.0
     dependencies:
-      '@swc/helpers': 0.4.14
-      zod: 3.21.1
-    dev: false
-
-  /zod@3.21.1:
-    resolution: {integrity: sha512-+dTu2m6gmCbO9Ahm4ZBDapx2O6ZY9QSPXst2WXjcznPMwf2YNpn3RevLx4KkZp1OPW/ouFcoBtBzFz/LeY69oA==}
+      zod: 3.22.4
     dev: false
 
   /zod@3.21.4:
     resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: true
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false

--- a/tests/integration/test-run/package.json
+++ b/tests/integration/test-run/package.json
@@ -17,6 +17,6 @@
         "swr": "^1.3.0",
         "typescript": "^4.9.3",
         "zenstack": "file:../../../packages/schema/dist",
-        "zod": "3.21.1"
+        "zod": "^3.22.4"
     }
 }

--- a/tests/integration/tests/frameworks/nextjs/test-project/package.json
+++ b/tests/integration/tests/frameworks/nextjs/test-project/package.json
@@ -21,7 +21,7 @@
     "superjson": "^1.12.4",
     "swr": "^2.2.0",
     "typescript": "4.9.4",
-    "zod": "3.21.1"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "prisma": "^4.8.0"

--- a/tests/integration/tests/frameworks/trpc/test-project/package.json
+++ b/tests/integration/tests/frameworks/trpc/test-project/package.json
@@ -23,7 +23,7 @@
     "react-dom": "18.2.0",
     "superjson": "^1.12.2",
     "typescript": "4.9.4",
-    "zod": "3.21.1",
+    "zod": "^3.22.4",
     "@zenstackhq/runtime": "../../../../../../../packages/runtime/dist"
   },
   "devDependencies": {


### PR DESCRIPTION
Of note, Zod < `3.22.3` is [vulnerable to ReDOS](https://github.com/advisories/GHSA-m95q-7qp3-xv42).
Would recommend updating the dependency ASAP.

Zod's [changelog](https://github.com/colinhacks/zod/releases) doesn't obviously reflect any breaking API changes from `3.21.1` -> `3.22.4`, and I'm pretty sure Zod adheres to [SemVer](https://semver.org/) so the version numbers agree with this.