### PR TITLE
allow enum names to be used as declaration names

### DIFF
--- a/packages/language/src/generated/ast.ts
+++ b/packages/language/src/generated/ast.ts
@@ -366,7 +366,7 @@ export interface EnumField extends AstNode {
     readonly $type: 'EnumField';
     attributes: Array<DataModelFieldAttribute>
     comments: Array<string>
-    name: RegularID
+    name: RegularIDWithTypeNames
 }
 
 export const EnumField = 'EnumField';

--- a/packages/language/src/generated/grammar.ts
+++ b/packages/language/src/generated/grammar.ts
@@ -2357,7 +2357,7 @@ export const ZModelGrammar = (): Grammar => loadedZModelGrammar ?? (loadedZModel
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@46"
+                "$ref": "#/rules@47"
               },
               "arguments": []
             }

--- a/packages/language/src/zmodel.langium
+++ b/packages/language/src/zmodel.langium
@@ -209,7 +209,7 @@ Enum:
 
 EnumField:
     (comments+=TRIPLE_SLASH_COMMENT)*
-    name=RegularID (attributes+=DataModelFieldAttribute)*;
+    name=RegularIDWithTypeNames (attributes+=DataModelFieldAttribute)*;
 
 // function
 FunctionDecl:


### PR DESCRIPTION
Fixing bug from https://github.com/zenstackhq/zenstack/pull/1424 that errored if a special name e.g. `DateTime` was used in an Enum name