### PR TITLE
fix: handle foreign key field-level access check during relation update

### DIFF
--- a/packages/runtime/src/version.ts
+++ b/packages/runtime/src/version.ts
@@ -19,6 +19,15 @@ export function getVersion() {
  * "prisma".
  */
 export function getPrismaVersion(): string | undefined {
+    if (process.env.ZENSTACK_TEST === '1') {
+        // test environment
+        try {
+            return require(path.resolve('./node_modules/@prisma/client/package.json')).version;
+        } catch {
+            return undefined;
+        }
+    }
+
     try {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         return require('@prisma/client/package.json').version;
@@ -27,15 +36,6 @@ export function getPrismaVersion(): string | undefined {
             // eslint-disable-next-line @typescript-eslint/no-var-requires
             return require('prisma/package.json').version;
         } catch {
-            if (process.env.ZENSTACK_TEST === '1') {
-                // test environment
-                try {
-                    return require(path.resolve('./node_modules/@prisma/client/package.json')).version;
-                } catch {
-                    return undefined;
-                }
-            }
-
             return undefined;
         }
     }

--- a/packages/schema/tests/schema/validation/attribute-validation.test.ts
+++ b/packages/schema/tests/schema/validation/attribute-validation.test.ts
@@ -1186,5 +1186,43 @@ describe('Attribute tests', () => {
             }
         `)
         ).toContain('"future()" is not allowed in field-level policy rules');
+
+        expect(
+            await loadModelWithError(`
+            ${prelude}
+            model M {
+                id String @id
+                n N @allow('update', n.x > 0)
+            }
+
+            model N {
+                id String @id
+                x Int
+                m M? @relation(fields: [mId], references: [id])
+                mId String
+            }
+        `)
+        ).toContain(
+            'Field-level policy rules with "update" or "all" kind are not allowed for relation fields. Put rules on foreign-key fields instead.'
+        );
+
+        expect(
+            await loadModelWithError(`
+            ${prelude}
+            model M {
+                id String @id
+                n N[] @allow('update', n.x > 0)
+            }
+
+            model N {
+                id String @id
+                x Int
+                m M? @relation(fields: [mId], references: [id])
+                mId String
+            }
+        `)
+        ).toContain(
+            'Field-level policy rules with "update" or "all" kind are not allowed for relation fields. Put rules on foreign-key fields instead.'
+        );
     });
 });


### PR DESCRIPTION
- Disallow field-level policies on relation fields (should be put on foreign keys)
- Translate connect/disconnect/set relation update to foreign key field-level policy check

Fixes #819 