### PR TITLE
Refactor: find up

### DIFF
--- a/packages/schema/src/cli/cli-util.ts
+++ b/packages/schema/src/cli/cli-util.ts
@@ -13,7 +13,7 @@ import { PLUGIN_MODULE_NAME, STD_LIB_MODULE_NAME } from '../language-server/cons
 import { ZModelFormatter } from '../language-server/zmodel-formatter';
 import { createZModelServices, ZModelServices } from '../language-server/zmodel-module';
 import { mergeBaseModel, resolveImport, resolveTransitiveImports } from '../utils/ast-utils';
-import { findPackageJson } from '../utils/pkg-utils';
+import { findUp } from '../utils/pkg-utils';
 import { getVersion } from '../utils/version-utils';
 import { CliError } from './cli-error';
 
@@ -280,7 +280,7 @@ export async function formatDocument(fileName: string) {
 
 export function getDefaultSchemaLocation() {
     // handle override from package.json
-    const pkgJsonPath = findPackageJson();
+    const pkgJsonPath = findUp(['package.json']);
     if (pkgJsonPath) {
         const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
         if (typeof pkgJson?.zenstack?.schema === 'string') {

--- a/packages/schema/src/plugins/prisma/schema-generator.ts
+++ b/packages/schema/src/plugins/prisma/schema-generator.ts
@@ -48,7 +48,7 @@ import { name } from '.';
 import { getStringLiteral } from '../../language-server/validator/utils';
 import telemetry from '../../telemetry';
 import { execPackage } from '../../utils/exec-utils';
-import { findPackageJson } from '../../utils/pkg-utils';
+import { findUp } from '../../utils/pkg-utils';
 import {
     ModelFieldType,
     AttributeArg as PrismaAttributeArg,
@@ -450,7 +450,7 @@ export default class PrismaSchemaGenerator {
 
 export function getDefaultPrismaOutputFile(schemaPath: string) {
     // handle override from package.json
-    const pkgJsonPath = findPackageJson(path.dirname(schemaPath));
+    const pkgJsonPath = findUp(['package.json'], path.dirname(schemaPath));
     if (pkgJsonPath) {
         const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
         if (typeof pkgJson?.zenstack?.prisma === 'string') {

--- a/packages/schema/src/utils/pkg-utils.ts
+++ b/packages/schema/src/utils/pkg-utils.ts
@@ -107,6 +107,11 @@ export function ensurePackage(
     }
 }
 
+/**
+ * A function that searches for the nearest package.json file starting from the provided search path or the current working directory if no search path is provided. 
+ * It iterates through the directory structure going one level up at a time until it finds a package.json file. If no package.json file is found, it returns undefined.
+ * @deprecated Use findUp instead @see findUp
+ */
 export function findPackageJson(searchPath?: string) {
     let currDir = searchPath ?? process.cwd();
     while (currDir) {

--- a/packages/schema/src/utils/pkg-utils.ts
+++ b/packages/schema/src/utils/pkg-utils.ts
@@ -8,7 +8,6 @@ export type PackageManagers = 'npm' | 'yarn' | 'pnpm';
  * A type named FindUp that takes a type parameter e which extends boolean. 
  * If e extends true, it returns a union type of string[] or undefined. 
  * If e does not extend true, it returns a union type of string or undefined.
- * @author Jonathan Stevens (TGTGamer)
  *
  * @export
  * @template e A type parameter that extends boolean
@@ -19,7 +18,6 @@ export type FindUp<e extends boolean> = e extends true ? string[] | undefined : 
  * Optionally return a single path or multiple paths. 
  * If multiple allowed, return all paths found. 
  * If no paths are found, return undefined.
- * @author Jonathan Stevens (TGTGamer)
  *
  * @export
  * @template [e=false]

--- a/packages/schema/src/utils/pkg-utils.ts
+++ b/packages/schema/src/utils/pkg-utils.ts
@@ -129,7 +129,7 @@ export function findPackageJson(searchPath?: string) {
 }
 
 export function getPackageJson(searchPath?: string) {
-    const pkgJsonPath = findPackageJson(searchPath);
+    const pkgJsonPath = findUp(['package.json'], searchPath ?? process.cwd());
     if (pkgJsonPath) {
         return JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
     } else {


### PR DESCRIPTION
# Goal
Starts #1008 

Refactor to make better use of this function and ensure multiple directories can be found such as needed for `node_module` directories to ensure support for mono-repos

Details as follows.

# findUp (): String | String[] | undefined

## Summary
The `findUp` function is used to search for file paths by recursively searching parent directories based on a given list of names and the current working directory. It can return a single path or multiple paths, depending on the specified flag. If no paths are found, it returns undefined.

## Example Usage
```javascript
const names = ['node_modules'];
const cwd = '/path/to/parent/child/project/current/directory';
const result = findUp(names, cwd, true);
console.log(result);
// Output: ['/path/to/parent/child/project/current/directory/node_modules', '/path/to/parent/node_modules']
```

## Code Analysis
### Inputs
- `names` (array of strings): An array of names to search for within the directory.
- `cwd` (string, optional): The current working directory. Defaults to the process's current working directory.
- `multiple` (boolean, optional): A flag indicating whether to search for multiple levels of files. Defaults to false.
- `result` (array of strings, optional): An array to store the accumulated results when searching for multiple paths.
___
### Flow
1. Check if any of the names in the list are empty. If all names are empty, return undefined.
2. Find the first name in the list that exists in the current working directory. If found and multiple is false, return the path as a string.
3. If multiple is true and a name is found, add the path to the result array.
4. Get the parent directory path of the current working directory.
5. If the parent directory is the same as the current working directory, return the result array if multiple is true and it contains paths, otherwise return undefined.
6. Recursively call the `findUp` function with the parent directory as the new current working directory.
7. Return the result of the recursive call.
___
### Outputs
- If multiple is false and a path is found, it returns the path as a string or undefined if no path is found.
- If multiple is true and at least one path is found, it returns an array of paths or undefined if no path is found.
___

### Tests                                                                                                                                                     
findup.spec.js
Total: 7 milliseconds
✓ 9

✓ should return the name of the first matching file when multiple is false and a match is found - 3 milliseconds
✓ should return undefined when no matches are found - 1 millisecond
✓ should search for specified files in parent directories starting from the given current working directory (cwd) - 0 milliseconds
✓ should accumulate results when multiple is true and matches are found - 2 milliseconds
✓ should return undefined when names array is empty - 0 milliseconds
✓ should return undefined when cwd is not a valid directory - 0 milliseconds
✓ should return undefined when no matches are found and multiple is true - 1 millisecond
✓ should return undefined when no matches are found and multiple is false - 0 milliseconds
✓ should return undefined when names array contains an empty string - 0 milliseconds

Tests can be found here: https://bit.cloud/tgtgamer/experiments/findup/~tests
___


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced file search functionality within the schema generation process for more efficient file path resolution.
- **Chores**
	- Updated internal utilities to support more flexible file searching capabilities and introduced a deprecation notice for outdated methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->