### PR TITLE
refactor(server): remove deprecated useSuperJSON flag

### DIFF
--- a/packages/server/src/express/middleware.ts
+++ b/packages/server/src/express/middleware.ts
@@ -33,11 +33,6 @@ const factory = (options: MiddlewareOptions): Handler => {
     const { modelMeta, zodSchemas } = loadAssets(options);
 
     const requestHandler = options.handler || RPCAPIHandler();
-    if (options.useSuperJson !== undefined) {
-        console.warn(
-            'The option "useSuperJson" is deprecated. The server APIs automatically use superjson for serialization.'
-        );
-    }
 
     return async (request, response, next) => {
         const prisma = (await options.getPrisma(request, response)) as DbClientContract;

--- a/packages/server/src/fastify/plugin.ts
+++ b/packages/server/src/fastify/plugin.ts
@@ -32,11 +32,6 @@ const pluginHandler: FastifyPluginCallback<PluginOptions> = (fastify, options, d
     const { modelMeta, zodSchemas } = loadAssets(options);
 
     const requestHandler = options.handler ?? RPCApiHandler();
-    if (options.useSuperJson !== undefined) {
-        console.warn(
-            'The option "useSuperJson" is deprecated. The server APIs automatically use superjson for serialization.'
-        );
-    }
 
     fastify.all(`${prefix}/*`, async (request, reply) => {
         const prisma = (await options.getPrisma(request, reply)) as DbClientContract;

--- a/packages/server/src/next/app-route-handler.ts
+++ b/packages/server/src/next/app-route-handler.ts
@@ -20,11 +20,6 @@ export default function factory(
     const { modelMeta, zodSchemas } = loadAssets(options);
 
     const requestHandler = options.handler || RPCAPIHandler();
-    if (options.useSuperJson !== undefined) {
-        console.warn(
-            'The option "useSuperJson" is deprecated. The server APIs automatically use superjson for serialization.'
-        );
-    }
 
     return async (req: NextRequest, context: Context) => {
         const prisma = (await options.getPrisma(req)) as DbClientContract;

--- a/packages/server/src/next/pages-route-handler.ts
+++ b/packages/server/src/next/pages-route-handler.ts
@@ -18,11 +18,6 @@ export default function factory(
     const { modelMeta, zodSchemas } = loadAssets(options);
 
     const requestHandler = options.handler || RPCAPIHandler();
-    if (options.useSuperJson !== undefined) {
-        console.warn(
-            'The option "useSuperJson" is deprecated. The server APIs automatically use superjson for serialization.'
-        );
-    }
 
     return async (req: NextApiRequest, res: NextApiResponse) => {
         const prisma = (await options.getPrisma(req, res)) as DbClientContract;

--- a/packages/server/src/sveltekit/handler.ts
+++ b/packages/server/src/sveltekit/handler.ts
@@ -29,11 +29,6 @@ export default function createHandler(options: HandlerOptions): Handle {
     const { modelMeta, zodSchemas } = loadAssets(options);
 
     const requestHandler = options.handler ?? RPCApiHandler();
-    if (options.useSuperJson !== undefined) {
-        console.warn(
-            'The option "useSuperJson" is deprecated. The server APIs automatically use superjson for serialization.'
-        );
-    }
 
     return async ({ event, resolve }) => {
         if (event.url.pathname.startsWith(options.prefix)) {

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -58,11 +58,4 @@ export interface AdapterBaseOptions {
      * Defaults to RPC-style API handler created with `/api/rpc`.
      */
     handler?: HandleRequestFn;
-
-    /**
-     * Whether to use superjson for serialization/deserialization. Defaults to `false`.
-     *
-     * @deprecated Not needed anymore and will be removed in a future release.
-     */
-    useSuperJson?: boolean;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Removed deprecated warnings and usage of the `useSuperJson` option across the app.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->