### PR TITLE
chore: upgrade ts-japi

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,13 +31,14 @@
         "lower-case-first": "^2.0.2",
         "superjson": "^1.11.0",
         "tiny-invariant": "^1.3.1",
-        "ts-japi": "^1.8.0",
+        "ts-japi": "^1.10.1",
         "upper-case-first": "^2.0.2",
         "url-pattern": "^1.0.3",
         "zod": "^3.22.4",
         "zod-validation-error": "^1.5.0"
     },
     "devDependencies": {
+        "@nestjs/common": "^10.0.0",
         "@nestjs/platform-express": "^10.3.5",
         "@nestjs/testing": "^10.3.5",
         "@sveltejs/kit": "1.21.0",
@@ -54,8 +55,7 @@
         "isomorphic-fetch": "^3.0.0",
         "next": "^13.4.5",
         "nuxt": "^3.7.4",
-        "supertest": "^6.3.3",
-        "@nestjs/common": "^10.0.0"
+        "supertest": "^6.3.3"
     },
     "exports": {
         "./package.json": "./package.json",

--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -1121,7 +1121,7 @@ class RequestHandler extends APIHandlerBase {
             throw new Error(`serializer not found for model ${model}`);
         }
 
-        // serialize to JSON:API strcuture
+        // serialize to JSON:API structure
         const serialized = await serializer.serialize(items, options);
 
         // convert the serialization result to plain object otherwise SuperJSON won't work

--- a/packages/server/src/api/utils.ts
+++ b/packages/server/src/api/utils.ts
@@ -39,12 +39,15 @@ export function registerCustomSerializers() {
         'Decimal'
     );
 
-    SuperJSON.registerCustom<Buffer, string>(
-        {
-            isApplicable: (v): v is Buffer => Buffer.isBuffer(v),
-            serialize: (v) => v.toString('base64'),
-            deserialize: (v) => Buffer.from(v, 'base64'),
-        },
-        'Bytes'
-    );
+    // `Buffer` is not available in edge runtime
+    if (globalThis.Buffer) {
+        SuperJSON.registerCustom<Buffer, string>(
+            {
+                isApplicable: (v): v is Buffer => Buffer.isBuffer(v),
+                serialize: (v) => v.toString('base64'),
+                deserialize: (v) => Buffer.from(v, 'base64'),
+            },
+            'Bytes'
+        );
+    }
 }

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -1014,7 +1014,7 @@ describe('REST server tests', () => {
                         query: { include: 'posts.comments' },
                         prisma,
                     });
-                    expect(r.body.included).toHaveLength(3);
+                    expect(r.body.included).toHaveLength(4);
                     expect(r.body.included[2]).toMatchObject({
                         type: 'comment',
                         attributes: { content: 'Comment1' },
@@ -1027,7 +1027,7 @@ describe('REST server tests', () => {
                         query: { include: 'posts.comments,profile' },
                         prisma,
                     });
-                    expect(r.body.included).toHaveLength(4);
+                    expect(r.body.included).toHaveLength(5);
                     const profile = r.body.included.find((item: any) => item.type === 'profile');
                     expect(profile).toMatchObject({
                         type: 'profile',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -674,8 +674,8 @@ importers:
         specifier: ^1.3.1
         version: 1.3.1
       ts-japi:
-        specifier: ^1.8.0
-        version: 1.8.0
+        specifier: ^1.10.1
+        version: 1.10.1
       upper-case-first:
         specifier: ^2.0.2
         version: 2.0.2
@@ -14608,8 +14608,8 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-japi@1.8.0:
-    resolution: {integrity: sha512-77cNpz1CMJsImcikE7gnihMKOME4c/prCaruBmr7yMRHGnmEt1llFyJbuokXCaEmm0hERPv2VlzTyZ+pb43leg==}
+  /ts-japi@1.10.1:
+    resolution: {integrity: sha512-03frHSZma1Bj5lxunZqqZTBmNjV1sdzLb60gGJ7O3viPS7g/rjF52tozZPy2iRnHazjj5I4r53mG4hmO8XeAyw==}
     engines: {node: '>=10'}
     dev: false
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved compatibility with edge runtime by conditionally registering `Buffer` type serializers.
	- Corrected a typo in a comment from "strcuture" to "structure."
	- Adjusted expected lengths of `r.body.included` in test cases to reflect data structure changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->