### PR TITLE
fix(zmodel): clean up logic for detecting what attributes should be inherited from base models

### DIFF
--- a/packages/schema/tests/schema/abstract.test.ts
+++ b/packages/schema/tests/schema/abstract.test.ts
@@ -61,4 +61,24 @@ describe('Abstract Schema Tests', () => {
           
         `);
     });
+
+    it('multiple id fields from base', async () => {
+        await loadModel(`
+        abstract model Base {
+            id1 String
+            id2 String
+            value String
+            
+            @@id([id1, id2])
+        }
+
+        model Item1 extends Base {
+            x String
+        }
+
+        model Item2 extends Base {
+            y String
+        }        
+        `);
+    });
 });

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -176,39 +176,51 @@ export function isDataModelFieldReference(node: AstNode): node is ReferenceExpr 
 }
 
 /**
- * Gets `@@id` fields declared at the data model level
+ * Gets `@@id` fields declared at the data model level (including search in base models)
  */
 export function getModelIdFields(model: DataModel) {
-    const idAttr = model.attributes.find((attr) => attr.decl.$refText === '@@id');
-    if (!idAttr) {
-        return [];
-    }
-    const fieldsArg = idAttr.args.find((a) => a.$resolvedParam?.name === 'fields');
-    if (!fieldsArg || !isArrayExpr(fieldsArg.value)) {
-        return [];
+    const modelsToCheck = model.$baseMerged ? [model] : [model, ...getRecursiveBases(model)];
+
+    for (const modelToCheck of modelsToCheck) {
+        const idAttr = modelToCheck.attributes.find((attr) => attr.decl.$refText === '@@id');
+        if (!idAttr) {
+            continue;
+        }
+        const fieldsArg = idAttr.args.find((a) => a.$resolvedParam?.name === 'fields');
+        if (!fieldsArg || !isArrayExpr(fieldsArg.value)) {
+            continue;
+        }
+
+        return fieldsArg.value.items
+            .filter((item): item is ReferenceExpr => isReferenceExpr(item))
+            .map((item) => resolved(item.target) as DataModelField);
     }
 
-    return fieldsArg.value.items
-        .filter((item): item is ReferenceExpr => isReferenceExpr(item))
-        .map((item) => resolved(item.target) as DataModelField);
+    return [];
 }
 
 /**
- * Gets `@@unique` fields declared at the data model level
+ * Gets `@@unique` fields declared at the data model level (including search in base models)
  */
 export function getModelUniqueFields(model: DataModel) {
-    const uniqueAttr = model.attributes.find((attr) => attr.decl.$refText === '@@unique');
-    if (!uniqueAttr) {
-        return [];
-    }
-    const fieldsArg = uniqueAttr.args.find((a) => a.$resolvedParam?.name === 'fields');
-    if (!fieldsArg || !isArrayExpr(fieldsArg.value)) {
-        return [];
+    const modelsToCheck = model.$baseMerged ? [model] : [model, ...getRecursiveBases(model)];
+
+    for (const modelToCheck of modelsToCheck) {
+        const uniqueAttr = modelToCheck.attributes.find((attr) => attr.decl.$refText === '@@unique');
+        if (!uniqueAttr) {
+            continue;
+        }
+        const fieldsArg = uniqueAttr.args.find((a) => a.$resolvedParam?.name === 'fields');
+        if (!fieldsArg || !isArrayExpr(fieldsArg.value)) {
+            continue;
+        }
+
+        return fieldsArg.value.items
+            .filter((item): item is ReferenceExpr => isReferenceExpr(item))
+            .map((item) => resolved(item.target) as DataModelField);
     }
 
-    return fieldsArg.value.items
-        .filter((item): item is ReferenceExpr => isReferenceExpr(item))
-        .map((item) => resolved(item.target) as DataModelField);
+    return [];
 }
 
 /**

--- a/tests/integration/tests/enhancements/with-delegate/issue-1243.test.ts
+++ b/tests/integration/tests/enhancements/with-delegate/issue-1243.test.ts
@@ -1,0 +1,55 @@
+import { loadSchema } from '@zenstackhq/testtools';
+
+describe('Regression for issue 1243', () => {
+    it('uninheritable fields', async () => {
+        const schema = `
+        model Base {
+            id String @id @default(cuid())
+            type String
+            foo String
+            
+            @@delegate(type)
+            @@index([foo])
+            @@map('base')
+            @@unique([foo])
+        }
+
+        model Item1 extends Base {
+            x String
+        }
+
+        model Item2 extends Base {
+            y String
+        }
+        `;
+
+        await loadSchema(schema, {
+            enhancements: ['delegate'],
+        });
+    });
+
+    it('multiple id fields', async () => {
+        const schema = `
+        model Base {
+            id1 String
+            id2 String
+            type String
+            
+            @@delegate(type)
+            @@id([id1, id2])
+        }
+
+        model Item1 extends Base {
+            x String
+        }
+
+        model Item2 extends Base {
+            y String
+        }
+        `;
+
+        await loadSchema(schema, {
+            enhancements: ['delegate'],
+        });
+    });
+});


### PR DESCRIPTION
Fixes #1243 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced attribute filtering in base model merging to exclude certain inherited attributes and handle delegate scenarios more effectively.
	- Expanded search functionality in SDK utilities to include base models when identifying unique and ID fields.

- **Bug Fixes**
	- Refined merging logic to accurately exclude specific attribute types during inheritance.

- **Tests**
	- Added new test cases for handling multiple ID fields and uninheritable attributes in schemas.
	- Introduced regression tests related to specific inheritance issues in schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->