### PR TITLE
fix: zenstack generate fails when path contains space

### DIFF
--- a/packages/schema/src/plugins/prisma/schema-generator.ts
+++ b/packages/schema/src/plugins/prisma/schema-generator.ts
@@ -134,12 +134,12 @@ export default class PrismaSchemaGenerator {
         if (generateClient) {
             try {
                 // run 'prisma generate'
-                await execSync(`npx prisma generate --schema ${outFile}`, 'ignore');
+                await execSync(`npx prisma generate --schema "${outFile}"`, 'ignore');
             } catch {
                 await this.trackPrismaSchemaError(outFile);
                 try {
                     // run 'prisma generate' again with output to the console
-                    await execSync(`npx prisma generate --schema ${outFile}`);
+                    await execSync(`npx prisma generate --schema "${outFile}"`);
                 } catch {
                     // noop
                 }


### PR DESCRIPTION
Fixes #805 