### PR TITLE
fix(polymorphism): relation name disambiguation

### DIFF
--- a/packages/schema/src/language-server/validator/datamodel-validator.ts
+++ b/packages/schema/src/language-server/validator/datamodel-validator.ts
@@ -241,7 +241,7 @@ export default class DataModelValidator implements AstValidator<DataModel> {
         const oppositeModel = field.type.reference!.ref! as DataModel;
 
         // Use name because the current document might be updated
-        let oppositeFields = getModelFieldsWithBases(oppositeModel).filter(
+        let oppositeFields = getModelFieldsWithBases(oppositeModel, false).filter(
             (f) => f.type.reference?.ref?.name === contextModel.name
         );
         oppositeFields = oppositeFields.filter((f) => {

--- a/packages/schema/src/plugins/enhancer/enhance/index.ts
+++ b/packages/schema/src/plugins/enhancer/enhance/index.ts
@@ -133,7 +133,7 @@ async function generateLogicalPrisma(model: Model, options: PluginOptions, outDi
         } catch {
             // noop
         }
-        throw new PluginError(name, `Failed to run "prisma generate"`);
+        throw new PluginError(name, `Failed to run "prisma generate" on logical schema: ${logicalPrismaFile}`);
     }
 
     // make a bunch of typing fixes to the generated prisma client

--- a/packages/schema/src/utils/ast-utils.ts
+++ b/packages/schema/src/utils/ast-utils.ts
@@ -16,7 +16,7 @@ import {
     ModelImport,
     ReferenceExpr,
 } from '@zenstackhq/language/ast';
-import { isFromStdlib } from '@zenstackhq/sdk';
+import { isDelegateModel, isFromStdlib } from '@zenstackhq/sdk';
 import {
     AstNode,
     copyAstNode,
@@ -207,19 +207,22 @@ export function getContainingDataModel(node: Expression): DataModel | undefined 
     return undefined;
 }
 
-export function getModelFieldsWithBases(model: DataModel) {
+export function getModelFieldsWithBases(model: DataModel, includeDelegate = true) {
     if (model.$baseMerged) {
         return model.fields;
     } else {
-        return [...model.fields, ...getRecursiveBases(model).flatMap((base) => base.fields)];
+        return [...model.fields, ...getRecursiveBases(model, includeDelegate).flatMap((base) => base.fields)];
     }
 }
 
-export function getRecursiveBases(dataModel: DataModel): DataModel[] {
+export function getRecursiveBases(dataModel: DataModel, includeDelegate = true): DataModel[] {
     const result: DataModel[] = [];
     dataModel.superTypes.forEach((superType) => {
         const baseDecl = superType.ref;
         if (baseDecl) {
+            if (!includeDelegate && isDelegateModel(baseDecl)) {
+                return;
+            }
             result.push(baseDecl);
             result.push(...getRecursiveBases(baseDecl));
         }

--- a/tests/integration/tests/enhancements/with-delegate/issue-1100.test.ts
+++ b/tests/integration/tests/enhancements/with-delegate/issue-1100.test.ts
@@ -1,0 +1,69 @@
+import { loadModelWithError, loadSchema } from '@zenstackhq/testtools';
+
+describe('Regression for issue 1100', () => {
+    it('missing opposite relation', async () => {
+        const schema = `
+        model User {
+          id String @id @default(cuid())
+          name String?
+          content Content[]
+          post Post[]
+        }
+        
+        model Content {
+          id String @id @default(cuid())
+          published Boolean @default(false)
+          contentType String
+          @@delegate(contentType)
+        
+          user User @relation(fields: [userId], references: [id])
+          userId String
+        }
+        
+        model Post extends Content {
+          title String
+        }
+        
+        model Image extends Content {
+          url String
+        }
+        `;
+
+        await expect(loadModelWithError(schema)).resolves.toContain(
+            'The relation field "post" on model "User" is missing an opposite relation field on model "Post"'
+        );
+    });
+
+    it('success', async () => {
+        const schema = `
+      model User {
+        id String @id @default(cuid())
+        name String?
+        content Content[]
+        post Post[]
+      }
+      
+      model Content {
+        id String @id @default(cuid())
+        published Boolean @default(false)
+        contentType String
+        @@delegate(contentType)
+      
+        user User @relation(fields: [userId], references: [id])
+        userId String
+      }
+      
+      model Post extends Content {
+        title String
+        author User @relation(fields: [authorId], references: [id])
+        authorId String
+      }
+      
+      model Image extends Content {
+        url String
+      }
+      `;
+
+        await expect(loadSchema(schema)).toResolveTruthy();
+    });
+});


### PR DESCRIPTION
Fixes #1100 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhancements for relation naming disambiguation, including the use of field names as relation names in certain scenarios.
- **Bug Fixes**
	- Improved error messages to specify the file where "prisma generate" failed, aiding in troubleshooting.
- **Tests**
	- Added integration tests for validating schema enhancements and error handling related to relation fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->