### PR TITLE
fix(api-handler): return http 422 when the request is rejected due to validation errors

### DIFF
--- a/packages/plugins/openapi/src/rest-generator.ts
+++ b/packages/plugins/openapi/src/rest-generator.ts
@@ -217,6 +217,7 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
             responses: {
                 '201': this.success(`${model.name}Response`),
                 '403': this.forbidden(),
+                '422': this.validationError(),
             },
             security: resourceMeta?.security ?? policies.create === true ? [] : undefined,
         };
@@ -292,6 +293,7 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
                 '200': this.success(`${model.name}Response`),
                 '403': this.forbidden(),
                 '404': this.notFound(),
+                '422': this.validationError(),
             },
             security: resourceMeta?.security ?? policies.update === true ? [] : undefined,
         };
@@ -948,6 +950,17 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
     private forbidden() {
         return {
             description: 'Request is forbidden',
+            content: {
+                'application/vnd.api+json': {
+                    schema: this.ref('_errorResponse'),
+                },
+            },
+        };
+    }
+
+    private validationError() {
+        return {
+            description: 'Request is unprocessable due to validation errors',
             content: {
                 'application/vnd.api+json': {
                     schema: this.ref('_errorResponse'),

--- a/packages/plugins/openapi/src/rpc-generator.ts
+++ b/packages/plugins/openapi/src/rpc-generator.ts
@@ -516,6 +516,14 @@ export class RPCOpenAPIGenerator extends OpenAPIGeneratorBase {
                         },
                         description: 'Request is forbidden',
                     },
+                    '422': {
+                        content: {
+                            'application/json': {
+                                schema: this.ref('_Error'),
+                            },
+                        },
+                        description: 'Request is unprocessable due to validation errors',
+                    },
                 },
             };
 

--- a/packages/plugins/openapi/tests/baseline/rest-3.0.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-3.0.0.baseline.yaml
@@ -229,7 +229,13 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/user/{id}':
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
+    /user/{id}:
         get:
             operationId: fetch-User
             description: Fetch a "User" resource
@@ -288,6 +294,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
         patch:
             operationId: update-User-patch
             description: Update a "User" resource
@@ -319,6 +331,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
         delete:
             operationId: delete-User
             description: Delete a "User" resource
@@ -341,7 +359,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/user/{id}/posts':
+    /user/{id}/posts:
         get:
             operationId: fetch-User-related-posts
             description: Fetch the related "posts" resource for "User"
@@ -544,7 +562,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/user/{id}/relationships/posts':
+    /user/{id}/relationships/posts:
         get:
             operationId: fetch-User-relationship-posts
             description: Fetch the "posts" relationships for a "User"
@@ -839,7 +857,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/user/{id}/profile':
+    /user/{id}/profile:
         get:
             operationId: fetch-User-related-profile
             description: Fetch the related "profile" resource for "User"
@@ -867,7 +885,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/user/{id}/relationships/profile':
+    /user/{id}/relationships/profile:
         get:
             operationId: fetch-User-relationship-profile
             description: Fetch the "profile" relationships for a "User"
@@ -1067,7 +1085,13 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/profile/{id}':
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
+    /profile/{id}:
         get:
             operationId: fetch-Profile
             description: Fetch a "Profile" resource
@@ -1126,6 +1150,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
         patch:
             operationId: update-Profile-patch
             description: Update a "Profile" resource
@@ -1157,6 +1187,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
         delete:
             operationId: delete-Profile
             description: Delete a "Profile" resource
@@ -1179,7 +1215,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/profile/{id}/user':
+    /profile/{id}/user:
         get:
             operationId: fetch-Profile-related-user
             description: Fetch the related "user" resource for "Profile"
@@ -1207,7 +1243,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/profile/{id}/relationships/user':
+    /profile/{id}/relationships/user:
         get:
             operationId: fetch-Profile-relationship-user
             description: Fetch the "user" relationships for a "Profile"
@@ -1593,7 +1629,13 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/post_Item/{id}':
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
+    /post_Item/{id}:
         get:
             operationId: fetch-post_Item
             description: Fetch a "post_Item" resource
@@ -1652,6 +1694,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
         patch:
             operationId: update-post_Item-patch
             description: Update a "post_Item" resource
@@ -1683,6 +1731,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
         delete:
             operationId: delete-post_Item
             description: Delete a "post_Item" resource
@@ -1705,7 +1759,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/post_Item/{id}/author':
+    /post_Item/{id}/author:
         get:
             operationId: fetch-post_Item-related-author
             description: Fetch the related "author" resource for "post_Item"
@@ -1733,7 +1787,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/post_Item/{id}/relationships/author':
+    /post_Item/{id}/relationships/author:
         get:
             operationId: fetch-post_Item-relationship-author
             description: Fetch the "author" relationships for a "post_Item"

--- a/packages/plugins/openapi/tests/baseline/rest-3.1.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-3.1.0.baseline.yaml
@@ -229,7 +229,13 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/user/{id}':
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
+    /user/{id}:
         get:
             operationId: fetch-User
             description: Fetch a "User" resource
@@ -288,6 +294,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
         patch:
             operationId: update-User-patch
             description: Update a "User" resource
@@ -319,6 +331,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
         delete:
             operationId: delete-User
             description: Delete a "User" resource
@@ -341,7 +359,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/user/{id}/posts':
+    /user/{id}/posts:
         get:
             operationId: fetch-User-related-posts
             description: Fetch the related "posts" resource for "User"
@@ -544,7 +562,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/user/{id}/relationships/posts':
+    /user/{id}/relationships/posts:
         get:
             operationId: fetch-User-relationship-posts
             description: Fetch the "posts" relationships for a "User"
@@ -839,7 +857,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/user/{id}/profile':
+    /user/{id}/profile:
         get:
             operationId: fetch-User-related-profile
             description: Fetch the related "profile" resource for "User"
@@ -867,7 +885,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/user/{id}/relationships/profile':
+    /user/{id}/relationships/profile:
         get:
             operationId: fetch-User-relationship-profile
             description: Fetch the "profile" relationships for a "User"
@@ -1067,7 +1085,13 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/profile/{id}':
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
+    /profile/{id}:
         get:
             operationId: fetch-Profile
             description: Fetch a "Profile" resource
@@ -1126,6 +1150,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
         patch:
             operationId: update-Profile-patch
             description: Update a "Profile" resource
@@ -1157,6 +1187,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
         delete:
             operationId: delete-Profile
             description: Delete a "Profile" resource
@@ -1179,7 +1215,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/profile/{id}/user':
+    /profile/{id}/user:
         get:
             operationId: fetch-Profile-related-user
             description: Fetch the related "user" resource for "Profile"
@@ -1207,7 +1243,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/profile/{id}/relationships/user':
+    /profile/{id}/relationships/user:
         get:
             operationId: fetch-Profile-relationship-user
             description: Fetch the "user" relationships for a "Profile"
@@ -1593,7 +1629,13 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/post_Item/{id}':
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
+    /post_Item/{id}:
         get:
             operationId: fetch-post_Item
             description: Fetch a "post_Item" resource
@@ -1652,6 +1694,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
         patch:
             operationId: update-post_Item-patch
             description: Update a "post_Item" resource
@@ -1683,6 +1731,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
         delete:
             operationId: delete-post_Item
             description: Delete a "post_Item" resource
@@ -1705,7 +1759,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/post_Item/{id}/author':
+    /post_Item/{id}/author:
         get:
             operationId: fetch-post_Item-related-author
             description: Fetch the related "author" resource for "post_Item"
@@ -1733,7 +1787,7 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
-    '/post_Item/{id}/relationships/author':
+    /post_Item/{id}/relationships/author:
         get:
             operationId: fetch-post_Item-relationship-author
             description: Fetch the "author" relationships for a "post_Item"

--- a/packages/plugins/openapi/tests/baseline/rest-type-coverage-3.0.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-type-coverage-3.0.0.baseline.yaml
@@ -1,803 +1,821 @@
 openapi: 3.0.0
 info:
-    title: ZenStack Generated API
-    version: 1.0.0
+  title: ZenStack Generated API
+  version: 1.0.0
 tags:
-    - name: foo
-      description: Foo operations
+  - name: foo
+    description: Foo operations
 paths:
-    /foo:
-        get:
-            operationId: list-Foo
-            description: List "Foo" resources
-            tags:
-                - foo
-            parameters:
-                - $ref: '#/components/parameters/include'
-                - $ref: '#/components/parameters/sort'
-                - $ref: '#/components/parameters/page-offset'
-                - $ref: '#/components/parameters/page-limit'
-                - name: filter[id]
-                  required: false
-                  description: Id filter
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                - name: filter[string]
-                  required: false
-                  description: Equality filter for "string"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                - name: filter[string$contains]
-                  required: false
-                  description: String contains filter for "string"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                - name: filter[string$icontains]
-                  required: false
-                  description: String case-insensitive contains filter for "string"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                - name: filter[string$search]
-                  required: false
-                  description: String full-text search filter for "string"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                - name: filter[string$startsWith]
-                  required: false
-                  description: String startsWith filter for "string"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                - name: filter[string$endsWith]
-                  required: false
-                  description: String endsWith filter for "string"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                - name: filter[int]
-                  required: false
-                  description: Equality filter for "int"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: integer
-                - name: filter[int$lt]
-                  required: false
-                  description: Less-than filter for "int"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: integer
-                - name: filter[int$lte]
-                  required: false
-                  description: Less-than or equal filter for "int"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: integer
-                - name: filter[int$gt]
-                  required: false
-                  description: Greater-than filter for "int"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: integer
-                - name: filter[int$gte]
-                  required: false
-                  description: Greater-than or equal filter for "int"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: integer
-                - name: filter[bigInt]
-                  required: false
-                  description: Equality filter for "bigInt"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: integer
-                - name: filter[bigInt$lt]
-                  required: false
-                  description: Less-than filter for "bigInt"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: integer
-                - name: filter[bigInt$lte]
-                  required: false
-                  description: Less-than or equal filter for "bigInt"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: integer
-                - name: filter[bigInt$gt]
-                  required: false
-                  description: Greater-than filter for "bigInt"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: integer
-                - name: filter[bigInt$gte]
-                  required: false
-                  description: Greater-than or equal filter for "bigInt"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: integer
-                - name: filter[date]
-                  required: false
-                  description: Equality filter for "date"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                      format: date-time
-                - name: filter[date$lt]
-                  required: false
-                  description: Less-than filter for "date"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                      format: date-time
-                - name: filter[date$lte]
-                  required: false
-                  description: Less-than or equal filter for "date"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                      format: date-time
-                - name: filter[date$gt]
-                  required: false
-                  description: Greater-than filter for "date"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                      format: date-time
-                - name: filter[date$gte]
-                  required: false
-                  description: Greater-than or equal filter for "date"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                      format: date-time
-                - name: filter[float]
-                  required: false
-                  description: Equality filter for "float"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: number
-                - name: filter[float$lt]
-                  required: false
-                  description: Less-than filter for "float"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: number
-                - name: filter[float$lte]
-                  required: false
-                  description: Less-than or equal filter for "float"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: number
-                - name: filter[float$gt]
-                  required: false
-                  description: Greater-than filter for "float"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: number
-                - name: filter[float$gte]
-                  required: false
-                  description: Greater-than or equal filter for "float"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: number
-                - name: filter[decimal]
-                  required: false
-                  description: Equality filter for "decimal"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      oneOf:
-                          - type: number
-                          - type: string
-                - name: filter[decimal$lt]
-                  required: false
-                  description: Less-than filter for "decimal"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      oneOf:
-                          - type: number
-                          - type: string
-                - name: filter[decimal$lte]
-                  required: false
-                  description: Less-than or equal filter for "decimal"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      oneOf:
-                          - type: number
-                          - type: string
-                - name: filter[decimal$gt]
-                  required: false
-                  description: Greater-than filter for "decimal"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      oneOf:
-                          - type: number
-                          - type: string
-                - name: filter[decimal$gte]
-                  required: false
-                  description: Greater-than or equal filter for "decimal"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      oneOf:
-                          - type: number
-                          - type: string
-                - name: filter[boolean]
-                  required: false
-                  description: Equality filter for "boolean"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: boolean
-                - name: filter[bytes]
-                  required: false
-                  description: Equality filter for "bytes"
-                  in: query
-                  style: form
-                  explode: false
-                  schema:
-                      type: string
-                      format: byte
-                      description: Base64 encoded byte array
-            responses:
-                '200':
-                    description: Successful operation
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/FooListResponse'
-                '403':
-                    description: Request is forbidden
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/_errorResponse'
-            security: []
-        post:
-            operationId: create-Foo
-            description: Create a "Foo" resource
-            tags:
-                - foo
-            requestBody:
-                content:
-                    application/vnd.api+json:
-                        schema:
-                            $ref: '#/components/schemas/FooCreateRequest'
-            responses:
-                '201':
-                    description: Successful operation
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/FooResponse'
-                '403':
-                    description: Request is forbidden
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/_errorResponse'
-            security: []
-    '/foo/{id}':
-        get:
-            operationId: fetch-Foo
-            description: Fetch a "Foo" resource
-            tags:
-                - foo
-            parameters:
-                - $ref: '#/components/parameters/id'
-                - $ref: '#/components/parameters/include'
-            responses:
-                '200':
-                    description: Successful operation
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/FooResponse'
-                '403':
-                    description: Request is forbidden
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/_errorResponse'
-                '404':
-                    description: Resource is not found
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/_errorResponse'
-            security: []
-        put:
-            operationId: update-Foo-put
-            description: Update a "Foo" resource
-            tags:
-                - foo
-            parameters:
-                - $ref: '#/components/parameters/id'
-            requestBody:
-                content:
-                    application/vnd.api+json:
-                        schema:
-                            $ref: '#/components/schemas/FooUpdateRequest'
-            responses:
-                '200':
-                    description: Successful operation
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/FooResponse'
-                '403':
-                    description: Request is forbidden
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/_errorResponse'
-                '404':
-                    description: Resource is not found
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/_errorResponse'
-            security: []
-        patch:
-            operationId: update-Foo-patch
-            description: Update a "Foo" resource
-            tags:
-                - foo
-            parameters:
-                - $ref: '#/components/parameters/id'
-            requestBody:
-                content:
-                    application/vnd.api+json:
-                        schema:
-                            $ref: '#/components/schemas/FooUpdateRequest'
-            responses:
-                '200':
-                    description: Successful operation
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/FooResponse'
-                '403':
-                    description: Request is forbidden
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/_errorResponse'
-                '404':
-                    description: Resource is not found
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/_errorResponse'
-            security: []
-        delete:
-            operationId: delete-Foo
-            description: Delete a "Foo" resource
-            tags:
-                - foo
-            parameters:
-                - $ref: '#/components/parameters/id'
-            responses:
-                '200':
-                    description: Successful operation
-                '403':
-                    description: Request is forbidden
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/_errorResponse'
-                '404':
-                    description: Resource is not found
-                    content:
-                        application/vnd.api+json:
-                            schema:
-                                $ref: '#/components/schemas/_errorResponse'
-            security: []
+  /foo:
+    get:
+      operationId: list-Foo
+      description: List "Foo" resources
+      tags:
+        - foo
+      parameters:
+        - $ref: "#/components/parameters/include"
+        - $ref: "#/components/parameters/sort"
+        - $ref: "#/components/parameters/page-offset"
+        - $ref: "#/components/parameters/page-limit"
+        - name: filter[id]
+          required: false
+          description: Id filter
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+        - name: filter[string]
+          required: false
+          description: Equality filter for "string"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+        - name: filter[string$contains]
+          required: false
+          description: String contains filter for "string"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+        - name: filter[string$icontains]
+          required: false
+          description: String case-insensitive contains filter for "string"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+        - name: filter[string$search]
+          required: false
+          description: String full-text search filter for "string"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+        - name: filter[string$startsWith]
+          required: false
+          description: String startsWith filter for "string"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+        - name: filter[string$endsWith]
+          required: false
+          description: String endsWith filter for "string"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+        - name: filter[int]
+          required: false
+          description: Equality filter for "int"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: integer
+        - name: filter[int$lt]
+          required: false
+          description: Less-than filter for "int"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: integer
+        - name: filter[int$lte]
+          required: false
+          description: Less-than or equal filter for "int"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: integer
+        - name: filter[int$gt]
+          required: false
+          description: Greater-than filter for "int"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: integer
+        - name: filter[int$gte]
+          required: false
+          description: Greater-than or equal filter for "int"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: integer
+        - name: filter[bigInt]
+          required: false
+          description: Equality filter for "bigInt"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: integer
+        - name: filter[bigInt$lt]
+          required: false
+          description: Less-than filter for "bigInt"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: integer
+        - name: filter[bigInt$lte]
+          required: false
+          description: Less-than or equal filter for "bigInt"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: integer
+        - name: filter[bigInt$gt]
+          required: false
+          description: Greater-than filter for "bigInt"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: integer
+        - name: filter[bigInt$gte]
+          required: false
+          description: Greater-than or equal filter for "bigInt"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: integer
+        - name: filter[date]
+          required: false
+          description: Equality filter for "date"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            format: date-time
+        - name: filter[date$lt]
+          required: false
+          description: Less-than filter for "date"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            format: date-time
+        - name: filter[date$lte]
+          required: false
+          description: Less-than or equal filter for "date"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            format: date-time
+        - name: filter[date$gt]
+          required: false
+          description: Greater-than filter for "date"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            format: date-time
+        - name: filter[date$gte]
+          required: false
+          description: Greater-than or equal filter for "date"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            format: date-time
+        - name: filter[float]
+          required: false
+          description: Equality filter for "float"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: number
+        - name: filter[float$lt]
+          required: false
+          description: Less-than filter for "float"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: number
+        - name: filter[float$lte]
+          required: false
+          description: Less-than or equal filter for "float"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: number
+        - name: filter[float$gt]
+          required: false
+          description: Greater-than filter for "float"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: number
+        - name: filter[float$gte]
+          required: false
+          description: Greater-than or equal filter for "float"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: number
+        - name: filter[decimal]
+          required: false
+          description: Equality filter for "decimal"
+          in: query
+          style: form
+          explode: false
+          schema:
+            oneOf:
+              - type: number
+              - type: string
+        - name: filter[decimal$lt]
+          required: false
+          description: Less-than filter for "decimal"
+          in: query
+          style: form
+          explode: false
+          schema:
+            oneOf:
+              - type: number
+              - type: string
+        - name: filter[decimal$lte]
+          required: false
+          description: Less-than or equal filter for "decimal"
+          in: query
+          style: form
+          explode: false
+          schema:
+            oneOf:
+              - type: number
+              - type: string
+        - name: filter[decimal$gt]
+          required: false
+          description: Greater-than filter for "decimal"
+          in: query
+          style: form
+          explode: false
+          schema:
+            oneOf:
+              - type: number
+              - type: string
+        - name: filter[decimal$gte]
+          required: false
+          description: Greater-than or equal filter for "decimal"
+          in: query
+          style: form
+          explode: false
+          schema:
+            oneOf:
+              - type: number
+              - type: string
+        - name: filter[boolean]
+          required: false
+          description: Equality filter for "boolean"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: boolean
+        - name: filter[bytes]
+          required: false
+          description: Equality filter for "bytes"
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            format: byte
+            description: Base64 encoded byte array
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/FooListResponse"
+        "403":
+          description: Request is forbidden
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+      security: []
+    post:
+      operationId: create-Foo
+      description: Create a "Foo" resource
+      tags:
+        - foo
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/FooCreateRequest"
+      responses:
+        "201":
+          description: Successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/FooResponse"
+        "403":
+          description: Request is forbidden
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+        "422":
+          description: Request is unprocessable due to validation errors
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+      security: []
+  /foo/{id}:
+    get:
+      operationId: fetch-Foo
+      description: Fetch a "Foo" resource
+      tags:
+        - foo
+      parameters:
+        - $ref: "#/components/parameters/id"
+        - $ref: "#/components/parameters/include"
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/FooResponse"
+        "403":
+          description: Request is forbidden
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+        "404":
+          description: Resource is not found
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+      security: []
+    put:
+      operationId: update-Foo-put
+      description: Update a "Foo" resource
+      tags:
+        - foo
+      parameters:
+        - $ref: "#/components/parameters/id"
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/FooUpdateRequest"
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/FooResponse"
+        "403":
+          description: Request is forbidden
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+        "404":
+          description: Resource is not found
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+        "422":
+          description: Request is unprocessable due to validation errors
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+      security: []
+    patch:
+      operationId: update-Foo-patch
+      description: Update a "Foo" resource
+      tags:
+        - foo
+      parameters:
+        - $ref: "#/components/parameters/id"
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              $ref: "#/components/schemas/FooUpdateRequest"
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/FooResponse"
+        "403":
+          description: Request is forbidden
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+        "404":
+          description: Resource is not found
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+        "422":
+          description: Request is unprocessable due to validation errors
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+      security: []
+    delete:
+      operationId: delete-Foo
+      description: Delete a "Foo" resource
+      tags:
+        - foo
+      parameters:
+        - $ref: "#/components/parameters/id"
+      responses:
+        "200":
+          description: Successful operation
+        "403":
+          description: Request is forbidden
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+        "404":
+          description: Resource is not found
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/_errorResponse"
+      security: []
 components:
-    schemas:
-        _jsonapi:
-            type: object
-            description: An object describing the server’s implementation
-            required:
-                - version
-            properties:
-                version:
-                    type: string
-        _meta:
-            type: object
-            description: Meta information about the request or response
-            properties:
-                serialization:
-                    description: Superjson serialization metadata
-            additionalProperties: true
-        _resourceIdentifier:
-            type: object
-            description: Identifier for a resource
-            required:
-                - type
-                - id
-            properties:
-                type:
-                    type: string
-                    description: Resource type
-                id:
-                    type: string
-                    description: Resource id
-        _resource:
-            allOf:
-                - $ref: '#/components/schemas/_resourceIdentifier'
-                - type: object
-                  description: A resource with attributes and relationships
-                  properties:
-                      attributes:
-                          type: object
-                          description: Resource attributes
-                      relationships:
-                          type: object
-                          description: Resource relationships
-        _links:
-            type: object
-            required:
-                - self
-            description: Links related to the resource
-            properties:
-                self:
-                    type: string
-                    description: Link for refetching the curent results
-        _pagination:
-            type: object
-            description: Pagination information
-            required:
-                - first
-                - last
-                - prev
-                - next
-            properties:
-                first:
-                    type: string
-                    description: Link to the first page
-                    nullable: true
-                last:
-                    type: string
-                    description: Link to the last page
-                    nullable: true
-                prev:
-                    type: string
-                    description: Link to the previous page
-                    nullable: true
-                next:
-                    type: string
-                    description: Link to the next page
-                    nullable: true
-        _errors:
-            type: array
-            description: An array of error objects
-            items:
-                type: object
-                required:
-                    - status
-                    - code
-                properties:
-                    status:
-                        type: string
-                        description: HTTP status
-                    code:
-                        type: string
-                        description: Error code
-                    prismaCode:
-                        type: string
-                        description: Prisma error code if the error is thrown by Prisma
-                    title:
-                        type: string
-                        description: Error title
-                    detail:
-                        type: string
-                        description: Error detail
-                    reason:
-                        type: string
-                        description: Detailed error reason
-                    zodErrors:
-                        type: object
-                        additionalProperties: true
-                        description: Zod validation errors if the error is due to data validation
-                            failure
-        _errorResponse:
-            type: object
-            required:
-                - errors
-            description: An error response
-            properties:
-                jsonapi:
-                    $ref: '#/components/schemas/_jsonapi'
-                errors:
-                    $ref: '#/components/schemas/_errors'
-        Foo:
-            type: object
-            description: The "Foo" model
-            required:
-                - id
-                - type
-                - attributes
-            properties:
-                id:
-                    type: string
-                type:
-                    type: string
-                attributes:
-                    type: object
-                    properties:
-                        string:
-                            type: string
-                        int:
-                            type: integer
-                        bigInt:
-                            type: integer
-                        date:
-                            type: string
-                            format: date-time
-                        float:
-                            type: number
-                        decimal:
-                            oneOf:
-                                - type: number
-                                - type: string
-                        boolean:
-                            type: boolean
-                        bytes:
-                            type: string
-                            format: byte
-                            description: Base64 encoded byte array
-        FooCreateRequest:
-            type: object
-            description: Input for creating a "Foo"
-            required:
-                - data
-            properties:
-                data:
-                    type: object
-                    description: The "Foo" model
-                    required:
-                        - type
-                        - attributes
-                    properties:
-                        type:
-                            type: string
-                        attributes:
-                            type: object
-                            required:
-                                - string
-                                - int
-                                - bigInt
-                                - date
-                                - float
-                                - decimal
-                                - boolean
-                                - bytes
-                            properties:
-                                string:
-                                    type: string
-                                int:
-                                    type: integer
-                                bigInt:
-                                    type: integer
-                                date:
-                                    type: string
-                                    format: date-time
-                                float:
-                                    type: number
-                                decimal:
-                                    oneOf:
-                                        - type: number
-                                        - type: string
-                                boolean:
-                                    type: boolean
-                                bytes:
-                                    type: string
-                                    format: byte
-                                    description: Base64 encoded byte array
-                meta:
-                    $ref: '#/components/schemas/_meta'
-        FooUpdateRequest:
-            type: object
-            description: Input for updating a "Foo"
-            required:
-                - data
-            properties:
-                data:
-                    type: object
-                    description: The "Foo" model
-                    required:
-                        - id
-                        - type
-                        - attributes
-                    properties:
-                        id:
-                            type: string
-                        type:
-                            type: string
-                        attributes:
-                            type: object
-                            properties:
-                                string:
-                                    type: string
-                                int:
-                                    type: integer
-                                bigInt:
-                                    type: integer
-                                date:
-                                    type: string
-                                    format: date-time
-                                float:
-                                    type: number
-                                decimal:
-                                    oneOf:
-                                        - type: number
-                                        - type: string
-                                boolean:
-                                    type: boolean
-                                bytes:
-                                    type: string
-                                    format: byte
-                                    description: Base64 encoded byte array
-                meta:
-                    $ref: '#/components/schemas/_meta'
-        FooResponse:
-            type: object
-            description: Response for a "Foo"
-            required:
-                - data
-            properties:
-                jsonapi:
-                    $ref: '#/components/schemas/_jsonapi'
-                data:
-                    allOf:
-                        - $ref: '#/components/schemas/Foo'
-                        - type: object
-                          properties:
-                              relationships:
-                                  type: object
-                                  properties: &a1 {}
-                meta:
-                    $ref: '#/components/schemas/_meta'
-                included:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/_resource'
-                links:
-                    $ref: '#/components/schemas/_links'
-        FooListResponse:
-            type: object
-            description: Response for a list of "Foo"
-            required:
-                - data
-                - links
-            properties:
-                jsonapi:
-                    $ref: '#/components/schemas/_jsonapi'
-                data:
-                    type: array
-                    items:
-                        allOf:
-                            - $ref: '#/components/schemas/Foo'
-                            - type: object
-                              properties:
-                                  relationships:
-                                      type: object
-                                      properties: *a1
-                meta:
-                    $ref: '#/components/schemas/_meta'
-                included:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/_resource'
-                links:
-                    allOf:
-                        - $ref: '#/components/schemas/_links'
-                        - $ref: '#/components/schemas/_pagination'
-    parameters:
+  schemas:
+    _jsonapi:
+      type: object
+      description: An object describing the server’s implementation
+      required:
+        - version
+      properties:
+        version:
+          type: string
+    _meta:
+      type: object
+      description: Meta information about the request or response
+      properties:
+        serialization:
+          description: Superjson serialization metadata
+      additionalProperties: true
+    _resourceIdentifier:
+      type: object
+      description: Identifier for a resource
+      required:
+        - type
+        - id
+      properties:
+        type:
+          type: string
+          description: Resource type
         id:
-            name: id
-            in: path
-            description: The resource id
-            required: true
-            schema:
-                type: string
-        include:
-            name: include
-            in: query
-            description: Relationships to include
-            required: false
-            style: form
-            schema:
-                type: string
-        sort:
-            name: sort
-            in: query
-            description: Fields to sort by
-            required: false
-            style: form
-            schema:
-                type: string
-        page-offset:
-            name: page[offset]
-            in: query
-            description: Offset for pagination
-            required: false
-            style: form
-            schema:
-                type: integer
-        page-limit:
-            name: page[limit]
-            in: query
-            description: Limit for pagination
-            required: false
-            style: form
-            schema:
-                type: integer
+          type: string
+          description: Resource id
+    _resource:
+      allOf:
+        - $ref: "#/components/schemas/_resourceIdentifier"
+        - type: object
+          description: A resource with attributes and relationships
+          properties:
+            attributes:
+              type: object
+              description: Resource attributes
+            relationships:
+              type: object
+              description: Resource relationships
+    _links:
+      type: object
+      required:
+        - self
+      description: Links related to the resource
+      properties:
+        self:
+          type: string
+          description: Link for refetching the curent results
+    _pagination:
+      type: object
+      description: Pagination information
+      required:
+        - first
+        - last
+        - prev
+        - next
+      properties:
+        first:
+          type: string
+          description: Link to the first page
+          nullable: true
+        last:
+          type: string
+          description: Link to the last page
+          nullable: true
+        prev:
+          type: string
+          description: Link to the previous page
+          nullable: true
+        next:
+          type: string
+          description: Link to the next page
+          nullable: true
+    _errors:
+      type: array
+      description: An array of error objects
+      items:
+        type: object
+        required:
+          - status
+          - code
+        properties:
+          status:
+            type: string
+            description: HTTP status
+          code:
+            type: string
+            description: Error code
+          prismaCode:
+            type: string
+            description: Prisma error code if the error is thrown by Prisma
+          title:
+            type: string
+            description: Error title
+          detail:
+            type: string
+            description: Error detail
+          reason:
+            type: string
+            description: Detailed error reason
+          zodErrors:
+            type: object
+            additionalProperties: true
+            description: Zod validation errors if the error is due to data validation
+              failure
+    _errorResponse:
+      type: object
+      required:
+        - errors
+      description: An error response
+      properties:
+        jsonapi:
+          $ref: "#/components/schemas/_jsonapi"
+        errors:
+          $ref: "#/components/schemas/_errors"
+    Foo:
+      type: object
+      description: The "Foo" model
+      required:
+        - id
+        - type
+        - attributes
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+        attributes:
+          type: object
+          properties:
+            string:
+              type: string
+            int:
+              type: integer
+            bigInt:
+              type: integer
+            date:
+              type: string
+              format: date-time
+            float:
+              type: number
+            decimal:
+              oneOf:
+                - type: number
+                - type: string
+            boolean:
+              type: boolean
+            bytes:
+              type: string
+              format: byte
+              description: Base64 encoded byte array
+    FooCreateRequest:
+      type: object
+      description: Input for creating a "Foo"
+      required:
+        - data
+      properties:
+        data:
+          type: object
+          description: The "Foo" model
+          required:
+            - type
+            - attributes
+          properties:
+            type:
+              type: string
+            attributes:
+              type: object
+              required:
+                - string
+                - int
+                - bigInt
+                - date
+                - float
+                - decimal
+                - boolean
+                - bytes
+              properties:
+                string:
+                  type: string
+                int:
+                  type: integer
+                bigInt:
+                  type: integer
+                date:
+                  type: string
+                  format: date-time
+                float:
+                  type: number
+                decimal:
+                  oneOf:
+                    - type: number
+                    - type: string
+                boolean:
+                  type: boolean
+                bytes:
+                  type: string
+                  format: byte
+                  description: Base64 encoded byte array
+        meta:
+          $ref: "#/components/schemas/_meta"
+    FooUpdateRequest:
+      type: object
+      description: Input for updating a "Foo"
+      required:
+        - data
+      properties:
+        data:
+          type: object
+          description: The "Foo" model
+          required:
+            - id
+            - type
+            - attributes
+          properties:
+            id:
+              type: string
+            type:
+              type: string
+            attributes:
+              type: object
+              properties:
+                string:
+                  type: string
+                int:
+                  type: integer
+                bigInt:
+                  type: integer
+                date:
+                  type: string
+                  format: date-time
+                float:
+                  type: number
+                decimal:
+                  oneOf:
+                    - type: number
+                    - type: string
+                boolean:
+                  type: boolean
+                bytes:
+                  type: string
+                  format: byte
+                  description: Base64 encoded byte array
+        meta:
+          $ref: "#/components/schemas/_meta"
+    FooResponse:
+      type: object
+      description: Response for a "Foo"
+      required:
+        - data
+      properties:
+        jsonapi:
+          $ref: "#/components/schemas/_jsonapi"
+        data:
+          allOf:
+            - $ref: "#/components/schemas/Foo"
+            - type: object
+              properties:
+                relationships:
+                  type: object
+                  properties: &a1 {}
+        meta:
+          $ref: "#/components/schemas/_meta"
+        included:
+          type: array
+          items:
+            $ref: "#/components/schemas/_resource"
+        links:
+          $ref: "#/components/schemas/_links"
+    FooListResponse:
+      type: object
+      description: Response for a list of "Foo"
+      required:
+        - data
+        - links
+      properties:
+        jsonapi:
+          $ref: "#/components/schemas/_jsonapi"
+        data:
+          type: array
+          items:
+            allOf:
+              - $ref: "#/components/schemas/Foo"
+              - type: object
+                properties:
+                  relationships:
+                    type: object
+                    properties: *a1
+        meta:
+          $ref: "#/components/schemas/_meta"
+        included:
+          type: array
+          items:
+            $ref: "#/components/schemas/_resource"
+        links:
+          allOf:
+            - $ref: "#/components/schemas/_links"
+            - $ref: "#/components/schemas/_pagination"
+  parameters:
+    id:
+      name: id
+      in: path
+      description: The resource id
+      required: true
+      schema:
+        type: string
+    include:
+      name: include
+      in: query
+      description: Relationships to include
+      required: false
+      style: form
+      schema:
+        type: string
+    sort:
+      name: sort
+      in: query
+      description: Fields to sort by
+      required: false
+      style: form
+      schema:
+        type: string
+    page-offset:
+      name: page[offset]
+      in: query
+      description: Offset for pagination
+      required: false
+      style: form
+      schema:
+        type: integer
+    page-limit:
+      name: page[limit]
+      in: query
+      description: Limit for pagination
+      required: false
+      style: form
+      schema:
+        type: integer

--- a/packages/plugins/openapi/tests/baseline/rest-type-coverage-3.1.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-type-coverage-3.1.0.baseline.yaml
@@ -343,8 +343,14 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
             security: []
-    '/foo/{id}':
+    /foo/{id}:
         get:
             operationId: fetch-Foo
             description: Fetch a "Foo" resource
@@ -404,6 +410,12 @@ paths:
                         application/vnd.api+json:
                             schema:
                                 $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
             security: []
         patch:
             operationId: update-Foo-patch
@@ -432,6 +444,12 @@ paths:
                                 $ref: '#/components/schemas/_errorResponse'
                 '404':
                     description: Resource is not found
+                    content:
+                        application/vnd.api+json:
+                            schema:
+                                $ref: '#/components/schemas/_errorResponse'
+                '422':
+                    description: Request is unprocessable due to validation errors
                     content:
                         application/vnd.api+json:
                             schema:

--- a/packages/plugins/openapi/tests/baseline/rpc-3.0.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rpc-3.0.0.baseline.yaml
@@ -3734,6 +3734,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -3773,6 +3779,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -3812,6 +3824,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -3861,6 +3879,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -3912,6 +3936,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -3961,6 +3991,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4000,6 +4036,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4039,6 +4081,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4081,6 +4129,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4120,6 +4174,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4171,6 +4231,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4220,6 +4286,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4271,6 +4343,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4320,6 +4398,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4359,6 +4443,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4398,6 +4488,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4447,6 +4543,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4498,6 +4600,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4547,6 +4655,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4586,6 +4700,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4625,6 +4745,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4664,6 +4790,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4713,6 +4845,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4764,6 +4902,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4813,6 +4957,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4864,6 +5014,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4913,6 +5069,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4952,6 +5114,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4991,6 +5159,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -5040,6 +5214,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -5089,6 +5269,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -5128,6 +5314,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -5167,6 +5359,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -5206,6 +5404,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -5255,6 +5459,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -5306,6 +5516,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -5355,6 +5571,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -5406,6 +5628,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query

--- a/packages/plugins/openapi/tests/baseline/rpc-3.1.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rpc-3.1.0.baseline.yaml
@@ -3788,6 +3788,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -3827,6 +3833,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -3866,6 +3878,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -3915,6 +3933,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -3966,6 +3990,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4015,6 +4045,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4054,6 +4090,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4093,6 +4135,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4135,6 +4183,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4174,6 +4228,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4225,6 +4285,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4274,6 +4340,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4325,6 +4397,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4374,6 +4452,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4413,6 +4497,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4452,6 +4542,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4501,6 +4597,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4552,6 +4654,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4601,6 +4709,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4640,6 +4754,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4679,6 +4799,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -4718,6 +4844,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4767,6 +4899,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4818,6 +4956,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4867,6 +5011,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4918,6 +5068,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -4967,6 +5123,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -5006,6 +5168,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -5045,6 +5213,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -5094,6 +5268,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -5143,6 +5323,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -5182,6 +5368,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -5221,6 +5413,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -5260,6 +5458,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -5309,6 +5513,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -5360,6 +5570,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -5409,6 +5625,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -5460,6 +5682,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query

--- a/packages/plugins/openapi/tests/baseline/rpc-type-coverage-3.0.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rpc-type-coverage-3.0.0.baseline.yaml
@@ -2210,6 +2210,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -2250,6 +2256,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -2290,6 +2302,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2340,6 +2358,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2392,6 +2416,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2442,6 +2472,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -2482,6 +2518,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -2522,6 +2564,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -2562,6 +2610,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2612,6 +2666,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2664,6 +2724,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2714,6 +2780,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2766,6 +2838,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query

--- a/packages/plugins/openapi/tests/baseline/rpc-type-coverage-3.1.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rpc-type-coverage-3.1.0.baseline.yaml
@@ -2242,6 +2242,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -2282,6 +2288,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -2322,6 +2334,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2372,6 +2390,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2424,6 +2448,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2474,6 +2504,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -2514,6 +2550,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -2554,6 +2596,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             requestBody:
                 content:
                     application/json:
@@ -2594,6 +2642,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2644,6 +2698,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2696,6 +2756,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2746,6 +2812,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query
@@ -2798,6 +2870,12 @@ paths:
                             schema:
                                 $ref: '#/components/schemas/_Error'
                     description: Request is forbidden
+                '422':
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/_Error'
+                    description: Request is unprocessable due to validation errors
             parameters:
                 - name: q
                   in: query

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -1333,7 +1333,7 @@ describe('REST server tests', () => {
                         prisma,
                     });
 
-                    expect(r.status).toBe(400);
+                    expect(r.status).toBe(422);
                     expect(r.body.errors[0].code).toBe('invalid-payload');
                 });
 
@@ -1670,7 +1670,7 @@ describe('REST server tests', () => {
                         prisma,
                     });
 
-                    expect(r.status).toBe(400);
+                    expect(r.status).toBe(422);
                     expect(r.body.errors[0].code).toBe('invalid-payload');
                 });
 
@@ -1940,7 +1940,7 @@ describe('REST server tests', () => {
                         prisma,
                     });
 
-                    expect(r.status).toBe(400);
+                    expect(r.status).toBe(422);
                     expect(r.body.errors[0].code).toBe('invalid-payload');
                     expect(r.body.errors[0].reason).toBe(CrudFailureReason.DATA_VALIDATION_VIOLATION);
                     expect(r.body.errors[0].zodErrors).toBeTruthy();

--- a/packages/server/tests/api/rpc.test.ts
+++ b/packages/server/tests/api/rpc.test.ts
@@ -176,7 +176,7 @@ describe('RPC API Handler Tests', () => {
             path: '/post/findUnique',
             prisma,
         });
-        expect(r.status).toBe(400);
+        expect(r.status).toBe(422);
         expect(r.error.message).toContain('Validation error');
         expect(r.error.message).toContain('where');
 
@@ -187,9 +187,20 @@ describe('RPC API Handler Tests', () => {
             prisma,
             zodSchemas,
         });
-        expect(r.status).toBe(400);
+        expect(r.status).toBe(422);
         expect(r.error.message).toContain('Validation error');
         expect(r.error.message).toContain('data');
+
+        r = await handleRequest({
+            method: 'post',
+            path: '/user/create',
+            requestBody: { data: { email: 'hello' } },
+            prisma: enhance(),
+            zodSchemas,
+        });
+        expect(r.status).toBe(422);
+        expect(r.error.message).toContain('Validation error');
+        expect(r.error.message).toContain('email');
     });
 
     it('invalid path or args', async () => {

--- a/packages/server/tests/utils.ts
+++ b/packages/server/tests/utils.ts
@@ -5,11 +5,11 @@ model User {
     id String @id @default(cuid())
     createdAt DateTime @default (now())
     updatedAt DateTime @updatedAt
-    email String @unique
+    email String @unique @email
     posts Post[]
 
     @@allow('all', auth() == this)
-    @@allow('read', true)
+    @@allow('create,read', true)
 }
 
 model Post {


### PR DESCRIPTION
Fixes #683 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added handling for HTTP status code `422` to indicate unprocessable requests due to validation errors in both RESTful and RPC APIs.
- **Bug Fixes**
	- Improved error handling logic to accurately differentiate between `validationError` and `forbidden` errors.
- **Tests**
	- Updated HTTP status code assertions from `400` to `422` in REST and RPC test cases to reflect the new validation error handling.
	- Added a new test case for user creation to check for email validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->