### PR TITLE
fix: several issues with using `auth()` in `@default`

### DIFF
--- a/packages/runtime/src/cross/model-meta.ts
+++ b/packages/runtime/src/cross/model-meta.ts
@@ -75,7 +75,14 @@ export type FieldInfo = {
     isForeignKey?: boolean;
 
     /**
-     * Mapping from foreign key field names to relation field names
+     * If the field is a foreign key field, the field name of the corresponding relation field.
+     * Only available on foreign key fields.
+     */
+    relationField?: string;
+
+    /**
+     * Mapping from foreign key field names to relation field names.
+     * Only available on relation fields.
      */
     foreignKeyMapping?: Record<string, string>;
 

--- a/packages/runtime/src/enhancements/utils.ts
+++ b/packages/runtime/src/enhancements/utils.ts
@@ -1,4 +1,5 @@
 import * as util from 'util';
+import { FieldInfo, ModelMeta, resolveField } from '..';
 import type { DbClientContract } from '../types';
 
 /**
@@ -21,4 +22,22 @@ export function prismaClientKnownRequestError(prisma: DbClientContract, prismaMo
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function prismaClientUnknownRequestError(prismaModule: any, ...args: unknown[]): Error {
     throw new prismaModule.PrismaClientUnknownRequestError(...args);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isUnsafeMutate(model: string, args: any, modelMeta: ModelMeta) {
+    if (!args) {
+        return false;
+    }
+    for (const k of Object.keys(args)) {
+        const field = resolveField(modelMeta, model, k);
+        if (field && (isAutoIncrementIdField(field) || field.isForeignKey)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export function isAutoIncrementIdField(field: FieldInfo) {
+    return field.isId && field.isAutoIncrement;
 }

--- a/packages/schema/src/plugins/enhancer/enhancer-utils.ts
+++ b/packages/schema/src/plugins/enhancer/enhancer-utils.ts
@@ -1,0 +1,20 @@
+import { isAuthInvocation } from '@zenstackhq/sdk';
+import type { DataModelFieldAttribute } from '@zenstackhq/sdk/ast';
+import { streamAst } from 'langium';
+
+/**
+ * Check if the given field attribute is a `@default` with `auth()` invocation
+ */
+export function isDefaultWithAuth(attr: DataModelFieldAttribute) {
+    if (attr.decl.ref?.name !== '@default') {
+        return false;
+    }
+
+    const expr = attr.args[0]?.value;
+    if (!expr) {
+        return false;
+    }
+
+    // find `auth()` in default value expression
+    return streamAst(expr).some(isAuthInvocation);
+}

--- a/packages/schema/tests/schema/validation/attribute-validation.test.ts
+++ b/packages/schema/tests/schema/validation/attribute-validation.test.ts
@@ -227,7 +227,7 @@ describe('Attribute tests', () => {
         `);
 
         await loadModel(`
-            ${ prelude }
+            ${prelude}
             model A {
                 id String @id
                 x String
@@ -1051,21 +1051,6 @@ describe('Attribute tests', () => {
         }
     `);
 
-        // expect(
-        //     await loadModelWithError(`
-        //     ${prelude}
-
-        //     model User {
-        //         id String @id
-        //         name String
-        //     }
-        //     model B {
-        //         id String @id
-        //         userData String @default(auth())
-        //     }
-        // `)
-        // ).toContain("Value is not assignable to parameter");
-
         expect(
             await loadModelWithError(`
             ${prelude}
@@ -1185,15 +1170,6 @@ describe('Attribute tests', () => {
     });
 
     it('incorrect function expression context', async () => {
-        // expect(
-        //     await loadModelWithError(`
-        //     ${prelude}
-        //     model M {
-        //         id String @id @default(auth())
-        //     }
-        // `)
-        // ).toContain('function "auth" is not allowed in the current context: DefaultValue');
-
         expect(
             await loadModelWithError(`
             ${prelude}

--- a/packages/sdk/src/model-meta-generator.ts
+++ b/packages/sdk/src/model-meta-generator.ts
@@ -32,6 +32,7 @@ import {
     isIdField,
     resolved,
     TypeScriptExpressionTransformer,
+    getRelationField,
 } from '.';
 
 /**
@@ -247,6 +248,11 @@ function writeFields(
             if (isForeignKeyField(f)) {
                 writer.write(`
         isForeignKey: true,`);
+                const relationField = getRelationField(f);
+                if (relationField) {
+                    writer.write(`
+        relationField: '${relationField.name}',`);
+                }
             }
 
             if (fkMapping && Object.keys(fkMapping).length > 0) {
@@ -408,7 +414,6 @@ function generateForeignKeyMapping(field: DataModelField) {
     const fieldNames = fields.items.map((item) => (isReferenceExpr(item) ? item.target.$refText : undefined));
     const referenceNames = references.items.map((item) => (isReferenceExpr(item) ? item.target.$refText : undefined));
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result: Record<string, string> = {};
     referenceNames.forEach((name, i) => {
         if (name) {

--- a/packages/testtools/src/schema.ts
+++ b/packages/testtools/src/schema.ts
@@ -121,6 +121,7 @@ export type SchemaLoadOptions = {
     getPrismaOnly?: boolean;
     enhancements?: EnhancementKind[];
     enhanceOptions?: Partial<EnhancementOptions>;
+    extraSourceFiles?: { name: string; content: string }[];
 };
 
 const defaultOptions: SchemaLoadOptions = {
@@ -246,6 +247,11 @@ export async function loadSchema(schema: string, options?: SchemaLoadOptions) {
 
     if (opt.compile) {
         console.log('Compiling...');
+
+        opt.extraSourceFiles?.forEach(({ name, content }) => {
+            fs.writeFileSync(path.join(projectRoot, name), content);
+        });
+
         run('npx tsc --init');
 
         // add generated '.zenstack/zod' folder to typescript's search path,


### PR DESCRIPTION
- Make generated TS field optional if it has a default
- Handle the difference between save and unsafe Prisma mutation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced support for `@default(auth())` attribute handling, including better default value management for fields and foreign key fields.
	- Introduced new utility functions for handling unsafe mutations and identifying auto-increment ID fields.
	- Added logic for better differentiation between foreign key fields and relation fields.
	- Improved handling of relation fields in model metadata generation.
- **Refactor**
	- Refactored policy handling logic to include an updated `isUnsafeMutate` function.
	- Updated `PrismaSchemaGenerator` to refine the handling of default values with `auth()` annotations.
	- Renamed and updated logic in the schema enhancer for better clarity and functionality.
- **Tests**
	- Added integration tests for new and enhanced functionalities, particularly focusing on `auth()` field optionality and scenarios involving a mix of safe and unsafe default values.
- **Chores**
	- Introduced `enhancer-utils.ts` for specific utility functions like `isDefaultWithAuth`.
	- Added a property to `SchemaLoadOptions` to support additional source files during schema loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->