### PR TITLE
fix: compatibility with pnpm monorepo

### DIFF
--- a/packages/schema/src/plugins/enhancer/index.ts
+++ b/packages/schema/src/plugins/enhancer/index.ts
@@ -1,4 +1,4 @@
-import { PluginError, createProject, resolvePath, type PluginFunction } from '@zenstackhq/sdk';
+import { PluginError, RUNTIME_PACKAGE, createProject, resolvePath, type PluginFunction } from '@zenstackhq/sdk';
 import path from 'path';
 import { getDefaultOutputFolder } from '../plugin-utils';
 import { EnhancerGenerator } from './enhance';
@@ -31,7 +31,7 @@ const run: PluginFunction = async (model, options, _dmmf, globalOptions) => {
             // resolve it relative to the schema path
             prismaClientPath = path.relative(path.dirname(options.schemaPath), prismaClientPathAbs);
         } else {
-            prismaClientPath = `.zenstack/models`;
+            prismaClientPath = `${RUNTIME_PACKAGE}/models`;
         }
     }
 

--- a/packages/schema/src/plugins/zod/transformer.ts
+++ b/packages/schema/src/plugins/zod/transformer.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { indentString, type PluginOptions } from '@zenstackhq/sdk';
 import { checkModelHasModelRelation, findModelByName, isAggregateInputType } from '@zenstackhq/sdk/dmmf-helpers';
-import { getPrismaClientImportSpec, type DMMF as PrismaDMMF } from '@zenstackhq/sdk/prisma';
+import { type DMMF as PrismaDMMF } from '@zenstackhq/sdk/prisma';
 import path from 'path';
 import type { Project, SourceFile } from 'ts-morph';
 import { upperCaseFirst } from 'upper-case-first';
+import { computePrismaClientImport } from './generator';
 import { AggregateOperationSupport, TransformerParams } from './types';
 
 export default class Transformer {
@@ -290,7 +291,7 @@ export const ${this.name}ObjectSchema: SchemaType = ${schema} as SchemaType;`;
     }
 
     generateImportPrismaStatement(options: PluginOptions) {
-        const prismaClientImportPath = getPrismaClientImportSpec(
+        const prismaClientImportPath = computePrismaClientImport(
             path.resolve(Transformer.outputPath, './objects'),
             options
         );


### PR DESCRIPTION
- Use `@zenstackhq/runtime/models` to import logical prisma client types
- Except for zod plugin, when generating into default location, still use ".zenstack/models" to avoid cyclic dependencies
- Only run prisma client generator when generating for logical schema