### PR TITLE
Support @nanoid

### DIFF
--- a/packages/schema/src/res/stdlib.zmodel
+++ b/packages/schema/src/res/stdlib.zmodel
@@ -94,6 +94,12 @@ function cuid(): String {
 } @@@expressionContext([DefaultValue])
 
 /**
+ * Generates an indentifier based on the nanoid spec.
+ */
+function nanoid(length: Int?): String {
+} @@@expressionContext([DefaultValue])
+
+/**
  * Creates a sequence of integers in the underlying database and assign the incremented 
  * values to the ID values of the created records based on the sequence.
  */

--- a/packages/schema/tests/schema/validation/attribute-validation.test.ts
+++ b/packages/schema/tests/schema/validation/attribute-validation.test.ts
@@ -352,7 +352,7 @@ describe('Attribute tests', () => {
         `);
     });
 
-    it('attribute function coverage', async () => {
+    it.only('attribute function coverage', async () => {
         await loadModel(`
             ${prelude}
             model User { id String @id }
@@ -360,6 +360,8 @@ describe('Attribute tests', () => {
             model A {
                 id String @id @default(uuid())
                 id1 String @default(cuid())
+                nanodId String @default(nanoid())
+                nanodIdWithLength String @default(nanoid(3))
                 created DateTime @default(now())
                 serial Int @default(autoincrement())
                 foo String @default(dbgenerated("gen_random_uuid()"))

--- a/packages/schema/tests/schema/validation/attribute-validation.test.ts
+++ b/packages/schema/tests/schema/validation/attribute-validation.test.ts
@@ -352,7 +352,7 @@ describe('Attribute tests', () => {
         `);
     });
 
-    it.only('attribute function coverage', async () => {
+    it('attribute function coverage', async () => {
         await loadModel(`
             ${prelude}
             model User { id String @id }


### PR DESCRIPTION
support `@nanoid`

- handle with or without `length` argument
- add test

Prisma ref: https://github.com/prisma/prisma-engines/pull/3556
Fixes: https://github.com/zenstackhq/zenstack/issues/923

