### PR TITLE
fix: Auto fix code generate to the wrong place for the imported module

### DIFF
--- a/packages/schema/src/language-server/zmodel-code-action.ts
+++ b/packages/schema/src/language-server/zmodel-code-action.ts
@@ -134,7 +134,7 @@ export class ZModelCodeActionProvider implements CodeActionProvider {
 
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 const endOffset = oppositeModel.$cstNode!.end - 1;
-                const position = document.textDocument.positionAt(endOffset);
+                const position = targetDocument.textDocument.positionAt(endOffset);
 
                 return {
                     title: `Add opposite relation fields on ${oppositeModel.name}`,


### PR DESCRIPTION
Use the correct document to find the position. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy in the position calculation for code actions related to adding opposite relation fields in the language server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->