### PR TITLE
fix: relation fields are included even if they are set `false` in select clause

### DIFF
--- a/packages/runtime/src/enhancements/policy/policy-utils.ts
+++ b/packages/runtime/src/enhancements/policy/policy-utils.ts
@@ -653,6 +653,10 @@ export class PolicyUtil extends QueryUtils {
         const hoistedConditions: any[] = [];
 
         for (const field of getModelFields(injectTarget)) {
+            if (injectTarget[field] === false) {
+                continue;
+            }
+
             const fieldInfo = resolveField(this.modelMeta, model, field);
             if (!fieldInfo || !fieldInfo.isDataModel) {
                 // only care about relation fields

--- a/packages/schema/src/language-server/validator/expression-validator.ts
+++ b/packages/schema/src/language-server/validator/expression-validator.ts
@@ -30,7 +30,7 @@ export default class ExpressionValidator implements AstValidator<Expression> {
                 // check was done at link time
                 accept(
                     'error',
-                    'auth() cannot be resolved because no model marked wth "@@auth()" or named "User" is found',
+                    'auth() cannot be resolved because no model marked with "@@auth()" or named "User" is found',
                     { node: expr }
                 );
             } else {

--- a/packages/schema/tests/schema/validation/attribute-validation.test.ts
+++ b/packages/schema/tests/schema/validation/attribute-validation.test.ts
@@ -1051,7 +1051,7 @@ describe('Attribute tests', () => {
                 @@allow('all', auth() != null)
             }
         `)
-        ).toContain(`auth() cannot be resolved because no model marked wth "@@auth()" or named "User" is found`);
+        ).toContain(`auth() cannot be resolved because no model marked with "@@auth()" or named "User" is found`);
 
         await loadModel(`
             ${prelude}

--- a/tests/regression/tests/issue-1427.test.ts
+++ b/tests/regression/tests/issue-1427.test.ts
@@ -1,0 +1,42 @@
+import { loadSchema } from '@zenstackhq/testtools';
+
+describe('issue 1427', () => {
+    it('regression', async () => {
+        const { prisma, enhance } = await loadSchema(
+            `
+            model User {
+              id   String @id @default(cuid())
+              name String
+              profile Profile?
+              @@allow('all', true)
+            }
+            
+            model Profile {
+              id   String @id @default(cuid())
+              user User   @relation(fields: [userId], references: [id])
+              userId String @unique
+              @@allow('all', true)
+            }
+            `
+        );
+
+        await prisma.user.create({
+            data: {
+                name: 'John',
+                profile: {
+                    create: {},
+                },
+            },
+        });
+
+        const db = enhance();
+        const found = await db.user.findFirst({
+            select: {
+                id: true,
+                name: true,
+                profile: false,
+            },
+        });
+        expect(found.profile).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Fixes #1427 