### PR TITLE
chore(zmodel): add vscode prerelease command

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -26,7 +26,7 @@
         "linkDirectory": true
     },
     "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.63.0"
     },
     "categories": [
         "Programming Languages"
@@ -76,6 +76,7 @@
     "main": "./bundle/extension.js",
     "scripts": {
         "vscode:publish": "vsce publish --no-dependencies",
+        "vscode:prerelease": "vsce publish --no-dependencies --pre-release",
         "vscode:prepublish": "pnpm bundle",
         "vscode:package": "pnpm bundle && vsce package --no-dependencies",
         "clean": "rimraf dist",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
	- Updated the required version of VS Code to "^1.63.0."
	- Added a new script for publishing pre-release versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->