### PR TITLE
fix(zod): add coercion call when generating schema for DateTime field

### DIFF
--- a/packages/schema/src/plugins/zod/utils/schema-gen.ts
+++ b/packages/schema/src/plugins/zod/utils/schema-gen.ts
@@ -174,7 +174,7 @@ function makeZodSchema(field: DataModelField) {
                 schema = 'z.boolean()';
                 break;
             case 'DateTime':
-                schema = 'z.date()';
+                schema = 'z.coerce.date()';
                 break;
             case 'Bytes':
                 schema = 'z.union([z.string(), z.instanceof(Uint8Array)])';

--- a/packages/server/tests/utils.ts
+++ b/packages/server/tests/utils.ts
@@ -20,6 +20,7 @@ model Post {
     author User? @relation(fields: [authorId], references: [id])
     authorId String?
     published Boolean @default(false)
+    publishedAt DateTime?
     viewCount Int @default(0)
 
     @@allow('all', author == auth())

--- a/tests/integration/tests/plugins/zod.test.ts
+++ b/tests/integration/tests/plugins/zod.test.ts
@@ -503,6 +503,50 @@ describe('Zod plugin tests', () => {
         ).toBeFalsy();
     });
 
+    it('does date coercion', async () => {
+        const { zodSchemas } = await loadSchema(
+            `
+        datasource db {
+            provider = 'postgresql'
+            url = env('DATABASE_URL')
+        }
+        
+        generator js {
+            provider = 'prisma-client-js'
+        }
+    
+        plugin zod {
+            provider = "@core/zod"
+        }        
+
+        model Model {
+            id Int @id @default(autoincrement())
+            dt DateTime
+        }
+        `,
+            { addPrelude: false, pushDb: false }
+        );
+        const schemas = zodSchemas.models;
+
+        expect(
+            schemas.ModelCreateSchema.safeParse({
+                dt: new Date(),
+            }).success
+        ).toBeTruthy();
+
+        expect(
+            schemas.ModelCreateSchema.safeParse({
+                dt: '2023-01-01T00:00:00.000Z',
+            }).success
+        ).toBeTruthy();
+
+        expect(
+            schemas.ModelCreateSchema.safeParse({
+                dt: '2023-13-01',
+            }).success
+        ).toBeFalsy();
+    });
+
     it('generate for selected models full', async () => {
         const { projectDir } = await loadSchema(
             `


### PR DESCRIPTION
Fixes #1067 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new `publishedAt` field of type `DateTime` to the `Post` entity to enhance date handling and validation.
- **Tests**
	- Enhanced REST server tests to include scenarios for creating and updating items with the `publishedAt` field.
	- Added tests for handling data validation errors using the Zod plugin, including date coercion and format validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->