### PR TITLE
Allows enum types for id fields

### DIFF
--- a/packages/schema/src/language-server/validator/datamodel-validator.ts
+++ b/packages/schema/src/language-server/validator/datamodel-validator.ts
@@ -61,8 +61,15 @@ export default class DataModelValidator implements AstValidator<DataModel> {
                 if (idField.type.optional) {
                     accept('error', 'Field with @id attribute must not be optional', { node: idField });
                 }
-                if (idField.type.array || !idField.type.type || !SCALAR_TYPES.includes(idField.type.type)) {
-                    accept('error', 'Field with @id attribute must be of scalar type', { node: idField });
+
+                const isArray = idField.type.array;
+                const isReference = !idField.type.type;
+                const isEnum = isReference && idField.type.reference?.ref?.$type === 'Enum'
+                const isScalar = SCALAR_TYPES.includes(idField.type.type as typeof SCALAR_TYPES[number])
+                const isValidType = isScalar || isEnum
+
+                if (isArray || !isValidType) {
+                    accept('error', 'Field with @id attribute must be of scalar or enum type', { node: idField });
                 }
             });
         }

--- a/packages/schema/src/language-server/validator/datamodel-validator.ts
+++ b/packages/schema/src/language-server/validator/datamodel-validator.ts
@@ -65,7 +65,7 @@ export default class DataModelValidator implements AstValidator<DataModel> {
 
                 const isArray = idField.type.array;
                 const isScalar = SCALAR_TYPES.includes(idField.type.type as typeof SCALAR_TYPES[number])
-                const isValidType = isScalar || isEnum(idField.type.reference?.ref?.$type)
+                const isValidType = isScalar || isEnum(idField.type.reference?.ref)
 
                 if (isArray || !isValidType) {
                     accept('error', 'Field with @id attribute must be of scalar or enum type', { node: idField });

--- a/packages/schema/src/language-server/validator/datamodel-validator.ts
+++ b/packages/schema/src/language-server/validator/datamodel-validator.ts
@@ -5,6 +5,7 @@ import {
     isDataModel,
     isStringLiteral,
     ReferenceExpr,
+    isEnum,
 } from '@zenstackhq/language/ast';
 import { getLiteral, getModelIdFields, getModelUniqueFields } from '@zenstackhq/sdk';
 import { AstNode, DiagnosticInfo, getDocument, ValidationAcceptor } from 'langium';
@@ -63,10 +64,8 @@ export default class DataModelValidator implements AstValidator<DataModel> {
                 }
 
                 const isArray = idField.type.array;
-                const isReference = !idField.type.type;
-                const isEnum = isReference && idField.type.reference?.ref?.$type === 'Enum'
                 const isScalar = SCALAR_TYPES.includes(idField.type.type as typeof SCALAR_TYPES[number])
-                const isValidType = isScalar || isEnum
+                const isValidType = isScalar || isEnum(idField.type.reference?.ref?.$type)
 
                 if (isArray || !isValidType) {
                     accept('error', 'Field with @id attribute must be of scalar or enum type', { node: idField });

--- a/packages/schema/tests/schema/stdlib.test.ts
+++ b/packages/schema/tests/schema/stdlib.test.ts
@@ -24,7 +24,7 @@ describe('Stdlib Tests', () => {
                     }`
                 );
             }
-            throw new SchemaLoadingError(validationErrors.map((e) => e.message));
+            throw new SchemaLoadingError(validationErrors);
         }
     });
 });

--- a/packages/schema/tests/schema/validation/datasource-validation.test.ts
+++ b/packages/schema/tests/schema/validation/datasource-validation.test.ts
@@ -1,18 +1,21 @@
-import { loadModel, loadModelWithError } from '../../utils';
+import { loadModel, loadModelWithError, safelyLoadModel } from '../../utils';
 
 describe('Datasource Validation Tests', () => {
     it('missing fields', async () => {
-        expect(
-            await loadModelWithError(`
+        const result = await safelyLoadModel(`
                 datasource db {
                 }
-        `)
-        ).toEqual(
-            expect.arrayContaining([
-                'datasource must include a "provider" field',
-                'datasource must include a "url" field',
-            ])
-        );
+        `);
+
+        expect(result).toMatchObject({
+            status: 'rejected',
+            reason: {
+                cause: [
+                    { message: 'datasource must include a "provider" field' },
+                    { message: 'datasource must include a "url" field' },
+                ]
+            }
+        })
     });
 
     it('dup fields', async () => {
@@ -41,7 +44,7 @@ describe('Datasource Validation Tests', () => {
                     provider = 'abc'
                 }
         `)
-        ).toContainEqual(expect.stringContaining('Provider "abc" is not supported'));
+        ).toContain('Provider "abc" is not supported');
     });
 
     it('invalid url value', async () => {


### PR DESCRIPTION
This PR fixes an issue where enum types were being marked as invalid for id fields. 

Also, I improved `SchemaLoadingError`, so that it shows the source of the error in jest, rather than inside the utility function. In addition, you can pass it an array of errors rather than strings. (It will still take those too!)

I also created the `safelyLoadModel` utility function, which uses `Promise.allSettled` to get a result that you can use `toMatchObject`, which allows for easier pattern-matching of complex responses.

For `packages/schema/tests/schema/validation/datamodel-validation.test.ts`, I broke up the expect calls into their own tests for easy identification of what went wrong when something breaks. They will of course show up as individual tests in the errors. 