### PR TITLE
fix: validate zod schema before update operation is executed

### DIFF
--- a/tests/integration/tests/schema/refactor-pg.zmodel
+++ b/tests/integration/tests/schema/refactor-pg.zmodel
@@ -5,7 +5,7 @@ enum Role {
 
 model User {
     id Int @id @default(autoincrement())
-    email String @unique @email
+    email String @unique @email @lower
     role Role @default(USER)
     profile Profile?
     posts Post[]
@@ -52,7 +52,7 @@ model Image {
 
 model Post {
     id Int @id @default(autoincrement())
-    title String @length(1, 8)
+    title String @length(1, 8) @trim
     published Boolean @default(false)
     comments Comment[]
     author User @relation(fields: [authorId], references: [id], onDelete: Cascade)
@@ -67,7 +67,7 @@ model Post {
 
 model Comment {
     id Int @id @default(autoincrement())
-    content String
+    content String @trim
 
     author User @relation(fields: [authorId], references: [id], onDelete: Cascade)
     authorId Int


### PR DESCRIPTION
This makes sure transformation rules like `@trim`, `@upper`, `@lower` are effective for updates.

Fixes #1005 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data validation for create and update operations, ensuring more robust input checks.
	- Introduced a new `@lower` directive for field validation to enforce lowercasing.
	- Added `@trim` directive to fields for automatic trimming of whitespace.

- **Refactor**
	- Improved handling of policy violations and permissions.
	- Refined input validation logic for better data integrity.

- **Tests**
	- Expanded integration tests to cover new validation rules and directives.
	- Updated tests to reflect changes in data creation, update operations, and schema directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->