### PR TITLE
fix: default auth without user context

### DIFF
--- a/packages/runtime/src/enhancements/default-auth.ts
+++ b/packages/runtime/src/enhancements/default-auth.ts
@@ -15,7 +15,7 @@ import { DefaultPrismaProxyHandler, PrismaProxyActions, makeProxy } from './prox
 export function withDefaultAuth<DbClient extends object>(
     prisma: DbClient,
     options: InternalEnhancementOptions,
-    context?: EnhancementContext
+    context: EnhancementContext = {}
 ): DbClient {
     return makeProxy(
         prisma,
@@ -32,13 +32,9 @@ class DefaultAuthHandler extends DefaultPrismaProxyHandler {
         prisma: DbClientContract,
         model: string,
         options: InternalEnhancementOptions,
-        private readonly context?: EnhancementContext
+        private readonly context: EnhancementContext
     ) {
         super(prisma, model, options);
-
-        if (!this.context?.user) {
-            throw new Error(`Using \`auth()\` in \`@default\` requires a user context`);
-        }
 
         this.userContext = this.context.user;
     }
@@ -95,6 +91,9 @@ class DefaultAuthHandler extends DefaultPrismaProxyHandler {
     }
 
     private getDefaultValueFromAuth(fieldInfo: FieldInfo) {
+        if (!this.userContext) {
+            throw new Error(`Using \`auth()\` in \`@default\` requires a user context`);
+        }
         return fieldInfo.defaultValueProvider?.(this.userContext);
     }
 }

--- a/packages/runtime/src/enhancements/default-auth.ts
+++ b/packages/runtime/src/enhancements/default-auth.ts
@@ -92,7 +92,7 @@ class DefaultAuthHandler extends DefaultPrismaProxyHandler {
 
     private getDefaultValueFromAuth(fieldInfo: FieldInfo) {
         if (!this.userContext) {
-            throw new Error(`Using \`auth()\` in \`@default\` requires a user context`);
+            throw new Error(`Evaluating default value of field \`${fieldInfo.name}\` requires a user context`);
         }
         return fieldInfo.defaultValueProvider?.(this.userContext);
     }

--- a/tests/integration/tests/enhancements/with-policy/auth.test.ts
+++ b/tests/integration/tests/enhancements/with-policy/auth.test.ts
@@ -522,7 +522,7 @@ describe('With Policy: auth() test', () => {
             author User @relation(fields: [authorId], references: [id])
             authorId String @default(auth().id)
 
-            @@allow('all', auth().id != null)
+            @@allow('all', true)
         }
         `
         );
@@ -530,7 +530,7 @@ describe('With Policy: auth() test', () => {
         const db = enhance();
         await expect(db.user.create({ data: { id: 'userId-1' } })).toResolveTruthy();
         await expect(db.post.create({ data: { title: 'title' } })).rejects.toThrow(
-            'Using `auth()` in `@default` requires a user context'
+            'Evaluating default value of field `authorId` requires a user context'
         );
         await expect(db.post.findMany({})).toResolveTruthy();
     });


### PR DESCRIPTION
The withDefaultAuth enhancer should allow actions that do not use this feature. However, it throws an error when there is a @default(auth()) in the schema for an anonymous user, regardless of whether the action involves it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved default authentication handling for enhanced security and reliability.
- **Tests**
	- Added new test case to verify authentication behavior in specific scenarios.
- **Bug Fixes**
	- Updated parameter type in `useModelQuery` and `useInfiniteModelQuery` functions to exclude `queryKey` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->