### PR TITLE
fix(sdk): exclude prisma module from barrel file to avoid eager loading of prisma packages

### DIFF
--- a/packages/plugins/openapi/src/generator-base.ts
+++ b/packages/plugins/openapi/src/generator-base.ts
@@ -1,12 +1,6 @@
-import {
-    PluginError,
-    getDataModels,
-    hasAttribute,
-    type DMMF,
-    type PluginOptions,
-    type PluginResult,
-} from '@zenstackhq/sdk';
+import { PluginError, getDataModels, hasAttribute, type PluginOptions, type PluginResult } from '@zenstackhq/sdk';
 import { Model } from '@zenstackhq/sdk/ast';
+import type { DMMF } from '@zenstackhq/sdk/prisma';
 import type { OpenAPIV3_1 as OAPI } from 'openapi-types';
 import semver from 'semver';
 import { fromZodError } from 'zod-validation-error';

--- a/packages/plugins/openapi/src/rest-generator.ts
+++ b/packages/plugins/openapi/src/rest-generator.ts
@@ -9,9 +9,9 @@ import {
     isRelationshipField,
     requireOption,
     resolvePath,
-    type DMMF,
 } from '@zenstackhq/sdk';
 import { DataModel, DataModelField, DataModelFieldType, Enum, isDataModel, isEnum } from '@zenstackhq/sdk/ast';
+import type { DMMF } from '@zenstackhq/sdk/prisma';
 import fs from 'fs';
 import { lowerCaseFirst } from 'lower-case-first';
 import type { OpenAPIV3_1 as OAPI } from 'openapi-types';

--- a/packages/plugins/openapi/src/rpc-generator.ts
+++ b/packages/plugins/openapi/src/rpc-generator.ts
@@ -1,6 +1,6 @@
 // Inspired by: https://github.com/omar-dulaimi/prisma-trpc-generator
 
-import { analyzePolicies, PluginError, requireOption, resolvePath, type DMMF } from '@zenstackhq/sdk';
+import { analyzePolicies, PluginError, requireOption, resolvePath } from '@zenstackhq/sdk';
 import { DataModel, isDataModel } from '@zenstackhq/sdk/ast';
 import {
     addMissingInputObjectTypesForAggregate,
@@ -10,6 +10,7 @@ import {
     AggregateOperationSupport,
     resolveAggregateOperationSupport,
 } from '@zenstackhq/sdk/dmmf-helpers';
+import type { DMMF } from '@zenstackhq/sdk/prisma';
 import * as fs from 'fs';
 import { lowerCaseFirst } from 'lower-case-first';
 import type { OpenAPIV3_1 as OAPI } from 'openapi-types';

--- a/packages/plugins/swr/src/generator.ts
+++ b/packages/plugins/swr/src/generator.ts
@@ -4,17 +4,14 @@ import {
     ensureEmptyDir,
     generateModelMeta,
     getDataModels,
-    getPrismaClientImportSpec,
-    getPrismaVersion,
     requireOption,
     resolvePath,
     saveProject,
-    type DMMF,
 } from '@zenstackhq/sdk';
 import { DataModel, Model } from '@zenstackhq/sdk/ast';
+import { getPrismaClientImportSpec, type DMMF } from '@zenstackhq/sdk/prisma';
 import { paramCase } from 'change-case';
 import path from 'path';
-import semver from 'semver';
 import type { OptionalKind, ParameterDeclarationStructure, Project, SourceFile } from 'ts-morph';
 import { upperCaseFirst } from 'upper-case-first';
 import { name } from '.';
@@ -74,7 +71,6 @@ function generateModelHooks(
     ]);
 
     const modelNameCap = upperCaseFirst(model.name);
-    const prismaVersion = getPrismaVersion();
 
     const mutationFuncs: string[] = [];
 
@@ -168,11 +164,7 @@ function generateModelHooks(
 
     // groupBy
     if (mapping.groupBy) {
-        let useName = modelNameCap;
-        if (prismaVersion && semver.gte(prismaVersion, '5.0.0')) {
-            // prisma 4 and 5 different typing for "groupBy" and we have to deal with it separately
-            useName = model.name;
-        }
+        const useName = model.name;
         const typeParameters = [
             `T extends Prisma.${useName}GroupByArgs`,
             `HasSelectOrTake extends Prisma.Or<Prisma.Extends<'skip', Prisma.Keys<T>>, Prisma.Extends<'take', Prisma.Keys<T>>>`,

--- a/packages/plugins/tanstack-query/src/generator.ts
+++ b/packages/plugins/tanstack-query/src/generator.ts
@@ -5,18 +5,15 @@ import {
     ensureEmptyDir,
     generateModelMeta,
     getDataModels,
-    getPrismaClientImportSpec,
-    getPrismaVersion,
     requireOption,
     resolvePath,
     saveProject,
-    type DMMF,
 } from '@zenstackhq/sdk';
 import { DataModel, Model } from '@zenstackhq/sdk/ast';
+import { getPrismaClientImportSpec, type DMMF } from '@zenstackhq/sdk/prisma';
 import { paramCase } from 'change-case';
 import { lowerCaseFirst } from 'lower-case-first';
 import path from 'path';
-import semver from 'semver';
 import { Project, SourceFile, VariableDeclarationKind } from 'ts-morph';
 import { match } from 'ts-pattern';
 import { upperCaseFirst } from 'upper-case-first';
@@ -274,7 +271,6 @@ function generateModelHooks(
     options: PluginOptions
 ) {
     const modelNameCap = upperCaseFirst(model.name);
-    const prismaVersion = getPrismaVersion();
     const fileName = paramCase(model.name);
     const sf = project.createSourceFile(path.join(outDir, `${fileName}.ts`), undefined, { overwrite: true });
 
@@ -401,11 +397,7 @@ function generateModelHooks(
 
     // groupBy
     if (mapping.groupBy) {
-        let useName = modelNameCap;
-        // prisma 4 and 5 different typing for "groupBy" and we have to deal with it separately
-        if (prismaVersion && semver.gte(prismaVersion, '5.0.0')) {
-            useName = model.name;
-        }
+        const useName = model.name;
 
         const returnType = `{} extends InputErrors ? 
         Array<PickEnumerable<Prisma.${modelNameCap}GroupByOutputType, TArgs['by']> &

--- a/packages/plugins/trpc/src/generator.ts
+++ b/packages/plugins/trpc/src/generator.ts
@@ -3,15 +3,14 @@ import {
     PluginError,
     RUNTIME_PACKAGE,
     ensureEmptyDir,
-    getPrismaClientImportSpec,
     parseOptionAsStrings,
     requireOption,
     resolvePath,
     saveProject,
-    type DMMF,
     type PluginOptions,
 } from '@zenstackhq/sdk';
 import { Model } from '@zenstackhq/sdk/ast';
+import { getPrismaClientImportSpec, type DMMF } from '@zenstackhq/sdk/prisma';
 import fs from 'fs';
 import { lowerCaseFirst } from 'lower-case-first';
 import path from 'path';

--- a/packages/plugins/trpc/src/helpers.ts
+++ b/packages/plugins/trpc/src/helpers.ts
@@ -1,4 +1,5 @@
-import { PluginError, getPrismaClientImportSpec, type DMMF, type PluginOptions } from '@zenstackhq/sdk';
+import { PluginError, type PluginOptions } from '@zenstackhq/sdk';
+import { getPrismaClientImportSpec, type DMMF } from '@zenstackhq/sdk/prisma';
 import { lowerCaseFirst } from 'lower-case-first';
 import { CodeBlockWriter, SourceFile } from 'ts-morph';
 import { upperCaseFirst } from 'upper-case-first';

--- a/packages/schema/src/cli/plugin-runner.ts
+++ b/packages/schema/src/cli/plugin-runner.ts
@@ -11,12 +11,12 @@ import {
     PluginError,
     resolvePath,
     saveProject,
-    type DMMF,
     type OptionValue,
     type PluginDeclaredOptions,
     type PluginFunction,
     type PluginResult,
 } from '@zenstackhq/sdk';
+import { type DMMF } from '@zenstackhq/sdk/prisma';
 import colors from 'colors';
 import ora from 'ora';
 import path from 'path';

--- a/packages/schema/src/plugins/enhancer/enhance/index.ts
+++ b/packages/schema/src/plugins/enhancer/enhance/index.ts
@@ -4,11 +4,8 @@ import {
     getAttribute,
     getAttributeArg,
     getAuthModel,
-    getDMMF,
     getDataModels,
-    getPrismaClientImportSpec,
     isDelegateModel,
-    type DMMF,
     type PluginOptions,
 } from '@zenstackhq/sdk';
 import {
@@ -20,6 +17,7 @@ import {
     isReferenceExpr,
     type Model,
 } from '@zenstackhq/sdk/ast';
+import { getDMMF, getPrismaClientImportSpec, type DMMF } from '@zenstackhq/sdk/prisma';
 import fs from 'fs';
 import path from 'path';
 import {

--- a/packages/schema/src/plugins/enhancer/policy/policy-guard-generator.ts
+++ b/packages/schema/src/plugins/enhancer/policy/policy-guard-generator.ts
@@ -37,7 +37,6 @@ import {
     getDataModels,
     getIdFields,
     getLiteral,
-    getPrismaClientImportSpec,
     hasAttribute,
     hasValidationAttributes,
     isAuthInvocation,
@@ -47,6 +46,7 @@ import {
     isFutureExpr,
     resolved,
 } from '@zenstackhq/sdk';
+import { getPrismaClientImportSpec } from '@zenstackhq/sdk/prisma';
 import { streamAllContents, streamAst, streamContents } from 'langium';
 import { lowerCaseFirst } from 'lower-case-first';
 import path from 'path';

--- a/packages/schema/src/plugins/prisma/index.ts
+++ b/packages/schema/src/plugins/prisma/index.ts
@@ -1,5 +1,6 @@
-import { PluginError, PluginFunction, getDMMF, getLiteral, resolvePath } from '@zenstackhq/sdk';
+import { PluginError, PluginFunction, getLiteral, resolvePath } from '@zenstackhq/sdk';
 import { GeneratorDecl, isGeneratorDecl } from '@zenstackhq/sdk/ast';
+import { getDMMF } from '@zenstackhq/sdk/prisma';
 import fs from 'fs';
 import path from 'path';
 import stripColor from 'strip-color';

--- a/packages/schema/src/plugins/prisma/schema-generator.ts
+++ b/packages/schema/src/plugins/prisma/schema-generator.ts
@@ -28,6 +28,7 @@ import {
     NumberLiteral,
     StringLiteral,
 } from '@zenstackhq/language/ast';
+import { getPrismaVersion } from '@zenstackhq/sdk/prisma';
 import { match, P } from 'ts-pattern';
 import { getIdFields } from '../../utils/ast-utils';
 
@@ -37,7 +38,6 @@ import {
     getAttributeArg,
     getAttributeArgLiteral,
     getLiteral,
-    getPrismaVersion,
     isDelegateModel,
     isIdField,
     PluginError,
@@ -222,20 +222,6 @@ export class PrismaSchemaGenerator {
 
                 if (!Array.isArray(previewFeatures)) {
                     throw new PluginError(name, 'option "previewFeatures" must be an array');
-                }
-
-                if (semver.lt(prismaVersion, '5.0.0')) {
-                    // extendedWhereUnique feature is opt-in pre V5
-                    if (!previewFeatures.includes('extendedWhereUnique')) {
-                        previewFeatures.push('extendedWhereUnique');
-                    }
-                }
-
-                if (semver.lt(prismaVersion, '5.0.0')) {
-                    // fieldReference feature is opt-in pre V5
-                    if (!previewFeatures.includes('fieldReference')) {
-                        previewFeatures.push('fieldReference');
-                    }
                 }
 
                 if (previewFeatures.length > 0) {

--- a/packages/schema/src/plugins/zod/generator.ts
+++ b/packages/schema/src/plugins/zod/generator.ts
@@ -3,17 +3,16 @@ import {
     PluginOptions,
     ensureEmptyDir,
     getDataModels,
-    getPrismaClientImportSpec,
     hasAttribute,
     isEnumFieldReference,
     isForeignKeyField,
     isFromStdlib,
     parseOptionAsStrings,
     resolvePath,
-    type DMMF,
 } from '@zenstackhq/sdk';
 import { DataModel, EnumField, Model, isDataModel, isEnum } from '@zenstackhq/sdk/ast';
 import { addMissingInputObjectTypes, resolveAggregateOperationSupport } from '@zenstackhq/sdk/dmmf-helpers';
+import { getPrismaClientImportSpec, type DMMF } from '@zenstackhq/sdk/prisma';
 import { streamAllContents } from 'langium';
 import path from 'path';
 import type { SourceFile } from 'ts-morph';

--- a/packages/schema/src/plugins/zod/transformer.ts
+++ b/packages/schema/src/plugins/zod/transformer.ts
@@ -1,14 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import {
-    getPrismaClientImportSpec,
-    getPrismaVersion,
-    type PluginOptions,
-    type DMMF as PrismaDMMF,
-} from '@zenstackhq/sdk';
+import { type PluginOptions } from '@zenstackhq/sdk';
 import { checkModelHasModelRelation, findModelByName, isAggregateInputType } from '@zenstackhq/sdk/dmmf-helpers';
+import { getPrismaClientImportSpec, type DMMF as PrismaDMMF } from '@zenstackhq/sdk/prisma';
 import { indentString } from '@zenstackhq/sdk/utils';
 import path from 'path';
-import * as semver from 'semver';
 import type { Project, SourceFile } from 'ts-morph';
 import { upperCaseFirst } from 'upper-case-first';
 import { AggregateOperationSupport, TransformerParams } from './types';
@@ -568,10 +563,6 @@ export const ${this.name}ObjectSchema: SchemaType = ${schema} as SchemaType;`;
 
             const aggregateOperations = [];
 
-            // DMMF messed up the model name casing used in the aggregate operations,
-            // AND the casing behavior varies from version to version -_-||
-            const prismaVersion = getPrismaVersion();
-
             if (this.aggregateOperationSupport[modelName]?.count) {
                 imports.push(
                     `import { ${modelName}CountAggregateInputObjectSchema } from '../objects/${modelName}CountAggregateInput.schema'`
@@ -629,12 +620,7 @@ export const ${this.name}ObjectSchema: SchemaType = ${schema} as SchemaType;`;
                     ', '
                 )} }),`;
 
-                // prisma 4 and 5 different typing for "groupBy" and we have to deal with it separately
-                if (prismaVersion && semver.gte(prismaVersion, '5.0.0')) {
-                    operations.push(['groupBy', origModelName]);
-                } else {
-                    operations.push(['groupBy', modelName]);
-                }
+                operations.push(['groupBy', origModelName]);
             }
 
             // count

--- a/packages/schema/src/plugins/zod/transformer.ts
+++ b/packages/schema/src/plugins/zod/transformer.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { type PluginOptions } from '@zenstackhq/sdk';
+import { indentString, type PluginOptions } from '@zenstackhq/sdk';
 import { checkModelHasModelRelation, findModelByName, isAggregateInputType } from '@zenstackhq/sdk/dmmf-helpers';
 import { getPrismaClientImportSpec, type DMMF as PrismaDMMF } from '@zenstackhq/sdk/prisma';
-import { indentString } from '@zenstackhq/sdk/utils';
 import path from 'path';
 import type { Project, SourceFile } from 'ts-morph';
 import { upperCaseFirst } from 'upper-case-first';

--- a/packages/schema/src/plugins/zod/types.ts
+++ b/packages/schema/src/plugins/zod/types.ts
@@ -1,4 +1,4 @@
-import type { DMMF as PrismaDMMF } from '@zenstackhq/sdk';
+import type { DMMF as PrismaDMMF } from '@zenstackhq/sdk/prisma';
 import { Project } from 'ts-morph';
 
 export type TransformerParams = {

--- a/packages/schema/src/telemetry.ts
+++ b/packages/schema/src/telemetry.ts
@@ -1,5 +1,5 @@
 import { createId } from '@paralleldrive/cuid2';
-import { getPrismaVersion } from '@zenstackhq/sdk';
+import { getPrismaVersion } from '@zenstackhq/sdk/prisma';
 import exitHook from 'async-exit-hook';
 import { CommanderError } from 'commander';
 import { init, Mixpanel } from 'mixpanel';

--- a/packages/schema/tests/generator/prisma-builder.test.ts
+++ b/packages/schema/tests/generator/prisma-builder.test.ts
@@ -1,4 +1,4 @@
-import { getDMMF } from '@zenstackhq/sdk';
+import { getDMMF } from '@zenstackhq/sdk/prisma';
 import {
     AttributeArg,
     AttributeArgValue,

--- a/packages/schema/tests/generator/prisma-generator.test.ts
+++ b/packages/schema/tests/generator/prisma-generator.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="@types/jest" />
 
-import { getDMMF } from '@zenstackhq/sdk';
+import { getDMMF } from '@zenstackhq/sdk/prisma';
 import fs from 'fs';
 import path from 'path';
 import tmp from 'tmp';

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -31,5 +31,19 @@
     },
     "devDependencies": {
         "@types/semver": "^7.3.13"
+    },
+    "exports": {
+        ".": {
+            "types": "./index.d.ts",
+            "default": "./index.js"
+        },
+        "./ast": {
+            "types": "./ast.d.ts",
+            "default": "./ast.js"
+        },
+        "./prisma": {
+            "types": "./prisma.d.ts",
+            "default": "./prisma.js"
+        }
     }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -44,6 +44,10 @@
         "./prisma": {
             "types": "./prisma.d.ts",
             "default": "./prisma.js"
+        },
+        "./dmmf-helpers": {
+            "types": "./dmmf-helpers/index.d.ts",
+            "default": "./dmmf-helpers/index.js"
         }
     }
 }

--- a/packages/sdk/src/dmmf-helpers/aggregate-helpers.ts
+++ b/packages/sdk/src/dmmf-helpers/aggregate-helpers.ts
@@ -1,5 +1,5 @@
 import { upperCaseFirst } from 'upper-case-first';
-import type { DMMF } from '../types';
+import type { DMMF } from '../prisma';
 import { AggregateOperationSupport } from './types';
 
 const isAggregateOutputType = (name: string) => /(?:Count|Avg|Sum|Min|Max)AggregateOutputType$/.test(name);

--- a/packages/sdk/src/dmmf-helpers/include-helpers.ts
+++ b/packages/sdk/src/dmmf-helpers/include-helpers.ts
@@ -1,4 +1,4 @@
-import type { DMMF } from '../types';
+import type { DMMF } from '../prisma';
 import { checkIsModelRelationField, checkModelHasManyModelRelation, checkModelHasModelRelation } from './model-helpers';
 
 export function addMissingInputObjectTypesForInclude(inputObjectTypes: DMMF.InputType[], models: DMMF.Model[]) {

--- a/packages/sdk/src/dmmf-helpers/missing-types-helper.ts
+++ b/packages/sdk/src/dmmf-helpers/missing-types-helper.ts
@@ -1,4 +1,4 @@
-import type { DMMF } from '../types';
+import type { DMMF } from '../prisma';
 import { addMissingInputObjectTypesForAggregate } from './aggregate-helpers';
 import { addMissingInputObjectTypesForInclude } from './include-helpers';
 import { addMissingInputObjectTypesForModelArgs } from './modelArgs-helpers';

--- a/packages/sdk/src/dmmf-helpers/model-helpers.ts
+++ b/packages/sdk/src/dmmf-helpers/model-helpers.ts
@@ -1,4 +1,4 @@
-import type { DMMF } from '../types';
+import type { DMMF } from '../prisma';
 
 export function checkModelHasModelRelation(model: DMMF.Model) {
     const { fields: modelFields } = model;

--- a/packages/sdk/src/dmmf-helpers/modelArgs-helpers.ts
+++ b/packages/sdk/src/dmmf-helpers/modelArgs-helpers.ts
@@ -1,4 +1,4 @@
-import type { DMMF } from '../types';
+import type { DMMF } from '../prisma';
 import { checkModelHasModelRelation } from './model-helpers';
 
 export function addMissingInputObjectTypesForModelArgs(inputObjectTypes: DMMF.InputType[], models: DMMF.Model[]) {

--- a/packages/sdk/src/dmmf-helpers/select-helpers.ts
+++ b/packages/sdk/src/dmmf-helpers/select-helpers.ts
@@ -1,4 +1,4 @@
-import type { DMMF } from '../types';
+import type { DMMF } from '../prisma';
 import { checkIsModelRelationField, checkModelHasManyModelRelation } from './model-helpers';
 
 export function addMissingInputObjectTypesForSelect(

--- a/packages/sdk/src/dmmf-helpers/types.ts
+++ b/packages/sdk/src/dmmf-helpers/types.ts
@@ -1,4 +1,4 @@
-import type { DMMF } from '../types';
+import type { DMMF } from '../prisma';
 
 export type TransformerParams = {
     enumTypes?: DMMF.SchemaEnum[];

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,7 +2,6 @@ export * from './code-gen';
 export * from './constants';
 export { generate as generateModelMeta } from './model-meta-generator';
 export * from './policy';
-export * from './prisma';
 export * from './types';
 export * from './typescript-expression-transformer';
 export * from './utils';

--- a/packages/sdk/src/prisma.ts
+++ b/packages/sdk/src/prisma.ts
@@ -70,3 +70,5 @@ export function getPrismaVersion(): string | undefined {
         }
     }
 }
+
+export type { DMMF } from '@prisma/generator-helper';

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -93,5 +93,3 @@ export class PluginError extends Error {
         super(message);
     }
 }
-
-export type { DMMF } from '@prisma/generator-helper';

--- a/packages/testtools/src/schema.ts
+++ b/packages/testtools/src/schema.ts
@@ -8,7 +8,7 @@ import {
     type EnhancementKind,
     type EnhancementOptions,
 } from '@zenstackhq/runtime';
-import { getDMMF, type DMMF } from '@zenstackhq/sdk';
+import { getDMMF, type DMMF } from '@zenstackhq/sdk/prisma';
 import { execSync } from 'child_process';
 import * as fs from 'fs';
 import json from 'json5';


### PR DESCRIPTION
- Solves the problem that launching language server triggers loading "@prisma/internals"
- Removes several old logic for detecting Prisma versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined import paths and reorganized imports for improved clarity and maintainability.
- **Documentation**
	- Updated internal documentation to align with new import paths and module restructuring.
- **Chores**
	- Enhanced SDK's package.json with explicit export mappings for better module resolution and usage.
- **New Features**
	- Exported the `DMMF` type from `@prisma/generator-helper`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->