### PR TITLE
fix: openapi - do not generate "id" field in create input if the field has default value

### DIFF
--- a/packages/plugins/openapi/tests/baseline/rest-type-coverage.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-type-coverage.baseline.yaml
@@ -590,9 +590,9 @@ components:
                 - type
                 - attributes
             properties:
-                type:
-                    type: string
                 id:
+                    type: string
+                type:
                     type: string
                 attributes:
                     type: object
@@ -628,13 +628,10 @@ components:
                     type: object
                     description: The "Foo" model
                     required:
-                        - id
                         - type
                         - attributes
                     properties:
                         type:
-                            type: string
-                        id:
                             type: string
                         attributes:
                             type: object
@@ -685,9 +682,9 @@ components:
                         - type
                         - attributes
                     properties:
-                        type:
-                            type: string
                         id:
+                            type: string
+                        type:
                             type: string
                         attributes:
                             type: object

--- a/packages/plugins/openapi/tests/baseline/rest.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest.baseline.yaml
@@ -1525,9 +1525,9 @@ components:
                 - type
                 - attributes
             properties:
-                type:
-                    type: string
                 id:
+                    type: string
+                type:
                     type: string
                 attributes:
                     type: object
@@ -1557,13 +1557,10 @@ components:
                     type: object
                     description: The "User" model
                     required:
-                        - id
                         - type
                         - attributes
                     properties:
                         type:
-                            type: string
-                        id:
                             type: string
                         attributes:
                             type: object
@@ -1602,9 +1599,9 @@ components:
                         - type
                         - attributes
                     properties:
-                        type:
-                            type: string
                         id:
+                            type: string
+                        type:
                             type: string
                         attributes:
                             type: object
@@ -1689,9 +1686,9 @@ components:
                 - type
                 - attributes
             properties:
-                type:
-                    type: string
                 id:
+                    type: string
+                type:
                     type: string
                 attributes:
                     type: object
@@ -1729,9 +1726,9 @@ components:
                         - type
                         - attributes
                     properties:
-                        type:
-                            type: string
                         id:
+                            type: string
+                        type:
                             type: string
                         attributes:
                             type: object
@@ -1774,9 +1771,9 @@ components:
                         - type
                         - attributes
                     properties:
-                        type:
-                            type: string
                         id:
+                            type: string
+                        type:
                             type: string
                         attributes:
                             type: object

--- a/packages/plugins/openapi/tests/baseline/rpc.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rpc.baseline.yaml
@@ -352,7 +352,6 @@ components:
                 posts:
                     $ref: '#/components/schemas/Post_ItemCreateNestedManyWithoutAuthorInput'
             required:
-                - id
                 - email
         UserUpdateInput:
             type: object
@@ -397,7 +396,6 @@ components:
                 role:
                     $ref: '#/components/schemas/Role'
             required:
-                - id
                 - email
         UserUpdateManyMutationInput:
             type: object
@@ -1709,7 +1707,6 @@ components:
                 role:
                     $ref: '#/components/schemas/Role'
             required:
-                - id
                 - email
         UserUncheckedCreateWithoutPostsInput:
             type: object
@@ -1727,7 +1724,6 @@ components:
                 role:
                     $ref: '#/components/schemas/Role'
             required:
-                - id
                 - email
         UserCreateOrConnectWithoutPostsInput:
             type: object

--- a/packages/plugins/openapi/tests/openapi-restful.test.ts
+++ b/packages/plugins/openapi/tests/openapi-restful.test.ts
@@ -23,7 +23,7 @@ enum role {
 }
 
 model User {
-    id String @id
+    id String @id @default(cuid())
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
     email String @unique

--- a/packages/plugins/openapi/tests/openapi-rpc.test.ts
+++ b/packages/plugins/openapi/tests/openapi-rpc.test.ts
@@ -23,7 +23,7 @@ enum role {
 }
 
 model User {
-    id String @id
+    id String @id @default(cuid())
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
     email String @unique


### PR DESCRIPTION
Fixes #736 