### PR TITLE
fix(runtime): always use id fields to address existing entity during upsert

### DIFF
--- a/packages/plugins/swr/tests/test-model-meta.ts
+++ b/packages/plugins/swr/tests/test-model-meta.ts
@@ -43,7 +43,10 @@ export const modelMeta: ModelMeta = {
             ownerId: { ...fieldDefaults, type: 'User', name: 'owner', isForeignKey: true },
         },
     },
-    uniqueConstraints: {},
+    uniqueConstraints: {
+        user: { id: { name: 'id', fields: ['id'] } },
+        post: { id: { name: 'id', fields: ['id'] } },
+    },
     deleteCascade: {
         user: ['Post'],
     },

--- a/packages/plugins/tanstack-query/tests/test-model-meta.ts
+++ b/packages/plugins/tanstack-query/tests/test-model-meta.ts
@@ -43,7 +43,10 @@ export const modelMeta: ModelMeta = {
             ownerId: { ...fieldDefaults, type: 'User', name: 'owner', isForeignKey: true },
         },
     },
-    uniqueConstraints: {},
+    uniqueConstraints: {
+        user: { id: { name: 'id', fields: ['id'] } },
+        post: { id: { name: 'id', fields: ['id'] } },
+    },
     deleteCascade: {
         user: ['Post'],
     },

--- a/packages/runtime/src/cross/utils.ts
+++ b/packages/runtime/src/cross/utils.ts
@@ -1,5 +1,5 @@
 import { lowerCaseFirst } from 'lower-case-first';
-import { ModelMeta } from '.';
+import { ModelMeta, requireField } from '.';
 
 /**
  * Gets field names in a data model entity, filtering out internal fields.
@@ -47,17 +47,15 @@ export function zip<T1, T2>(x: Enumerable<T1>, y: Enumerable<T2>): Array<[T1, T2
 }
 
 export function getIdFields(modelMeta: ModelMeta, model: string, throwIfNotFound = false) {
-    let fields = modelMeta.fields[lowerCaseFirst(model)];
-    if (!fields) {
+    const uniqueConstraints = modelMeta.uniqueConstraints[lowerCaseFirst(model)] ?? {};
+
+    const entries = Object.values(uniqueConstraints);
+    if (entries.length === 0) {
         if (throwIfNotFound) {
-            throw new Error(`Unable to load fields for ${model}`);
-        } else {
-            fields = {};
+            throw new Error(`Model ${model} does not have any id field`);
         }
+        return [];
     }
-    const result = Object.values(fields).filter((f) => f.isId);
-    if (result.length === 0 && throwIfNotFound) {
-        throw new Error(`model ${model} does not have an id field`);
-    }
-    return result;
+
+    return entries[0].fields.map((f) => requireField(modelMeta, model, f));
 }

--- a/packages/runtime/src/enhancements/policy/handler.ts
+++ b/packages/runtime/src/enhancements/policy/handler.ts
@@ -1224,11 +1224,11 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
 
         const { result, error } = await this.transaction(async (tx) => {
             const { where, create, update, ...rest } = args;
-            const existing = await this.utils.checkExistence(tx, this.model, args.where);
+            const existing = await this.utils.checkExistence(tx, this.model, where);
 
             if (existing) {
                 // update case
-                const { result, postWriteChecks } = await this.doUpdate({ where, data: update, ...rest }, tx);
+                const { result, postWriteChecks } = await this.doUpdate({ where: existing, data: update, ...rest }, tx);
                 await this.runPostWriteChecks(postWriteChecks, tx);
                 return this.utils.readBack(tx, this.model, 'update', args, result);
             } else {

--- a/packages/runtime/src/enhancements/policy/handler.ts
+++ b/packages/runtime/src/enhancements/policy/handler.ts
@@ -420,7 +420,7 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
         });
 
         // return only the ids of the top-level entity
-        const ids = this.utils.getEntityIds(this.model, result);
+        const ids = this.utils.getEntityIds(model, result);
         return { result: ids, postWriteChecks: [...postCreateChecks.values()] };
     }
 
@@ -792,8 +792,10 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
             }
 
             // proceed with the create and collect post-create checks
-            const { postWriteChecks: checks } = await this.doCreate(model, { data: createData }, db);
+            const { postWriteChecks: checks, result } = await this.doCreate(model, { data: createData }, db);
             postWriteChecks.push(...checks);
+
+            return result;
         };
 
         const _createMany = async (
@@ -881,18 +883,10 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
                     // check pre-update guard
                     await this.utils.checkPolicyForUnique(model, uniqueFilter, 'update', db, args);
 
-                    // handles the case where id fields are updated
-                    const postUpdateIds = this.utils.clone(existing);
-                    for (const key of Object.keys(existing)) {
-                        const updateValue = (args as any).data ? (args as any).data[key] : (args as any)[key];
-                        if (
-                            typeof updateValue === 'string' ||
-                            typeof updateValue === 'number' ||
-                            typeof updateValue === 'bigint'
-                        ) {
-                            postUpdateIds[key] = updateValue;
-                        }
-                    }
+                    // handle the case where id fields are updated
+                    const _args: any = args;
+                    const updatePayload = _args.data && typeof _args.data === 'object' ? _args.data : _args;
+                    const postUpdateIds = this.calculatePostUpdateIds(model, existing, updatePayload);
 
                     // register post-update check
                     await _registerPostUpdateCheck(model, existing, postUpdateIds);
@@ -984,10 +978,13 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
                     // update case
 
                     // check pre-update guard
-                    await this.utils.checkPolicyForUnique(model, uniqueFilter, 'update', db, args);
+                    await this.utils.checkPolicyForUnique(model, existing, 'update', db, args);
+
+                    // handle the case where id fields are updated
+                    const postUpdateIds = this.calculatePostUpdateIds(model, existing, args.update);
 
                     // register post-update check
-                    await _registerPostUpdateCheck(model, uniqueFilter, uniqueFilter);
+                    await _registerPostUpdateCheck(model, existing, postUpdateIds);
 
                     // convert upsert to update
                     const convertedUpdate = {
@@ -1021,9 +1018,22 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
                 if (existing) {
                     // connect
                     await _connectDisconnect(model, args.where, context);
+                    return true;
                 } else {
                     // create
-                    await _create(model, args.create, context);
+                    const created = await _create(model, args.create, context);
+
+                    const upperContext = context.nestingPath[context.nestingPath.length - 2];
+                    if (upperContext?.where && context.field) {
+                        // check if the where clause of the upper context references the id
+                        // of the connected entity, if so, we need to update it
+                        this.overrideForeignKeyFields(upperContext.model, upperContext.where, context.field, created);
+                    }
+
+                    // remove the payload from the parent
+                    this.removeFromParent(context.parent, 'connectOrCreate', args);
+
+                    return false;
                 }
             },
 
@@ -1091,6 +1101,52 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
         });
 
         return { result, postWriteChecks };
+    }
+
+    // calculate id fields used for post-update check given an update payload
+    private calculatePostUpdateIds(_model: string, currentIds: any, updatePayload: any) {
+        const result = this.utils.clone(currentIds);
+        for (const key of Object.keys(currentIds)) {
+            const updateValue = updatePayload[key];
+            if (typeof updateValue === 'string' || typeof updateValue === 'number' || typeof updateValue === 'bigint') {
+                result[key] = updateValue;
+            }
+        }
+        return result;
+    }
+
+    // updates foreign key fields inside `payload` based on relation id fields in `newIds`
+    private overrideForeignKeyFields(
+        model: string,
+        payload: any,
+        relation: FieldInfo,
+        newIds: Record<string, unknown>
+    ) {
+        if (!relation.foreignKeyMapping || Object.keys(relation.foreignKeyMapping).length === 0) {
+            return;
+        }
+
+        // override foreign key values
+        for (const [id, fk] of Object.entries(relation.foreignKeyMapping)) {
+            if (payload[fk] !== undefined && newIds[id] !== undefined) {
+                payload[fk] = newIds[id];
+            }
+        }
+
+        // deal with compound id fields
+        const uniqueConstraints = this.utils.getUniqueConstraints(model);
+        for (const [name, constraint] of Object.entries(uniqueConstraints)) {
+            if (constraint.fields.length > 1) {
+                const target = payload[name];
+                if (target) {
+                    for (const [id, fk] of Object.entries(relation.foreignKeyMapping)) {
+                        if (target[fk] !== undefined && newIds[id] !== undefined) {
+                            target[fk] = newIds[id];
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // Validates the given update payload against Zod schema if any
@@ -1228,7 +1284,14 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
 
             if (existing) {
                 // update case
-                const { result, postWriteChecks } = await this.doUpdate({ where: existing, data: update, ...rest }, tx);
+                const { result, postWriteChecks } = await this.doUpdate(
+                    {
+                        where: this.utils.composeCompoundUniqueField(this.model, existing),
+                        data: update,
+                        ...rest,
+                    },
+                    tx
+                );
                 await this.runPostWriteChecks(postWriteChecks, tx);
                 return this.utils.readBack(tx, this.model, 'update', args, result);
             } else {

--- a/packages/sdk/src/model-meta-generator.ts
+++ b/packages/sdk/src/model-meta-generator.ts
@@ -1,6 +1,7 @@
 import {
     ArrayExpr,
     DataModel,
+    DataModelAttribute,
     DataModelField,
     isArrayExpr,
     isBooleanLiteral,
@@ -239,10 +240,7 @@ function getFieldAttributes(field: DataModelField): RuntimeAttribute[] {
 function getUniqueConstraints(model: DataModel) {
     const constraints: Array<{ name: string; fields: string[] }> = [];
 
-    // model-level constraints
-    for (const attr of model.attributes.filter(
-        (attr) => attr.decl.ref?.name === '@@unique' || attr.decl.ref?.name === '@@id'
-    )) {
+    const extractConstraint = (attr: DataModelAttribute) => {
         const argsMap = getAttributeArgs(attr);
         if (argsMap.fields) {
             const fieldNames = (argsMap.fields as ArrayExpr).items.map(
@@ -253,14 +251,45 @@ function getUniqueConstraints(model: DataModel) {
                 // default constraint name is fields concatenated with underscores
                 constraintName = fieldNames.join('_');
             }
-            constraints.push({ name: constraintName, fields: fieldNames });
+            return { name: constraintName, fields: fieldNames };
+        } else {
+            return undefined;
+        }
+    };
+
+    const addConstraint = (constraint: { name: string; fields: string[] }) => {
+        if (!constraints.some((c) => c.name === constraint.name)) {
+            constraints.push(constraint);
+        }
+    };
+
+    // field-level @id first
+    for (const field of model.fields) {
+        if (hasAttribute(field, '@id')) {
+            addConstraint({ name: field.name, fields: [field.name] });
         }
     }
 
-    // field-level constraints
+    // then model-level @@id
+    for (const attr of model.attributes.filter((attr) => attr.decl.ref?.name === '@@id')) {
+        const constraint = extractConstraint(attr);
+        if (constraint) {
+            addConstraint(constraint);
+        }
+    }
+
+    // then field-level @unique
     for (const field of model.fields) {
-        if (hasAttribute(field, '@id') || hasAttribute(field, '@unique')) {
-            constraints.push({ name: field.name, fields: [field.name] });
+        if (hasAttribute(field, '@unique')) {
+            addConstraint({ name: field.name, fields: [field.name] });
+        }
+    }
+
+    // then model-level @@unique
+    for (const attr of model.attributes.filter((attr) => attr.decl.ref?.name === '@@unique')) {
+        const constraint = extractConstraint(attr);
+        if (constraint) {
+            addConstraint(constraint);
         }
     }
 

--- a/tests/integration/tests/enhancements/with-policy/multi-id-fields.test.ts
+++ b/tests/integration/tests/enhancements/with-policy/multi-id-fields.test.ts
@@ -12,8 +12,8 @@ describe('With Policy: multiple id fields', () => {
         process.chdir(origDir);
     });
 
-    it('multi-id fields', async () => {
-        const { prisma, withPolicy } = await loadSchema(
+    it('multi-id fields crud', async () => {
+        const { prisma, enhance } = await loadSchema(
             `
         model A {
             x String
@@ -43,7 +43,7 @@ describe('With Policy: multiple id fields', () => {
         `
         );
 
-        const db = withPolicy();
+        const db = enhance();
 
         await expect(db.a.create({ data: { x: '1', y: 1, value: 0 } })).toBeRejectedByPolicy();
         await expect(db.a.create({ data: { x: '1', y: 2, value: 1 } })).toResolveTruthy();
@@ -69,8 +69,77 @@ describe('With Policy: multiple id fields', () => {
         ).toResolveTruthy();
     });
 
+    it('multi-id fields id update', async () => {
+        const { prisma, enhance } = await loadSchema(
+            `
+        model A {
+            x String
+            y Int
+            value Int
+            b B?
+            @@id([x, y])
+
+            @@allow('read', true)
+            @@allow('create', value > 0)
+            @@allow('update', value > 0 && future().value > 1)
+        }
+
+        model B {
+            b1 String
+            b2 String
+            value Int
+            a A @relation(fields: [ax, ay], references: [x, y])
+            ax String
+            ay Int
+
+            @@allow('read', value > 2)
+            @@allow('create', value > 1)
+
+            @@unique([ax, ay])
+            @@id([b1, b2])
+        }
+        `
+        );
+
+        const db = enhance();
+
+        await db.a.create({ data: { x: '1', y: 2, value: 1 } });
+
+        await expect(
+            db.a.update({ where: { x_y: { x: '1', y: 2 } }, data: { x: '2', y: 3, value: 0 } })
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.a.update({ where: { x_y: { x: '1', y: 2 } }, data: { x: '2', y: 3, value: 2 } })
+        ).resolves.toMatchObject({
+            x: '2',
+            y: 3,
+            value: 2,
+        });
+
+        await expect(
+            db.a.upsert({
+                where: { x_y: { x: '2', y: 3 } },
+                update: { x: '3', y: 4, value: 0 },
+                create: { x: '4', y: 5, value: 5 },
+            })
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.a.upsert({
+                where: { x_y: { x: '2', y: 3 } },
+                update: { x: '3', y: 4, value: 3 },
+                create: { x: '4', y: 5, value: 5 },
+            })
+        ).resolves.toMatchObject({
+            x: '3',
+            y: 4,
+            value: 3,
+        });
+    });
+
     it('multi-id auth', async () => {
-        const { prisma, withPolicy } = await loadSchema(
+        const { prisma, enhance } = await loadSchema(
             `
             model User {
                 x String
@@ -124,7 +193,7 @@ describe('With Policy: multiple id fields', () => {
         await prisma.user.create({ data: { x: '1', y: '1' } });
         await prisma.user.create({ data: { x: '1', y: '2' } });
 
-        const anonDb = withPolicy();
+        const anonDb = enhance();
 
         await expect(
             anonDb.m.create({ data: { owner: { connect: { x_y: { x: '1', y: '2' } } } } })
@@ -139,7 +208,7 @@ describe('With Policy: multiple id fields', () => {
             anonDb.n.create({ data: { owner: { connect: { x_y: { x: '1', y: '1' } } } } })
         ).toBeRejectedByPolicy();
 
-        const db = withPolicy({ x: '1', y: '1' });
+        const db = enhance({ x: '1', y: '1' });
 
         await expect(db.m.create({ data: { owner: { connect: { x_y: { x: '1', y: '2' } } } } })).toBeRejectedByPolicy();
         await expect(db.m.create({ data: { owner: { connect: { x_y: { x: '1', y: '1' } } } } })).toResolveTruthy();
@@ -149,13 +218,13 @@ describe('With Policy: multiple id fields', () => {
         await expect(db.p.create({ data: { owner: { connect: { x_y: { x: '1', y: '2' } } } } })).toResolveTruthy();
 
         await expect(
-            withPolicy(undefined).q.create({ data: { owner: { connect: { x_y: { x: '1', y: '1' } } } } })
+            enhance(undefined).q.create({ data: { owner: { connect: { x_y: { x: '1', y: '1' } } } } })
         ).toBeRejectedByPolicy();
         await expect(db.q.create({ data: { owner: { connect: { x_y: { x: '1', y: '2' } } } } })).toResolveTruthy();
     });
 
     it('multi-id to-one nested write', async () => {
-        const { withPolicy } = await loadSchema(
+        const { enhance } = await loadSchema(
             `
             model A {
                 x Int
@@ -177,7 +246,7 @@ describe('With Policy: multiple id fields', () => {
             }
             `
         );
-        const db = withPolicy();
+        const db = enhance();
         await expect(
             db.b.create({
                 data: {
@@ -205,7 +274,7 @@ describe('With Policy: multiple id fields', () => {
     });
 
     it('multi-id to-many nested write', async () => {
-        const { withPolicy } = await loadSchema(
+        const { enhance } = await loadSchema(
             `
             model A {
                 x Int
@@ -237,7 +306,7 @@ describe('With Policy: multiple id fields', () => {
             }
             `
         );
-        const db = withPolicy();
+        const db = enhance();
         await expect(
             db.b.create({
                 data: {
@@ -269,5 +338,80 @@ describe('With Policy: multiple id fields', () => {
 
         expect(await db.b.findUnique({ where: { id: 1 } })).toEqual(expect.objectContaining({ v: 5 }));
         expect(await db.c.findUnique({ where: { id: 1 } })).toEqual(expect.objectContaining({ v: 6 }));
+    });
+
+    it('multi-id fields nested id update', async () => {
+        const { enhance } = await loadSchema(
+            `
+        model A {
+            x String
+            y Int
+            value Int
+            b B @relation(fields: [bId], references: [id])
+            bId Int
+            @@id([x, y])
+
+            @@allow('read', true)
+            @@allow('create', value > 0)
+            @@allow('update', value > 0 && future().value > 1)
+        }
+
+        model B {
+            id Int @id @default(autoincrement())
+            a A[]
+            @@allow('all', true)
+        }
+        `
+        );
+
+        const db = enhance();
+
+        await db.b.create({ data: { id: 1, a: { create: { x: '1', y: 1, value: 1 } } } });
+
+        await expect(
+            db.b.update({
+                where: { id: 1 },
+                data: { a: { update: { where: { x_y: { x: '1', y: 1 } }, data: { x: '2', y: 2, value: 0 } } } },
+            })
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.b.update({
+                where: { id: 1 },
+                data: { a: { update: { where: { x_y: { x: '1', y: 1 } }, data: { x: '2', y: 2, value: 2 } } } },
+                include: { a: true },
+            })
+        ).resolves.toMatchObject({ a: expect.arrayContaining([expect.objectContaining({ x: '2', y: 2, value: 2 })]) });
+
+        await expect(
+            db.b.update({
+                where: { id: 1 },
+                data: {
+                    a: {
+                        upsert: {
+                            where: { x_y: { x: '2', y: 2 } },
+                            update: { x: '3', y: 3, value: 0 },
+                            create: { x: '4', y: '4', value: 4 },
+                        },
+                    },
+                },
+            })
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.b.update({
+                where: { id: 1 },
+                data: {
+                    a: {
+                        upsert: {
+                            where: { x_y: { x: '2', y: 2 } },
+                            update: { x: '3', y: 3, value: 3 },
+                            create: { x: '4', y: '4', value: 4 },
+                        },
+                    },
+                },
+                include: { a: true },
+            })
+        ).resolves.toMatchObject({ a: expect.arrayContaining([expect.objectContaining({ x: '3', y: 3, value: 3 })]) });
     });
 });

--- a/tests/integration/tests/enhancements/with-policy/nested-to-many.test.ts
+++ b/tests/integration/tests/enhancements/with-policy/nested-to-many.test.ts
@@ -284,6 +284,101 @@ describe('With Policy:nested to-many', () => {
         expect(r.m2).toEqual(expect.arrayContaining([expect.objectContaining({ id: '2', value: 3 })]));
     });
 
+    it('update id field', async () => {
+        const { withPolicy } = await loadSchema(
+            `
+        model M1 {
+            id String @id @default(uuid())
+            m2 M2[]
+        
+            @@allow('all', true)
+        }
+        
+        model M2 {
+            id String @id @default(uuid())
+            value Int
+            m1 M1 @relation(fields: [m1Id], references:[id])
+            m1Id String
+        
+            @@allow('read', true)
+            @@allow('create', true)
+            @@allow('update', value > 1 && future().value > 2)
+        }
+        `
+        );
+
+        const db = withPolicy();
+
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: { id: '1', value: 2 },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.update({
+                where: { id: '1' },
+                include: { m2: true },
+                data: {
+                    m2: {
+                        update: {
+                            where: { id: '1' },
+                            data: { id: '2', value: 1 },
+                        },
+                    },
+                },
+            })
+        ).toBeRejectedByPolicy();
+
+        let r = await db.m1.update({
+            where: { id: '1' },
+            include: { m2: true },
+            data: {
+                m2: {
+                    update: {
+                        where: { id: '1' },
+                        data: { id: '2', value: 3 },
+                    },
+                },
+            },
+        });
+        expect(r.m2).toEqual(expect.arrayContaining([expect.objectContaining({ id: '2', value: 3 })]));
+
+        await expect(
+            db.m1.update({
+                where: { id: '1' },
+                include: { m2: true },
+                data: {
+                    m2: {
+                        upsert: {
+                            where: { id: '2' },
+                            create: { id: '4', value: 4 },
+                            update: { id: '3', value: 1 },
+                        },
+                    },
+                },
+            })
+        ).toBeRejectedByPolicy();
+
+        r = await db.m1.update({
+            where: { id: '1' },
+            include: { m2: true },
+            data: {
+                m2: {
+                    upsert: {
+                        where: { id: '2' },
+                        create: { id: '4', value: 4 },
+                        update: { id: '3', value: 4 },
+                    },
+                },
+            },
+        });
+        expect(r.m2).toEqual(expect.arrayContaining([expect.objectContaining({ id: '3', value: 4 })]));
+    });
+
     it('update with create from one to many', async () => {
         const { withPolicy } = await loadSchema(
             `

--- a/tests/integration/tests/enhancements/with-policy/toplevel-operations.test.ts
+++ b/tests/integration/tests/enhancements/with-policy/toplevel-operations.test.ts
@@ -147,6 +147,82 @@ describe('With Policy: toplevel operations', () => {
         ).toBeTruthy();
     });
 
+    it('update id tests', async () => {
+        const { withPolicy } = await loadSchema(
+            `
+        model Model {
+            id String @id @default(uuid())
+            value Int
+        
+            @@allow('read', value > 1)
+            @@allow('create', value > 0)
+            @@allow('update', value > 1 && future().value > 2)
+        }
+        `
+        );
+
+        const db = withPolicy();
+
+        await db.model.create({
+            data: {
+                id: '1',
+                value: 2,
+            },
+        });
+
+        // update denied
+        await expect(
+            db.model.update({
+                where: { id: '1' },
+                data: {
+                    id: '2',
+                    value: 1,
+                },
+            })
+        ).toBeRejectedByPolicy();
+
+        // update success
+        await expect(
+            db.model.update({
+                where: { id: '1' },
+                data: {
+                    id: '2',
+                    value: 3,
+                },
+            })
+        ).resolves.toMatchObject({ id: '2', value: 3 });
+
+        // upsert denied
+        await expect(
+            db.model.upsert({
+                where: { id: '2' },
+                update: {
+                    id: '3',
+                    value: 1,
+                },
+                create: {
+                    id: '4',
+                    value: 5,
+                },
+            })
+        ).toBeRejectedByPolicy();
+
+        // upsert success
+        await expect(
+            db.model.upsert({
+                where: { id: '2' },
+                update: {
+                    id: '3',
+                    value: 4,
+                },
+                create: {
+                    id: '4',
+                    value: 5,
+                },
+            })
+        ).resolves.toMatchObject({ id: '3', value: 4 });
+    });
+
     it('delete tests', async () => {
         const { withPolicy, prisma } = await loadSchema(
             `

--- a/tests/integration/tests/regression/issue-1271.test.ts
+++ b/tests/integration/tests/regression/issue-1271.test.ts
@@ -47,7 +47,7 @@ describe('issue 1271', () => {
 
         const test = await db.test.create({
             data: {
-                key: 'hello',
+                key: 'test1',
             },
         });
         const anotherTest = await db.anotherTest.create({
@@ -85,18 +85,16 @@ describe('issue 1271', () => {
         expect(updated.linkingTable).toHaveLength(1);
         expect(updated.linkingTable[0]).toMatchObject({ another_test_id: anotherTest.id });
 
-        const newKey = 'newKey';
-        const newLocale = 'ZH';
-        const created = await db.test.upsert({
+        const test2 = await db.test.upsert({
             where: {
                 key_locale: {
-                    key: newKey,
-                    locale: newLocale,
+                    key: 'test2',
+                    locale: 'locale2',
                 },
             },
             create: {
-                key: newKey,
-                locale: newLocale,
+                key: 'test2',
+                locale: 'locale2',
                 linkingTable: {
                     create: {
                         another_test_id: anotherTest.id,
@@ -114,8 +112,81 @@ describe('issue 1271', () => {
                 linkingTable: true,
             },
         });
-        expect(created).toMatchObject({ key: newKey, locale: newLocale });
-        expect(created.linkingTable).toHaveLength(1);
-        expect(created.linkingTable[0]).toMatchObject({ another_test_id: anotherTest.id });
+        expect(test2).toMatchObject({ key: 'test2', locale: 'locale2' });
+        expect(test2.linkingTable).toHaveLength(1);
+        expect(test2.linkingTable[0]).toMatchObject({ another_test_id: anotherTest.id });
+
+        const linkingTable = test2.linkingTable[0];
+
+        // connectOrCreate: connect case
+        const test3 = await db.test.create({
+            data: {
+                key: 'test3',
+                locale: 'locale3',
+            },
+        });
+        console.log('test3 created:', test3);
+        const updated2 = await db.linkingTable.update({
+            where: {
+                test_id_another_test_id: {
+                    test_id: linkingTable.test_id,
+                    another_test_id: linkingTable.another_test_id,
+                },
+            },
+            data: {
+                test: {
+                    connectOrCreate: {
+                        where: {
+                            key_locale: {
+                                key: test3.key,
+                                locale: test3.locale,
+                            },
+                        },
+                        create: {
+                            key: 'test4',
+                            locale: 'locale4',
+                        },
+                    },
+                },
+                another_test: { connect: { id: anotherTest.id } },
+            },
+            include: { test: true },
+        });
+        expect(updated2).toMatchObject({
+            test: expect.objectContaining({ key: 'test3', locale: 'locale3' }),
+            another_test_id: anotherTest.id,
+        });
+
+        // connectOrCreate: create case
+        const updated3 = await db.linkingTable.update({
+            where: {
+                test_id_another_test_id: {
+                    test_id: updated2.test_id,
+                    another_test_id: updated2.another_test_id,
+                },
+            },
+            data: {
+                test: {
+                    connectOrCreate: {
+                        where: {
+                            key_locale: {
+                                key: 'test4',
+                                locale: 'locale4',
+                            },
+                        },
+                        create: {
+                            key: 'test4',
+                            locale: 'locale4',
+                        },
+                    },
+                },
+                another_test: { connect: { id: anotherTest.id } },
+            },
+            include: { test: true },
+        });
+        expect(updated3).toMatchObject({
+            test: expect.objectContaining({ key: 'test4', locale: 'locale4' }),
+            another_test_id: anotherTest.id,
+        });
     });
 });

--- a/tests/integration/tests/regression/issue-1271.test.ts
+++ b/tests/integration/tests/regression/issue-1271.test.ts
@@ -1,0 +1,121 @@
+import { loadSchema } from '@zenstackhq/testtools';
+
+describe('issue 1271', () => {
+    it('regression', async () => {
+        const { enhance } = await loadSchema(
+            `
+            model User {
+                id String @id @default(uuid())
+              
+                @@auth
+                @@allow('all', true)
+            }
+              
+            model Test {
+                id String @id @default(uuid())
+                linkingTable LinkingTable[]
+                key String @default('test')
+                locale String @default('EN')
+              
+                @@unique([key, locale])
+                @@allow("all", true)
+            }
+              
+            model LinkingTable {
+                test_id String
+                test Test @relation(fields: [test_id], references: [id])
+              
+                another_test_id String
+                another_test AnotherTest @relation(fields: [another_test_id], references: [id])
+              
+                @@id([test_id, another_test_id])
+                @@allow("all", true)
+            }
+              
+            model AnotherTest {
+                id String @id @default(uuid())
+                status String
+                linkingTable LinkingTable[]
+              
+                @@allow("all", true)
+            }              
+            `,
+            { logPrismaQuery: true }
+        );
+
+        const db = enhance();
+
+        const test = await db.test.create({
+            data: {
+                key: 'hello',
+            },
+        });
+        const anotherTest = await db.anotherTest.create({
+            data: {
+                status: 'available',
+            },
+        });
+
+        const updated = await db.test.upsert({
+            where: {
+                key_locale: {
+                    key: test.key,
+                    locale: test.locale,
+                },
+            },
+            create: {
+                linkingTable: {
+                    create: {
+                        another_test_id: anotherTest.id,
+                    },
+                },
+            },
+            update: {
+                linkingTable: {
+                    create: {
+                        another_test_id: anotherTest.id,
+                    },
+                },
+            },
+            include: {
+                linkingTable: true,
+            },
+        });
+
+        expect(updated.linkingTable).toHaveLength(1);
+        expect(updated.linkingTable[0]).toMatchObject({ another_test_id: anotherTest.id });
+
+        const newKey = 'newKey';
+        const newLocale = 'ZH';
+        const created = await db.test.upsert({
+            where: {
+                key_locale: {
+                    key: newKey,
+                    locale: newLocale,
+                },
+            },
+            create: {
+                key: newKey,
+                locale: newLocale,
+                linkingTable: {
+                    create: {
+                        another_test_id: anotherTest.id,
+                    },
+                },
+            },
+            update: {
+                linkingTable: {
+                    create: {
+                        another_test_id: anotherTest.id,
+                    },
+                },
+            },
+            include: {
+                linkingTable: true,
+            },
+        });
+        expect(created).toMatchObject({ key: newKey, locale: newLocale });
+        expect(created.linkingTable).toHaveLength(1);
+        expect(created.linkingTable[0]).toMatchObject({ another_test_id: anotherTest.id });
+    });
+});


### PR DESCRIPTION
Fixes #1271 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved update operations accuracy by using correct existing data.
- **Tests**
	- Added test cases for database operations involving relationships and nested updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->