### PR TITLE
refactor(tanstack): merge zenstack query/mutation options into tanstack options

### DIFF
--- a/packages/plugins/swr/src/generator.ts
+++ b/packages/plugins/swr/src/generator.ts
@@ -66,7 +66,7 @@ function generateModelHooks(
         moduleSpecifier: prismaImport,
     });
     sf.addStatements([
-        `import { type GetNextArgs, type QueryOptions, type InfiniteQueryOptions, type MutationOptions, type PickEnumerable, useHooksContext } from '@zenstackhq/swr/runtime';`,
+        `import { type GetNextArgs, type QueryOptions, type InfiniteQueryOptions, type MutationOptions, type PickEnumerable } from '@zenstackhq/swr/runtime';`,
         `import metadata from './__model_meta';`,
         `import * as request from '@zenstackhq/swr/runtime';`,
     ]);

--- a/packages/plugins/tanstack-query/package.json
+++ b/packages/plugins/tanstack-query/package.json
@@ -90,6 +90,7 @@
         "semver": "^7.5.2",
         "superjson": "^1.11.0",
         "ts-morph": "^16.0.0",
+        "ts-pattern": "^4.3.0",
         "upper-case-first": "^2.0.2"
     },
     "devDependencies": {

--- a/packages/plugins/tanstack-query/src/generator.ts
+++ b/packages/plugins/tanstack-query/src/generator.ts
@@ -17,6 +17,7 @@ import { lowerCaseFirst } from 'lower-case-first';
 import path from 'path';
 import semver from 'semver';
 import { Project, SourceFile, VariableDeclarationKind } from 'ts-morph';
+import { match } from 'ts-pattern';
 import { upperCaseFirst } from 'upper-case-first';
 import { name } from '.';
 
@@ -37,7 +38,7 @@ export async function generate(model: Model, options: PluginOptions, dmmf: DMMF.
         throw new PluginError(name, `Unsupported target "${target}", supported values: ${supportedTargets.join(', ')}`);
     }
 
-    const version = typeof options.version === 'string' ? options.version : 'v4';
+    const version = typeof options.version === 'string' ? options.version : 'v5';
     if (version !== 'v4' && version !== 'v5') {
         throw new PluginError(name, `Unsupported version "${version}": use "v4" or "v5"`);
     }
@@ -130,15 +131,6 @@ function generateQueryHook(
                     name: 'options?',
                     type: optionsType,
                 },
-                ...(optimistic
-                    ? [
-                          {
-                              name: 'optimisticUpdate',
-                              type: 'boolean',
-                              initializer: 'true',
-                          },
-                      ]
-                    : []),
             ],
             isExported: true,
         });
@@ -152,7 +144,7 @@ function generateQueryHook(
             makeGetContext(target),
             `return use${generateMode}ModelQuery<TQueryFnData, TData, TError>('${model}', \`\${endpoint}/${lowerCaseFirst(
                 model
-            )}/${operation}\`, args, options, fetch${optimistic ? ', optimisticUpdate' : ''});`,
+            )}/${operation}\`, args, options, fetch);`,
         ]);
     }
 }
@@ -189,16 +181,6 @@ function generateMutationHook(
                 name: 'options?',
                 type: nonGenericOptionsType,
             },
-            {
-                name: 'invalidateQueries',
-                type: 'boolean',
-                initializer: 'true',
-            },
-            {
-                name: 'optimisticUpdate',
-                type: 'boolean',
-                initializer: 'false',
-            },
         ],
     });
 
@@ -215,7 +197,7 @@ function generateMutationHook(
                     overrideReturnType ?? model
                 }, ${checkReadBack}>('${model}', '${httpVerb.toUpperCase()}', \`\${endpoint}/${lowerCaseFirst(
                     model
-                )}/${operation}\`, metadata, options, fetch, invalidateQueries, ${checkReadBack}, optimisticUpdate)
+                )}/${operation}\`, metadata, options, fetch, ${checkReadBack})
                 `,
             },
         ],
@@ -561,7 +543,7 @@ function makeBaseImports(target: TargetFramework, version: TanStackVersion) {
     const runtimeImportBase = makeRuntimeImportBase(version);
     const shared = [
         `import { useModelQuery, useInfiniteModelQuery, useModelMutation } from '${runtimeImportBase}/${target}';`,
-        `import type { PickEnumerable, CheckSelect, QueryError } from '${runtimeImportBase}';`,
+        `import type { PickEnumerable, CheckSelect, QueryError, ExtraQueryOptions, ExtraMutationOptions } from '${runtimeImportBase}';`,
         `import metadata from './__model_meta';`,
         `type DefaultError = QueryError;`,
     ];
@@ -612,41 +594,53 @@ function makeQueryOptions(
     suspense: boolean,
     version: TanStackVersion
 ) {
-    switch (target) {
-        case 'react':
-            return infinite
+    let result = match(target)
+        .with('react', () =>
+            infinite
                 ? version === 'v4'
                     ? `Omit<UseInfiniteQueryOptions<${returnType}, TError, ${dataType}>, 'queryKey'>`
                     : `Omit<Use${
                           suspense ? 'Suspense' : ''
                       }InfiniteQueryOptions<${returnType}, TError, InfiniteData<${dataType}>>, 'queryKey'>`
-                : `Omit<Use${suspense ? 'Suspense' : ''}QueryOptions<${returnType}, TError, ${dataType}>, 'queryKey'>`;
-        case 'vue':
-            return `Omit<Use${infinite ? 'Infinite' : ''}QueryOptions<${returnType}, TError, ${dataType}>, 'queryKey'>`;
-        case 'svelte':
-            return infinite
+                : `Omit<Use${suspense ? 'Suspense' : ''}QueryOptions<${returnType}, TError, ${dataType}>, 'queryKey'>`
+        )
+        .with(
+            'vue',
+            () => `Omit<Use${infinite ? 'Infinite' : ''}QueryOptions<${returnType}, TError, ${dataType}>, 'queryKey'>`
+        )
+        .with('svelte', () =>
+            infinite
                 ? version === 'v4'
                     ? `Omit<CreateInfiniteQueryOptions<${returnType}, TError, ${dataType}>, 'queryKey'>`
                     : `StoreOrVal<Omit<CreateInfiniteQueryOptions<${returnType}, TError, InfiniteData<${dataType}>>, 'queryKey'>>`
                 : version === 'v4'
                 ? `Omit<CreateQueryOptions<${returnType}, TError, ${dataType}>, 'queryKey'>`
-                : `StoreOrVal<Omit<CreateQueryOptions<${returnType}, TError, ${dataType}>, 'queryKey'>>`;
-        default:
+                : `StoreOrVal<Omit<CreateQueryOptions<${returnType}, TError, ${dataType}>, 'queryKey'>>`
+        )
+        .otherwise(() => {
             throw new PluginError(name, `Unsupported target: ${target}`);
+        });
+
+    if (!infinite) {
+        // non-infinite queries support extra options like optimistic updates
+        result = `(${result} & ExtraQueryOptions)`;
     }
+
+    return result;
 }
 
 function makeMutationOptions(target: string, returnType: string, argsType: string) {
-    switch (target) {
-        case 'react':
-            return `UseMutationOptions<${returnType}, DefaultError, ${argsType}>`;
-        case 'vue':
-            return `UseMutationOptions<${returnType}, DefaultError, ${argsType}, unknown>`;
-        case 'svelte':
-            return `MutationOptions<${returnType}, DefaultError, ${argsType}>`;
-        default:
+    let result = match(target)
+        .with('react', () => `UseMutationOptions<${returnType}, DefaultError, ${argsType}>`)
+        .with('vue', () => `UseMutationOptions<${returnType}, DefaultError, ${argsType}, unknown>`)
+        .with('svelte', () => `MutationOptions<${returnType}, DefaultError, ${argsType}>`)
+        .otherwise(() => {
             throw new PluginError(name, `Unsupported target: ${target}`);
-    }
+        });
+
+    result = `(${result} & ExtraMutationOptions)`;
+
+    return result;
 }
 
 function makeRuntimeImportBase(version: TanStackVersion) {

--- a/packages/plugins/tanstack-query/src/runtime-v5/index.ts
+++ b/packages/plugins/tanstack-query/src/runtime-v5/index.ts
@@ -1,2 +1,8 @@
+export {
+    getQueryKey,
+    type ExtraMutationOptions,
+    type ExtraQueryOptions,
+    type FetchFn,
+    type QueryError,
+} from '../runtime/common';
 export * from '../runtime/prisma-types';
-export { type FetchFn, type QueryError, getQueryKey } from '../runtime/common';

--- a/packages/plugins/tanstack-query/src/runtime/common.ts
+++ b/packages/plugins/tanstack-query/src/runtime/common.ts
@@ -41,6 +41,31 @@ export type QueryError = Error & {
 };
 
 /**
+ * Extra mutation options.
+ */
+export type ExtraMutationOptions = {
+    /**
+     * Whether to automatically invalidate queries potentially affected by the mutation. Defaults to `true`.
+     */
+    invalidateQueries?: boolean;
+
+    /**
+     * Whether to optimistically update queries potentially affected by the mutation. Defaults to `false`.
+     */
+    optimisticUpdate?: boolean;
+};
+
+/**
+ * Extra query options.
+ */
+export type ExtraQueryOptions = {
+    /**
+     * Whether to opt-in to optimistic updates for this query. Defaults to `true`.
+     */
+    optimisticUpdate?: boolean;
+};
+
+/**
  * Context type for configuring the hooks.
  */
 export type APIContext = {
@@ -110,21 +135,24 @@ type QueryKey = [
  * @param model Model name.
  * @param urlOrOperation Prisma operation (e.g, `findMany`) or request URL. If it's a URL, the last path segment will be used as the operation name.
  * @param args Prisma query arguments.
- * @param infinite Whether the query is infinite.
- * @param optimisticUpdate Whether the query is optimistically updated.
+ * @param options Query options, including `infinite` indicating if it's an infinite query (defaults to false), and `optimisticUpdate` indicating if optimistic updates are enabled (defaults to true).
  * @returns Query key
  */
 export function getQueryKey(
     model: string,
     urlOrOperation: string,
     args: unknown,
-    infinite = false,
-    optimisticUpdate = false
+    options: { infinite: boolean; optimisticUpdate: boolean } = { infinite: false, optimisticUpdate: true }
 ): QueryKey {
     if (!urlOrOperation) {
         throw new Error('Invalid urlOrOperation');
     }
     const operation = urlOrOperation.split('/').pop();
+
+    const infinite = options.infinite;
+    // infinite query doesn't support optimistic updates
+    const optimisticUpdate = options.infinite ? false : options.optimisticUpdate;
+
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return [QUERY_KEY_PREFIX, model, operation!, args, { infinite, optimisticUpdate }];
 }

--- a/packages/plugins/tanstack-query/src/runtime/index.ts
+++ b/packages/plugins/tanstack-query/src/runtime/index.ts
@@ -1,2 +1,8 @@
+export {
+    getQueryKey,
+    type ExtraMutationOptions,
+    type ExtraQueryOptions,
+    type FetchFn,
+    type QueryError,
+} from './common';
 export * from './prisma-types';
-export { type FetchFn, type QueryError, getQueryKey } from './common';

--- a/packages/plugins/tanstack-query/src/runtime/react.ts
+++ b/packages/plugins/tanstack-query/src/runtime/react.ts
@@ -19,6 +19,8 @@ import {
     setupInvalidation,
     setupOptimisticUpdate,
     type APIContext,
+    type ExtraMutationOptions,
+    type ExtraQueryOptions,
     type FetchFn,
 } from './common';
 
@@ -52,20 +54,21 @@ export function getHooksContext() {
  * @param args The request args object, URL-encoded and appended as "?q=" parameter
  * @param options The react-query options object
  * @param fetch The fetch function to use for sending the HTTP request
- * @param optimisticUpdate Whether to enable automatic optimistic update
  * @returns useQuery hook
  */
 export function useModelQuery<TQueryFnData, TData, TError>(
     model: string,
     url: string,
     args?: unknown,
-    options?: Omit<UseQueryOptions<TQueryFnData, TError, TData>, 'queryKey'>,
-    fetch?: FetchFn,
-    optimisticUpdate = false
+    options?: Omit<UseQueryOptions<TQueryFnData, TError, TData>, 'queryKey'> & ExtraQueryOptions,
+    fetch?: FetchFn
 ) {
     const reqUrl = makeUrl(url, args);
     return useQuery<TQueryFnData, TError, TData>({
-        queryKey: getQueryKey(model, url, args, false, optimisticUpdate),
+        queryKey: getQueryKey(model, url, args, {
+            infinite: false,
+            optimisticUpdate: options?.optimisticUpdate !== false,
+        }),
         queryFn: () => fetcher<TQueryFnData, false>(reqUrl, undefined, fetch, false),
         ...options,
     });
@@ -89,7 +92,7 @@ export function useInfiniteModelQuery<TQueryFnData, TData, TError>(
     fetch?: FetchFn
 ) {
     return useInfiniteQuery<TQueryFnData, TError, TData>({
-        queryKey: getQueryKey(model, url, args, true),
+        queryKey: getQueryKey(model, url, args, { infinite: true, optimisticUpdate: false }),
         queryFn: ({ pageParam }) => {
             return fetcher<TQueryFnData, false>(makeUrl(url, pageParam ?? args), undefined, fetch, false);
         },
@@ -105,9 +108,7 @@ export function useInfiniteModelQuery<TQueryFnData, TData, TError>(
  * @param modelMeta The model metadata.
  * @param url The request URL.
  * @param options The react-query options.
- * @param invalidateQueries Whether to invalidate queries after mutation.
  * @param checkReadBack Whether to check for read back errors and return undefined if found.
- * @param optimisticUpdate Whether to enable automatic optimistic update
  * @returns useMutation hooks
  */
 export function useModelMutation<
@@ -121,11 +122,9 @@ export function useModelMutation<
     method: 'POST' | 'PUT' | 'DELETE',
     url: string,
     modelMeta: ModelMeta,
-    options?: Omit<UseMutationOptions<Result, TError, TArgs>, 'mutationFn'>,
+    options?: Omit<UseMutationOptions<Result, TError, TArgs>, 'mutationFn'> & ExtraMutationOptions,
     fetch?: FetchFn,
-    invalidateQueries = true,
-    checkReadBack?: C,
-    optimisticUpdate = false
+    checkReadBack?: C
 ) {
     const queryClient = useQueryClient();
     const mutationFn = (data: any) => {
@@ -144,6 +143,9 @@ export function useModelMutation<
 
     const finalOptions = { ...options, mutationFn };
     const operation = url.split('/').pop();
+    const invalidateQueries = options?.invalidateQueries !== false;
+    const optimisticUpdate = !!options?.optimisticUpdate;
+
     if (operation) {
         const { logging } = useContext(RequestHandlerContext);
         if (invalidateQueries) {

--- a/packages/plugins/tanstack-query/tests/plugin.test.ts
+++ b/packages/plugins/tanstack-query/tests/plugin.test.ts
@@ -53,6 +53,7 @@ plugin tanstack {
     provider = '${path.resolve(__dirname, '../dist')}'
     output = '$projectRoot/hooks'
     target = 'react'
+    version = 'v4'
 }
 
 ${sharedModel}
@@ -74,7 +75,6 @@ plugin tanstack {
     provider = '${path.resolve(__dirname, '../dist')}'
     output = '$projectRoot/hooks'
     target = 'react'
-    version = 'v5'
 }
 
 ${sharedModel}
@@ -96,6 +96,7 @@ plugin tanstack {
     provider = '${path.resolve(__dirname, '../dist')}'
     output = '$projectRoot/hooks'
     target = 'vue'
+    version = 'v4'
 }
 
 ${sharedModel}
@@ -117,7 +118,6 @@ plugin tanstack {
     provider = '${path.resolve(__dirname, '../dist')}'
     output = '$projectRoot/hooks'
     target = 'vue'
-    version = 'v5'
 }
 
 ${sharedModel}
@@ -139,6 +139,7 @@ plugin tanstack {
     provider = '${path.resolve(__dirname, '../dist')}'
     output = '$projectRoot/hooks'
     target = 'svelte'
+    version = 'v4'
 }
 
 ${sharedModel}
@@ -160,7 +161,6 @@ plugin tanstack {
     provider = '${path.resolve(__dirname, '../dist')}'
     output = '$projectRoot/hooks'
     target = 'svelte'
-    version = 'v5'
 }
 
 ${sharedModel}

--- a/packages/plugins/tanstack-query/tests/react-hooks-v5.test.tsx
+++ b/packages/plugins/tanstack-query/tests/react-hooks-v5.test.tsx
@@ -205,7 +205,7 @@ describe('Tanstack Query React Hooks V5 Test', () => {
             .persist();
 
         const { result } = renderHook(
-            () => useModelQuery('User', makeUrl('User', 'findMany'), undefined, undefined, undefined, true),
+            () => useModelQuery('User', makeUrl('User', 'findMany'), undefined, { optimisticUpdate: true }),
             {
                 wrapper,
             }
@@ -223,17 +223,10 @@ describe('Tanstack Query React Hooks V5 Test', () => {
 
         const { result: mutationResult } = renderHook(
             () =>
-                useModelMutation(
-                    'User',
-                    'POST',
-                    makeUrl('User', 'create'),
-                    modelMeta,
-                    undefined,
-                    undefined,
-                    false,
-                    undefined,
-                    true
-                ),
+                useModelMutation('User', 'POST', makeUrl('User', 'create'), modelMeta, {
+                    optimisticUpdate: true,
+                    invalidateQueries: false,
+                }),
             {
                 wrapper,
             }
@@ -242,7 +235,9 @@ describe('Tanstack Query React Hooks V5 Test', () => {
         act(() => mutationResult.current.mutate({ data: { name: 'foo' } }));
 
         await waitFor(() => {
-            const cacheData: any = queryClient.getQueryData(getQueryKey('User', 'findMany', undefined, false, true));
+            const cacheData: any = queryClient.getQueryData(
+                getQueryKey('User', 'findMany', undefined, { infinite: false, optimisticUpdate: true })
+            );
             expect(cacheData).toHaveLength(1);
             expect(cacheData[0].$optimistic).toBe(true);
             expect(cacheData[0].id).toBeTruthy();
@@ -264,7 +259,7 @@ describe('Tanstack Query React Hooks V5 Test', () => {
             .persist();
 
         const { result } = renderHook(
-            () => useModelQuery('User', makeUrl('User', 'findMany'), undefined, undefined, undefined, true),
+            () => useModelQuery('User', makeUrl('User', 'findMany'), undefined, { optimisticUpdate: true }),
             {
                 wrapper,
             }
@@ -282,17 +277,10 @@ describe('Tanstack Query React Hooks V5 Test', () => {
 
         const { result: mutationResult } = renderHook(
             () =>
-                useModelMutation(
-                    'User',
-                    'POST',
-                    makeUrl('User', 'createMany'),
-                    modelMeta,
-                    undefined,
-                    undefined,
-                    false,
-                    undefined,
-                    true
-                ),
+                useModelMutation('User', 'POST', makeUrl('User', 'createMany'), modelMeta, {
+                    optimisticUpdate: true,
+                    invalidateQueries: false,
+                }),
             {
                 wrapper,
             }
@@ -301,7 +289,9 @@ describe('Tanstack Query React Hooks V5 Test', () => {
         act(() => mutationResult.current.mutate({ data: [{ name: 'foo' }, { name: 'bar' }] }));
 
         await waitFor(() => {
-            const cacheData: any = queryClient.getQueryData(getQueryKey('User', 'findMany', undefined, false, true));
+            const cacheData: any = queryClient.getQueryData(
+                getQueryKey('User', 'findMany', undefined, { infinite: false, optimisticUpdate: true })
+            );
             expect(cacheData).toHaveLength(2);
         });
     });
@@ -409,7 +399,7 @@ describe('Tanstack Query React Hooks V5 Test', () => {
             .persist();
 
         const { result } = renderHook(
-            () => useModelQuery('User', makeUrl('User', 'findUnique'), queryArgs, undefined, undefined, true),
+            () => useModelQuery('User', makeUrl('User', 'findUnique'), queryArgs, { optimisticUpdate: true }),
             {
                 wrapper,
             }
@@ -427,17 +417,10 @@ describe('Tanstack Query React Hooks V5 Test', () => {
 
         const { result: mutationResult } = renderHook(
             () =>
-                useModelMutation(
-                    'User',
-                    'PUT',
-                    makeUrl('User', 'update'),
-                    modelMeta,
-                    undefined,
-                    undefined,
-                    false,
-                    undefined,
-                    true
-                ),
+                useModelMutation('User', 'PUT', makeUrl('User', 'update'), modelMeta, {
+                    optimisticUpdate: true,
+                    invalidateQueries: false,
+                }),
             {
                 wrapper,
             }
@@ -446,7 +429,9 @@ describe('Tanstack Query React Hooks V5 Test', () => {
         act(() => mutationResult.current.mutate({ ...queryArgs, data: { name: 'bar' } }));
 
         await waitFor(() => {
-            const cacheData = queryClient.getQueryData(getQueryKey('User', 'findUnique', queryArgs, false, true));
+            const cacheData = queryClient.getQueryData(
+                getQueryKey('User', 'findUnique', queryArgs, { infinite: false, optimisticUpdate: true })
+            );
             expect(cacheData).toMatchObject({ name: 'bar', $optimistic: true });
         });
     });
@@ -508,7 +493,7 @@ describe('Tanstack Query React Hooks V5 Test', () => {
             .persist();
 
         const { result } = renderHook(
-            () => useModelQuery('User', makeUrl('User', 'findMany'), undefined, undefined, undefined, true),
+            () => useModelQuery('User', makeUrl('User', 'findMany'), undefined, { optimisticUpdate: true }),
             {
                 wrapper,
             }
@@ -526,17 +511,10 @@ describe('Tanstack Query React Hooks V5 Test', () => {
 
         const { result: mutationResult } = renderHook(
             () =>
-                useModelMutation(
-                    'User',
-                    'DELETE',
-                    makeUrl('User', 'delete'),
-                    modelMeta,
-                    undefined,
-                    undefined,
-                    false,
-                    undefined,
-                    true
-                ),
+                useModelMutation('User', 'DELETE', makeUrl('User', 'delete'), modelMeta, {
+                    optimisticUpdate: true,
+                    invalidateQueries: false,
+                }),
             {
                 wrapper,
             }
@@ -545,7 +523,9 @@ describe('Tanstack Query React Hooks V5 Test', () => {
         act(() => mutationResult.current.mutate({ where: { id: '1' } }));
 
         await waitFor(() => {
-            const cacheData = queryClient.getQueryData(getQueryKey('User', 'findMany', undefined, false, true));
+            const cacheData = queryClient.getQueryData(
+                getQueryKey('User', 'findMany', undefined, { infinite: false, optimisticUpdate: true })
+            );
             expect(cacheData).toHaveLength(0);
         });
     });

--- a/packages/plugins/tanstack-query/tests/react-hooks.test.tsx
+++ b/packages/plugins/tanstack-query/tests/react-hooks.test.tsx
@@ -14,7 +14,7 @@ import { getQueryKey } from '../src/runtime/common';
 import { RequestHandlerContext, useModelMutation, useModelQuery } from '../src/runtime/react';
 import { modelMeta } from './test-model-meta';
 
-describe('Tanstack Query React Hooks Test', () => {
+describe('Tanstack Query React Hooks V4 Test', () => {
     function createWrapper() {
         const queryClient = new QueryClient();
         const Provider = RequestHandlerContext.Provider;
@@ -162,7 +162,7 @@ describe('Tanstack Query React Hooks Test', () => {
             .persist();
 
         const { result } = renderHook(
-            () => useModelQuery('User', makeUrl('User', 'findMany'), undefined, undefined, undefined, true),
+            () => useModelQuery('User', makeUrl('User', 'findMany'), undefined, { optimisticUpdate: true }),
             {
                 wrapper,
             }
@@ -185,11 +185,8 @@ describe('Tanstack Query React Hooks Test', () => {
                     'POST',
                     makeUrl('User', 'create'),
                     modelMeta,
-                    undefined,
-                    undefined,
-                    false,
-                    undefined,
-                    true
+                    { optimisticUpdate: true, invalidateQueries: false },
+                    undefined
                 ),
             {
                 wrapper,
@@ -199,7 +196,7 @@ describe('Tanstack Query React Hooks Test', () => {
         act(() => mutationResult.current.mutate({ data: { name: 'foo' } }));
 
         await waitFor(() => {
-            const cacheData: any = queryClient.getQueryData(getQueryKey('User', 'findMany', undefined, false, true));
+            const cacheData: any = queryClient.getQueryData(getQueryKey('User', 'findMany', undefined));
             expect(cacheData).toHaveLength(1);
             expect(cacheData[0].$optimistic).toBe(true);
             expect(cacheData[0].id).toBeTruthy();
@@ -221,7 +218,7 @@ describe('Tanstack Query React Hooks Test', () => {
             .persist();
 
         const { result } = renderHook(
-            () => useModelQuery('User', makeUrl('User', 'findMany'), undefined, undefined, undefined, true),
+            () => useModelQuery('User', makeUrl('User', 'findMany'), undefined, { optimisticUpdate: true }),
             {
                 wrapper,
             }
@@ -244,11 +241,8 @@ describe('Tanstack Query React Hooks Test', () => {
                     'POST',
                     makeUrl('User', 'createMany'),
                     modelMeta,
-                    undefined,
-                    undefined,
-                    false,
-                    undefined,
-                    true
+                    { optimisticUpdate: true, invalidateQueries: false },
+                    undefined
                 ),
             {
                 wrapper,
@@ -258,7 +252,7 @@ describe('Tanstack Query React Hooks Test', () => {
         act(() => mutationResult.current.mutate({ data: [{ name: 'foo' }, { name: 'bar' }] }));
 
         await waitFor(() => {
-            const cacheData: any = queryClient.getQueryData(getQueryKey('User', 'findMany', undefined, false, true));
+            const cacheData: any = queryClient.getQueryData(getQueryKey('User', 'findMany', undefined));
             expect(cacheData).toHaveLength(2);
         });
     });
@@ -322,7 +316,7 @@ describe('Tanstack Query React Hooks Test', () => {
             .persist();
 
         const { result } = renderHook(
-            () => useModelQuery('User', makeUrl('User', 'findUnique'), queryArgs, undefined, undefined, true),
+            () => useModelQuery('User', makeUrl('User', 'findUnique'), queryArgs, { optimisticUpdate: true }),
             {
                 wrapper,
             }
@@ -345,11 +339,8 @@ describe('Tanstack Query React Hooks Test', () => {
                     'PUT',
                     makeUrl('User', 'update'),
                     modelMeta,
-                    undefined,
-                    undefined,
-                    false,
-                    undefined,
-                    true
+                    { optimisticUpdate: true, invalidateQueries: false },
+                    undefined
                 ),
             {
                 wrapper,
@@ -359,7 +350,7 @@ describe('Tanstack Query React Hooks Test', () => {
         act(() => mutationResult.current.mutate({ ...queryArgs, data: { name: 'bar' } }));
 
         await waitFor(() => {
-            const cacheData = queryClient.getQueryData(getQueryKey('User', 'findUnique', queryArgs, false, true));
+            const cacheData = queryClient.getQueryData(getQueryKey('User', 'findUnique', queryArgs));
             expect(cacheData).toMatchObject({ name: 'bar', $optimistic: true });
         });
     });
@@ -421,7 +412,7 @@ describe('Tanstack Query React Hooks Test', () => {
             .persist();
 
         const { result } = renderHook(
-            () => useModelQuery('User', makeUrl('User', 'findMany'), undefined, undefined, undefined, true),
+            () => useModelQuery('User', makeUrl('User', 'findMany'), undefined, { optimisticUpdate: true }),
             {
                 wrapper,
             }
@@ -444,11 +435,8 @@ describe('Tanstack Query React Hooks Test', () => {
                     'DELETE',
                     makeUrl('User', 'delete'),
                     modelMeta,
-                    undefined,
-                    undefined,
-                    false,
-                    undefined,
-                    true
+                    { optimisticUpdate: true, invalidateQueries: false },
+                    undefined
                 ),
             {
                 wrapper,
@@ -458,7 +446,7 @@ describe('Tanstack Query React Hooks Test', () => {
         act(() => mutationResult.current.mutate({ where: { id: '1' } }));
 
         await waitFor(() => {
-            const cacheData = queryClient.getQueryData(getQueryKey('User', 'findMany', undefined, false, true));
+            const cacheData = queryClient.getQueryData(getQueryKey('User', 'findMany', undefined));
             expect(cacheData).toHaveLength(0);
         });
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       ts-morph:
         specifier: ^16.0.0
         version: 16.0.0
+      ts-pattern:
+        specifier: ^4.3.0
+        version: 4.3.0
       upper-case-first:
         specifier: ^2.0.2
         version: 2.0.2

--- a/tests/integration/tests/cli/plugins.test.ts
+++ b/tests/integration/tests/cli/plugins.test.ts
@@ -71,7 +71,7 @@ describe('CLI Plugins Tests', () => {
             'zod@3.21.1',
             'react',
             'swr',
-            '@tanstack/react-query@^4.0.0',
+            '@tanstack/react-query@^5.0.0',
             '@trpc/server',
             '@prisma/client@^4.0.0',
             `${path.join(__dirname, '../../../../.build/zenstackhq-language-' + ver + '.tgz')}`,


### PR DESCRIPTION
Fixes #835 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced query and mutation hooks in the Tanstack Query plugin to support additional options for more flexible and powerful data fetching and mutation capabilities.
	- Introduced `ExtraQueryOptions` and `ExtraMutationOptions` for extended control over queries and mutations, including handling of optimistic updates.
- **Refactor**
	- Updated Tanstack Query plugin to support version 5, removing outdated version-specific conditional logic.
	- Improved export organization for better usability across different frontend frameworks (React, Vue, Svelte).
	- Utilized pattern matching in options handling to simplify and enhance code readability.
- **Bug Fixes**
	- Fixed inconsistencies in query key generation, ensuring more reliable cache behavior and data fetching.
- **Tests**
	- Updated tests to reflect new versioning and added features, ensuring compatibility and reliability of the plugin across versions and frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->