### PR TITLE
fix: issue with `auth()` in `@default` accidentally overrides "connect"

### DIFF
--- a/packages/runtime/src/enhancements/default-auth.ts
+++ b/packages/runtime/src/enhancements/default-auth.ts
@@ -92,6 +92,11 @@ class DefaultAuthHandler extends DefaultPrismaProxyHandler {
     }
 
     private setAuthDefaultValue(fieldInfo: FieldInfo, model: string, data: any, authDefaultValue: unknown) {
+        if (fieldInfo.isForeignKey && fieldInfo.relationField && fieldInfo.relationField in data) {
+            // if the field is a fk, and the relation field is already set, we should not override it
+            return;
+        }
+
         if (fieldInfo.isForeignKey && !isUnsafeMutate(model, data, this.options.modelMeta)) {
             // if the field is a fk, and the create payload is not unsafe, we need to translate
             // the fk field setting to a `connect` of the corresponding relation field

--- a/tests/integration/tests/enhancements/with-policy/auth.test.ts
+++ b/tests/integration/tests/enhancements/with-policy/auth.test.ts
@@ -436,8 +436,7 @@ describe('auth() runtime test', () => {
 
             @@allow('all', true)
         }
-        `,
-            { logPrismaQuery: true }
+        `
         );
 
         await prisma.user.create({ data: { id: 'userId-1', email: 'user1@abc.com' } });


### PR DESCRIPTION
`@default` with `auth()` shouldn't be effective if it's on a foreign key and the user provides an explicit value for the relation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced authentication handling to preserve existing foreign key relationships in certain scenarios.
- **Tests**
	- Updated integration tests to accommodate new email fields in the User model and revised expectations for post creations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->