### PR TITLE
fix(plugins/prisma):  add missing enum value documentations in generated prisma schema

### DIFF
--- a/packages/schema/src/plugins/prisma/schema-generator.ts
+++ b/packages/schema/src/plugins/prisma/schema-generator.ts
@@ -738,7 +738,7 @@ export class PrismaSchemaGenerator {
         const nonPrismaAttributes = field.attributes.filter((attr) => attr.decl.ref && !this.isPrismaAttribute(attr));
 
         const documentations = nonPrismaAttributes.map((attr) => '/// ' + this.zModelGenerator.generate(attr));
-        _enum.addField(field.name, attributes, documentations);
+        _enum.addField(field.name, attributes, documentations.concat(field.comments));
     }
 }
 

--- a/packages/schema/tests/generator/prisma-generator.test.ts
+++ b/packages/schema/tests/generator/prisma-generator.test.ts
@@ -223,6 +223,8 @@ describe('Prisma generator test', () => {
             }
 
             enum Role {
+                /// Admin role documentation line 1
+                /// Admin role documentation line 2
                 ADMIN @map('admin')
                 CUSTOMER @map('customer')
                 @@map('_Role')
@@ -251,6 +253,9 @@ describe('Prisma generator test', () => {
         expect(content).toContain(`@@map("_Role")`);
         expect(content).toContain(`@map("admin")`);
         expect(content).toContain(`@map("customer")`);
+        expect(content).toContain('/// Admin role documentation line 1\n' +
+            '  /// Admin role documentation line 2\n' +
+            '  ADMIN');
     });
 
     it('attribute passthrough', async () => {


### PR DESCRIPTION
fix #1389 