### PR TITLE
refactor(policy): optimize post-create read to only use id fields to find the created entity

### DIFF
--- a/packages/runtime/src/enhancements/policy/handler.ts
+++ b/packages/runtime/src/enhancements/policy/handler.ts
@@ -126,12 +126,6 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
         );
     }
 
-    private addFluentSelect(args: any, field: string, fluentArgs: any) {
-        // overwrite include/select with the fluent field
-        delete args.include;
-        args.select = { [field]: fluentArgs ?? true };
-    }
-
     private async doFind(args: any, actionName: FindOperations, handleRejection: () => any) {
         const origArgs = args;
         const _args = this.policyUtils.clone(args);
@@ -364,7 +358,8 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
             const key = getEntityKey(model, scalarData);
             // only check if entity is created, not connected
             if (!connectedEntities.has(key) && !postCreateChecks.has(key)) {
-                postCreateChecks.set(key, { model, operation: 'create', uniqueFilter: scalarData });
+                const idFields = this.policyUtils.getIdFieldValues(model, scalarData);
+                postCreateChecks.set(key, { model, operation: 'create', uniqueFilter: idFields });
             }
         });
 

--- a/packages/runtime/src/enhancements/policy/policy-utils.ts
+++ b/packages/runtime/src/enhancements/policy/policy-utils.ts
@@ -1235,5 +1235,16 @@ export class PolicyUtil extends QueryUtils {
         return guard;
     }
 
+    /**
+     * Given an entity data, returns an object only containing id fields.
+     */
+    getIdFieldValues(model: string, data: any) {
+        if (!data) {
+            return undefined;
+        }
+        const idFields = this.getIdFields(model);
+        return Object.fromEntries(idFields.map((f) => [f.name, data[f.name]]));
+    }
+
     //#endregion
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the logic for post-create checks in policy handling to improve efficiency and accuracy.
- **New Features**
	- Enhanced the method for extracting ID fields from entity data, providing a more streamlined approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->