### PR TITLE
feat: support format switch in VSCode extension

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -55,7 +55,17 @@
                 "scopeName": "source.zmodel",
                 "path": "./bundle/syntaxes/zmodel.tmLanguage.json"
             }
-        ]
+        ],
+        "configuration": {
+            "title": "ZenStack",
+            "properties": {
+              "zmodel.format.usePrismaStyle": {
+                "type": "boolean",
+                "default": true,
+                "description": "Use Prisma style indentation."
+              }
+            }
+          }
     },
     "activationEvents": [
         "onLanguage:zmodel"

--- a/packages/schema/src/language-server/zmodel-formatter.ts
+++ b/packages/schema/src/language-server/zmodel-formatter.ts
@@ -79,10 +79,13 @@ export class ZModelFormatter extends AbstractFormatter {
         this.formatOptions = params.options;
 
         this.configurationProvider.getConfiguration(ZModelLanguageMetaData.languageId, 'format').then((config) => {
-            if (config.usePrismaStyle === false) {
-                this.setPrismaStyle(false);
-            } else {
-                this.setPrismaStyle(true);
+            // in the CLI case, the config is undefined
+            if (config) {
+                if (config.usePrismaStyle === false) {
+                    this.setPrismaStyle(false);
+                } else {
+                    this.setPrismaStyle(true);
+                }
             }
         });
 

--- a/packages/schema/src/language-server/zmodel-formatter.ts
+++ b/packages/schema/src/language-server/zmodel-formatter.ts
@@ -1,11 +1,28 @@
-import { AbstractFormatter, AstNode, Formatting, LangiumDocument } from 'langium';
+import {
+    AbstractFormatter,
+    AstNode,
+    ConfigurationProvider,
+    Formatting,
+    LangiumDocument,
+    LangiumServices,
+    MaybePromise,
+} from 'langium';
 
 import * as ast from '@zenstackhq/language/ast';
-import { FormattingOptions, Range, TextEdit } from 'vscode-languageserver';
+import { DocumentFormattingParams, FormattingOptions, TextEdit } from 'vscode-languageserver';
+import { ZModelLanguageMetaData } from '@zenstackhq/language/generated/module';
 
 export class ZModelFormatter extends AbstractFormatter {
     private formatOptions?: FormattingOptions;
     private isPrismaStyle = true;
+
+    protected readonly configurationProvider: ConfigurationProvider;
+
+    constructor(services: LangiumServices) {
+        super();
+        this.configurationProvider = services.shared.workspace.ConfigurationProvider;
+    }
+
     protected format(node: AstNode): void {
         const formatter = this.getNodeFormatter(node);
 
@@ -55,13 +72,21 @@ export class ZModelFormatter extends AbstractFormatter {
         }
     }
 
-    protected override doDocumentFormat(
+    override formatDocument(
         document: LangiumDocument<AstNode>,
-        options: FormattingOptions,
-        range?: Range | undefined
-    ): TextEdit[] {
-        this.formatOptions = options;
-        return super.doDocumentFormat(document, options, range);
+        params: DocumentFormattingParams
+    ): MaybePromise<TextEdit[]> {
+        this.formatOptions = params.options;
+
+        this.configurationProvider.getConfiguration(ZModelLanguageMetaData.languageId, 'format').then((config) => {
+            if (config.usePrismaStyle === false) {
+                this.setPrismaStyle(false);
+            } else {
+                this.setPrismaStyle(true);
+            }
+        });
+
+        return super.formatDocument(document, params);
     }
 
     public getFormatOptions(): FormattingOptions | undefined {

--- a/packages/schema/src/language-server/zmodel-module.ts
+++ b/packages/schema/src/language-server/zmodel-module.ts
@@ -66,7 +66,7 @@ export const ZModelModule: Module<ZModelServices, PartialLangiumServices & ZMode
         ZModelValidator: (services) => new ZModelValidator(services),
     },
     lsp: {
-        Formatter: () => new ZModelFormatter(),
+        Formatter: (services) => new ZModelFormatter(services),
         CodeActionProvider: (services) => new ZModelCodeActionProvider(services),
         DefinitionProvider: (services) => new ZModelDefinitionProvider(services),
         SemanticTokenProvider: (services) => new ZModelSemanticTokenProvider(services),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a new configuration option in `package.json` to customize Prisma style indentation.

- **Refactor**
	- Updated the document formatting logic in the language server to enhance customization and performance.

- **Documentation**
	- Improved internal documentation for the language server components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->