### PR TITLE
fix(openapi): `CreateManyArgs` does not take array as input

### DIFF
--- a/packages/plugins/openapi/src/rpc-generator.ts
+++ b/packages/plugins/openapi/src/rpc-generator.ts
@@ -176,7 +176,15 @@ export class RPCOpenAPIGenerator extends OpenAPIGeneratorBase {
                         type: 'object',
                         required: ['data'],
                         properties: {
-                            data: this.ref(`${modelName}CreateManyInput`),
+                            data: this.oneOf(
+                                this.ref(`${modelName}CreateManyInput`),
+                                this.array(this.ref(`${modelName}CreateManyInput`))
+                            ),
+                            skipDuplicates: {
+                                type: 'boolean',
+                                description:
+                                    'Do not insert records with unique fields or ID fields that already exist.',
+                            },
                             meta: this.ref('_Meta'),
                         },
                     },

--- a/packages/plugins/openapi/tests/baseline/rpc-3.0.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rpc-3.0.0.baseline.yaml
@@ -3194,7 +3194,15 @@ components:
                 - data
             properties:
                 data:
-                    $ref: '#/components/schemas/UserCreateManyInput'
+                    oneOf:
+                        - $ref: '#/components/schemas/UserCreateManyInput'
+                        - type: array
+                          items:
+                              $ref: '#/components/schemas/UserCreateManyInput'
+                skipDuplicates:
+                    type: boolean
+                    description: Do not insert records with unique fields or ID fields that already
+                        exist.
                 meta:
                     $ref: '#/components/schemas/_Meta'
         UserFindUniqueArgs:
@@ -3374,7 +3382,15 @@ components:
                 - data
             properties:
                 data:
-                    $ref: '#/components/schemas/ProfileCreateManyInput'
+                    oneOf:
+                        - $ref: '#/components/schemas/ProfileCreateManyInput'
+                        - type: array
+                          items:
+                              $ref: '#/components/schemas/ProfileCreateManyInput'
+                skipDuplicates:
+                    type: boolean
+                    description: Do not insert records with unique fields or ID fields that already
+                        exist.
                 meta:
                     $ref: '#/components/schemas/_Meta'
         ProfileFindUniqueArgs:
@@ -3554,7 +3570,15 @@ components:
                 - data
             properties:
                 data:
-                    $ref: '#/components/schemas/Post_ItemCreateManyInput'
+                    oneOf:
+                        - $ref: '#/components/schemas/Post_ItemCreateManyInput'
+                        - type: array
+                          items:
+                              $ref: '#/components/schemas/Post_ItemCreateManyInput'
+                skipDuplicates:
+                    type: boolean
+                    description: Do not insert records with unique fields or ID fields that already
+                        exist.
                 meta:
                     $ref: '#/components/schemas/_Meta'
         Post_ItemFindUniqueArgs:

--- a/packages/plugins/openapi/tests/baseline/rpc-3.1.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rpc-3.1.0.baseline.yaml
@@ -3248,7 +3248,15 @@ components:
                 - data
             properties:
                 data:
-                    $ref: '#/components/schemas/UserCreateManyInput'
+                    oneOf:
+                        - $ref: '#/components/schemas/UserCreateManyInput'
+                        - type: array
+                          items:
+                              $ref: '#/components/schemas/UserCreateManyInput'
+                skipDuplicates:
+                    type: boolean
+                    description: Do not insert records with unique fields or ID fields that already
+                        exist.
                 meta:
                     $ref: '#/components/schemas/_Meta'
         UserFindUniqueArgs:
@@ -3428,7 +3436,15 @@ components:
                 - data
             properties:
                 data:
-                    $ref: '#/components/schemas/ProfileCreateManyInput'
+                    oneOf:
+                        - $ref: '#/components/schemas/ProfileCreateManyInput'
+                        - type: array
+                          items:
+                              $ref: '#/components/schemas/ProfileCreateManyInput'
+                skipDuplicates:
+                    type: boolean
+                    description: Do not insert records with unique fields or ID fields that already
+                        exist.
                 meta:
                     $ref: '#/components/schemas/_Meta'
         ProfileFindUniqueArgs:
@@ -3608,7 +3624,15 @@ components:
                 - data
             properties:
                 data:
-                    $ref: '#/components/schemas/Post_ItemCreateManyInput'
+                    oneOf:
+                        - $ref: '#/components/schemas/Post_ItemCreateManyInput'
+                        - type: array
+                          items:
+                              $ref: '#/components/schemas/Post_ItemCreateManyInput'
+                skipDuplicates:
+                    type: boolean
+                    description: Do not insert records with unique fields or ID fields that already
+                        exist.
                 meta:
                     $ref: '#/components/schemas/_Meta'
         Post_ItemFindUniqueArgs:

--- a/packages/plugins/openapi/tests/baseline/rpc-type-coverage-3.0.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rpc-type-coverage-3.0.0.baseline.yaml
@@ -2017,7 +2017,15 @@ components:
                 - data
             properties:
                 data:
-                    $ref: '#/components/schemas/FooCreateManyInput'
+                    oneOf:
+                        - $ref: '#/components/schemas/FooCreateManyInput'
+                        - type: array
+                          items:
+                              $ref: '#/components/schemas/FooCreateManyInput'
+                skipDuplicates:
+                    type: boolean
+                    description: Do not insert records with unique fields or ID fields that already
+                        exist.
                 meta:
                     $ref: '#/components/schemas/_Meta'
         FooFindUniqueArgs:

--- a/packages/plugins/openapi/tests/baseline/rpc-type-coverage-3.1.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rpc-type-coverage-3.1.0.baseline.yaml
@@ -2049,7 +2049,15 @@ components:
                 - data
             properties:
                 data:
-                    $ref: '#/components/schemas/FooCreateManyInput'
+                    oneOf:
+                        - $ref: '#/components/schemas/FooCreateManyInput'
+                        - type: array
+                          items:
+                              $ref: '#/components/schemas/FooCreateManyInput'
+                skipDuplicates:
+                    type: boolean
+                    description: Do not insert records with unique fields or ID fields that already
+                        exist.
                 meta:
                     $ref: '#/components/schemas/_Meta'
         FooFindUniqueArgs:

--- a/packages/schema/src/plugins/zod/transformer.ts
+++ b/packages/schema/src/plugins/zod/transformer.ts
@@ -485,7 +485,7 @@ export const ${this.name}ObjectSchema: SchemaType = ${schema} as SchemaType;`;
                 imports.push(
                     `import { ${modelName}CreateManyInputObjectSchema } from '../objects/${modelName}CreateManyInput.schema'`
                 );
-                codeBody += `createMany: z.object({ data: z.union([${modelName}CreateManyInputObjectSchema, z.array(${modelName}CreateManyInputObjectSchema)]) }),`;
+                codeBody += `createMany: z.object({ data: z.union([${modelName}CreateManyInputObjectSchema, z.array(${modelName}CreateManyInputObjectSchema)]), skipDuplicates: z.boolean().optional() }),`;
                 operations.push(['createMany', origModelName]);
             }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced API flexibility by allowing the `data` property to include either a single object or an array of objects.
	- Introduced a new `skipDuplicates` property to enable skipping of records with unique constraints or existing IDs.
	- Updated schema logic for creating multiple instances of a model with the addition of an optional `skipDuplicates` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->