### PR TITLE
fix(zmodel): check optionality consistency between relation and fk fields

### DIFF
--- a/packages/schema/src/language-server/validator/datamodel-validator.ts
+++ b/packages/schema/src/language-server/validator/datamodel-validator.ts
@@ -148,7 +148,6 @@ export default class DataModelValidator implements AstValidator<DataModel> {
                 if (accept) {
                     accept('error', `Both "fields" and "references" must be provided`, { node: relAttr });
                 }
-                valid = false;
             }
         } else {
             // validate "fields" and "references" typing consistency
@@ -167,19 +166,16 @@ export default class DataModelValidator implements AstValidator<DataModel> {
                                 { node: fields[i].target.ref! }
                             );
                         }
-                        valid = false;
                     }
 
                     if (!fields[i].$resolvedType) {
                         if (accept) {
                             accept('error', `field reference is unresolved`, { node: fields[i] });
-                            valid = false;
                         }
                     }
                     if (!references[i].$resolvedType) {
                         if (accept) {
                             accept('error', `field reference is unresolved`, { node: references[i] });
-                            valid = false;
                         }
                     }
 
@@ -191,7 +187,6 @@ export default class DataModelValidator implements AstValidator<DataModel> {
                             accept('error', `values of "references" and "fields" must have the same type`, {
                                 node: relAttr,
                             });
-                            valid = false;
                         }
                     }
                 }

--- a/tests/integration/tests/regression/issue-1014.test.ts
+++ b/tests/integration/tests/regression/issue-1014.test.ts
@@ -19,8 +19,7 @@ describe('issue 1014', () => {
             
                 @@allow('read', true)
             }
-            `,
-            { logPrismaQuery: true }
+            `
         );
 
         const db = enhance();

--- a/tests/integration/tests/regression/issue-177.test.ts
+++ b/tests/integration/tests/regression/issue-177.test.ts
@@ -1,0 +1,27 @@
+import { loadModelWithError } from '@zenstackhq/testtools';
+
+describe('issue 177', () => {
+    it('regression', async () => {
+        await expect(
+            loadModelWithError(
+                `
+            model Foo {
+                id String @id @default(cuid())
+              
+                bar   Bar     @relation(fields: [barId1, barId2], references: [id1, id2])
+                barId1 String?
+                barId2 String
+            }
+              
+            model Bar {
+                id1  String @default(cuid())
+                id2  String @default(cuid())
+                foos Foo[]
+
+                @@id([id1, id2])
+            }              
+            `
+            )
+        ).resolves.toContain('relation "bar" is not optional, but field "barId1" is optional');
+    });
+});


### PR DESCRIPTION
Fixes #177 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved type comparison in schema validations.
	- Fixed typos in error messages for schema validations.
	- Enhanced validation for optional fields in non-optional relations.
- **Tests**
	- Adjusted test configurations for better accuracy.
	- Added a regression test for a specific model relationship scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->