### PR TITLE
chore(runtime): create a separate export for edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zenstack-monorepo",
-    "version": "2.0.0-beta.14",
+    "version": "2.0.0-beta.15",
     "description": "",
     "scripts": {
         "build": "pnpm -r build",

--- a/packages/ide/jetbrains/build.gradle.kts
+++ b/packages/ide/jetbrains/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "dev.zenstack"
-version = "2.0.0-beta.14"
+version = "2.0.0-beta.15"
 
 repositories {
     mavenCentral()

--- a/packages/ide/jetbrains/package.json
+++ b/packages/ide/jetbrains/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jetbrains",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "displayName": "ZenStack JetBrains IDE Plugin",
   "description": "ZenStack JetBrains IDE plugin",
   "homepage": "https://zenstack.dev",

--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenstackhq/language",
-    "version": "2.0.0-beta.14",
+    "version": "2.0.0-beta.15",
     "displayName": "ZenStack modeling language compiler",
     "description": "ZenStack modeling language compiler",
     "homepage": "https://zenstack.dev",

--- a/packages/misc/redwood/package.json
+++ b/packages/misc/redwood/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@zenstackhq/redwood",
     "displayName": "ZenStack RedwoodJS Integration",
-    "version": "2.0.0-beta.14",
+    "version": "2.0.0-beta.15",
     "description": "CLI and runtime for integrating ZenStack with RedwoodJS projects.",
     "repository": {
         "type": "git",

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zenstackhq/openapi",
   "displayName": "ZenStack Plugin and Runtime for OpenAPI",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "description": "ZenStack plugin and runtime supporting OpenAPI",
   "main": "index.js",
   "repository": {

--- a/packages/plugins/swr/package.json
+++ b/packages/plugins/swr/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@zenstackhq/swr",
     "displayName": "ZenStack plugin for generating SWR hooks",
-    "version": "2.0.0-beta.14",
+    "version": "2.0.0-beta.15",
     "description": "ZenStack plugin for generating SWR hooks",
     "main": "index.js",
     "repository": {

--- a/packages/plugins/tanstack-query/package.json
+++ b/packages/plugins/tanstack-query/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@zenstackhq/tanstack-query",
     "displayName": "ZenStack plugin for generating tanstack-query hooks",
-    "version": "2.0.0-beta.14",
+    "version": "2.0.0-beta.15",
     "description": "ZenStack plugin for generating tanstack-query hooks",
     "main": "index.js",
     "exports": {

--- a/packages/plugins/trpc/package.json
+++ b/packages/plugins/trpc/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@zenstackhq/trpc",
     "displayName": "ZenStack plugin for tRPC",
-    "version": "2.0.0-beta.14",
+    "version": "2.0.0-beta.15",
     "description": "ZenStack plugin for tRPC",
     "main": "index.js",
     "repository": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@zenstackhq/runtime",
     "displayName": "ZenStack Runtime Library",
-    "version": "2.0.0-beta.14",
+    "version": "2.0.0-beta.15",
     "description": "Runtime of ZenStack for both client-side and server-side environments.",
     "repository": {
         "type": "git",
@@ -18,21 +18,31 @@
     "types": "index.d.ts",
     "exports": {
         ".": {
+            "types": "./index.d.ts",
             "default": "./index.js"
         },
-        "./package.json": {
-            "default": "./package.json"
+        "./edge": {
+            "types": "./edge.d.ts",
+            "default": "./edge.js"
+        },
+        "./enhancements": {
+            "types": "./enhancements/index.d.ts",
+            "default": "./enhancements/index.js"
         },
         "./zod": {
+            "types": "./zod/index.d.ts",
             "default": "./zod/index.js"
         },
         "./zod/input": {
+            "types": "./zod/input.d.ts",
             "default": "./zod/input.js"
         },
         "./zod/models": {
+            "types": "./zod/models.d.ts",
             "default": "./zod/models.js"
         },
         "./zod/objects": {
+            "types": "./zod/objects.d.ts",
             "default": "./zod/objects.js"
         },
         "./browser": {
@@ -53,6 +63,9 @@
         },
         "./models": {
             "types": "./models.d.ts"
+        },
+        "./package.json": {
+            "default": "./package.json"
         }
     },
     "publishConfig": {

--- a/packages/runtime/src/edge.ts
+++ b/packages/runtime/src/edge.ts
@@ -1,0 +1,1 @@
+index.ts

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -3,7 +3,7 @@
     "publisher": "zenstack",
     "displayName": "ZenStack Language Tools",
     "description": "Build scalable web apps with minimum code by defining authorization and validation rules inside the data schema that closer to the database",
-    "version": "2.0.0-beta.14",
+    "version": "2.0.0-beta.15",
     "author": {
         "name": "ZenStack Team"
     },

--- a/packages/schema/src/plugins/enhancer/enhance/index.ts
+++ b/packages/schema/src/plugins/enhancer/enhance/index.ts
@@ -86,7 +86,8 @@ export class EnhancerGenerator {
 
         const enhanceTs = this.project.createSourceFile(
             path.join(this.outDir, 'enhance.ts'),
-            `import { createEnhancement, type EnhancementContext, type EnhancementOptions, type ZodSchemas, type AuthUser } from '@zenstackhq/runtime';
+            `import { type EnhancementContext, type EnhancementOptions, type ZodSchemas, type AuthUser } from '@zenstackhq/runtime';
+import { createEnhancement } from '@zenstackhq/runtime/enhancements';
 import modelMeta from './model-meta';
 import policy from './policy';
 ${this.options.withZodSchemas ? "import * as zodSchemas from './zod';" : 'const zodSchemas = undefined;'}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenstackhq/sdk",
-    "version": "2.0.0-beta.14",
+    "version": "2.0.0-beta.15",
     "description": "ZenStack plugin development SDK",
     "main": "index.js",
     "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenstackhq/server",
-    "version": "2.0.0-beta.14",
+    "version": "2.0.0-beta.15",
     "displayName": "ZenStack Server-side Adapters",
     "description": "ZenStack server-side adapters",
     "homepage": "https://zenstack.dev",

--- a/packages/testtools/package.json
+++ b/packages/testtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenstackhq/testtools",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "description": "ZenStack Test Tools",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new enhancements in the ZenStack Language Tools.
	- Added new exports to the `@zenstackhq/runtime` package.

- **Chores**
	- Updated version numbers across various packages and plugins to "2.0.0-beta.15".

- **Refactor**
	- Adjusted internal import locations for enhancement functionalities in the ZenStack Language Tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->