### PR TITLE
chore: format generated PLS automatically by default

### DIFF
--- a/packages/schema/src/plugins/prisma/schema-generator.ts
+++ b/packages/schema/src/plugins/prisma/schema-generator.ts
@@ -141,7 +141,7 @@ export class PrismaSchemaGenerator {
         }
         await writeFile(outFile, this.PRELUDE + prisma.toString());
 
-        if (options.format === true) {
+        if (options.format !== false) {
             try {
                 // run 'prisma format'
                 await execPackage(`prisma format --schema ${outFile}`, { stdio: 'ignore' });

--- a/packages/schema/tests/generator/prisma-generator.test.ts
+++ b/packages/schema/tests/generator/prisma-generator.test.ts
@@ -36,12 +36,16 @@ describe('Prisma generator test', () => {
                 directUrl = env("DATABASE_URL")
                 shadowDatabaseUrl = env("DATABASE_URL")
                 extensions = [pg_trgm, postgis(version: "3.3.2"), uuid_ossp(map: "uuid-ossp", schema: "extensions")]
-                schemas    = ["auth", "public"]
+                schemas = ["auth", "public"]
             }
 
             generator client {
                 provider        = "prisma-client-js"
                 previewFeatures = ["multiSchema", "postgresqlExtensions"]
+            }
+
+            plugin prisma {
+                provider = '@core/prisma'
             }
 
             model User {
@@ -56,6 +60,7 @@ describe('Prisma generator test', () => {
             provider: '@core/prisma',
             schemaPath: 'schema.zmodel',
             output: 'schema.prisma',
+            format: false,
         });
 
         const content = fs.readFileSync('schema.prisma', 'utf-8');
@@ -97,6 +102,7 @@ describe('Prisma generator test', () => {
             provider: '@core/prisma',
             schemaPath: 'schema.zmodel',
             output: name,
+            format: false,
         });
 
         const content = fs.readFileSync(name, 'utf-8');
@@ -328,6 +334,7 @@ describe('Prisma generator test', () => {
             schemaPath: 'schema.zmodel',
             output: name,
             generateClient: false,
+            format: false,
         });
 
         const content = fs.readFileSync(name, 'utf-8');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the condition for executing formatting commands based on user settings.
- **New Features**
	- Added a new `plugin prisma` with provider `@core/prisma`.
	- Included `format: false` property in multiple configurations for schema generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->