### PR TITLE
feat: allow comparing fields from different models in mutation policies

### DIFF
--- a/packages/runtime/src/enhancements/policy/constraint-solver.ts
+++ b/packages/runtime/src/enhancements/policy/constraint-solver.ts
@@ -1,10 +1,10 @@
 import Logic from 'logic-solver';
 import { match } from 'ts-pattern';
 import type {
-    CheckerConstraint,
     ComparisonConstraint,
     ComparisonTerm,
     LogicalConstraint,
+    PermissionCheckerConstraint,
     ValueConstraint,
     VariableConstraint,
 } from '../types';
@@ -22,7 +22,7 @@ export class ConstraintSolver {
     /**
      * Check the satisfiability of the given constraint.
      */
-    checkSat(constraint: CheckerConstraint): boolean {
+    checkSat(constraint: PermissionCheckerConstraint): boolean {
         // reset state
         this.stringTable = [];
         this.variables = new Map<string, Logic.Formula>();
@@ -46,7 +46,7 @@ export class ConstraintSolver {
         return !!solver.solve();
     }
 
-    private buildFormula(constraint: CheckerConstraint): Logic.Formula {
+    private buildFormula(constraint: PermissionCheckerConstraint): Logic.Formula {
         return match(constraint)
             .when(
                 (c): c is ValueConstraint => c.kind === 'value',
@@ -100,11 +100,11 @@ export class ConstraintSolver {
         return Logic.not(this.buildFormula(constraint.children[0]));
     }
 
-    private isTrue(constraint: CheckerConstraint): unknown {
+    private isTrue(constraint: PermissionCheckerConstraint): unknown {
         return constraint.kind === 'value' && constraint.value === true;
     }
 
-    private isFalse(constraint: CheckerConstraint): unknown {
+    private isFalse(constraint: PermissionCheckerConstraint): unknown {
         return constraint.kind === 'value' && constraint.value === false;
     }
 

--- a/packages/runtime/src/enhancements/policy/policy-utils.ts
+++ b/packages/runtime/src/enhancements/policy/policy-utils.ts
@@ -1,18 +1,26 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import deepcopy from 'deepcopy';
+import deepmerge from 'deepmerge';
 import { lowerCaseFirst } from 'lower-case-first';
 import { upperCaseFirst } from 'upper-case-first';
 import { ZodError } from 'zod';
 import { fromZodError } from 'zod-validation-error';
 import { CrudFailureReason, PrismaErrorCode } from '../../constants';
 import { enumerate, getFields, getModelFields, resolveField, zip, type FieldInfo, type ModelMeta } from '../../cross';
-import { AuthUser, CrudContract, DbClientContract, PolicyCrudKind, PolicyOperationKind } from '../../types';
+import {
+    AuthUser,
+    CrudContract,
+    DbClientContract,
+    PolicyCrudKind,
+    PolicyOperationKind,
+    QueryContext,
+} from '../../types';
 import { getVersion } from '../../version';
 import type { EnhancementContext, InternalEnhancementOptions } from '../create-enhancement';
 import { Logger } from '../logger';
 import { QueryUtils } from '../query-utils';
-import type { CheckerFunc, ModelPolicyDef, PolicyDef, PolicyFunc, ZodSchemas } from '../types';
+import type { EntityChecker, ModelPolicyDef, PermissionCheckerFunc, PolicyDef, PolicyFunc, ZodSchemas } from '../types';
 import { formatObject, prismaClientKnownRequestError } from '../utils';
 
 /**
@@ -272,7 +280,7 @@ export class PolicyUtil extends QueryUtils {
      */
     getFieldOverrideReadAuthGuard(db: CrudContract, model: string, field: string) {
         const def = this.getModelPolicyDef(model);
-        const guard = def.fieldLevel?.read?.overrideGuard?.[field];
+        const guard = def.fieldLevel?.read?.[field]?.overrideGuard;
 
         if (guard === undefined) {
             // field access is denied by default in override mode
@@ -292,7 +300,7 @@ export class PolicyUtil extends QueryUtils {
      */
     getFieldUpdateAuthGuard(db: CrudContract, model: string, field: string) {
         const def = this.getModelPolicyDef(model);
-        const guard = def.fieldLevel?.update?.guard?.[field];
+        const guard = def.fieldLevel?.update?.[field]?.guard;
 
         if (guard === undefined) {
             // field access is allowed by default
@@ -312,7 +320,7 @@ export class PolicyUtil extends QueryUtils {
      */
     getFieldOverrideUpdateAuthGuard(db: CrudContract, model: string, field: string) {
         const def = this.getModelPolicyDef(model);
-        const guard = def.fieldLevel?.update?.overrideGuard?.[field];
+        const guard = def.fieldLevel?.update?.[field]?.overrideGuard;
 
         if (guard === undefined) {
             // field access is denied by default in override mode
@@ -343,8 +351,13 @@ export class PolicyUtil extends QueryUtils {
             return false;
         }
         const def = this.getModelPolicyDef(model);
-        const guard = def.fieldLevel?.[operation]?.overrideGuard;
-        return guard && Object.keys(guard).length > 0;
+        if (def.fieldLevel?.[operation]) {
+            return Object.values(def.fieldLevel[operation]).some(
+                (f) => f.overrideGuard !== undefined || f.overrideEntityChecker !== undefined
+            );
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -551,7 +564,7 @@ export class PolicyUtil extends QueryUtils {
     /**
      * Gets checker constraints for the given model and operation.
      */
-    getCheckerConstraint(model: string, operation: PolicyCrudKind): ReturnType<CheckerFunc> | boolean {
+    getCheckerConstraint(model: string, operation: PolicyCrudKind): ReturnType<PermissionCheckerFunc> | boolean {
         if (this.options.kinds && !this.options.kinds.includes('policy')) {
             // policy enhancement not enabled, return a constant true checker result
             return true;
@@ -697,6 +710,8 @@ export class PolicyUtil extends QueryUtils {
             );
         }
 
+        let entityChecker: EntityChecker | undefined;
+
         if (operation === 'update' && args) {
             // merge field-level policy guards
             const fieldUpdateGuard = this.getFieldUpdateGuards(db, model, args);
@@ -710,41 +725,45 @@ export class PolicyUtil extends QueryUtils {
                     }"`,
                     CrudFailureReason.ACCESS_POLICY_VIOLATION
                 );
-            } else {
-                if (fieldUpdateGuard.guard) {
-                    // merge field-level guard
-                    guard = this.and(guard, fieldUpdateGuard.guard);
-                }
-
-                if (fieldUpdateGuard.overrideGuard) {
-                    // merge field-level override guard
-                    guard = this.or(guard, fieldUpdateGuard.overrideGuard);
-                }
             }
+
+            if (fieldUpdateGuard.guard) {
+                // merge field-level guard with AND
+                guard = this.and(guard, fieldUpdateGuard.guard);
+            }
+
+            if (fieldUpdateGuard.overrideGuard) {
+                // merge field-level override guard with OR
+                guard = this.or(guard, fieldUpdateGuard.overrideGuard);
+            }
+
+            // field-level entity checker
+            entityChecker = fieldUpdateGuard.entityChecker;
         }
 
         // Zod schema is to be checked for "create" and "postUpdate"
         const schema = ['create', 'postUpdate'].includes(operation) ? this.getZodSchema(model) : undefined;
 
-        const additionalChecker = this.getAdditionalChecker(model, operation);
+        // combine field-level entity checker with model-level
+        const modelEntityChecker = this.getEntityChecker(model, operation);
+        entityChecker = this.combineEntityChecker(entityChecker, modelEntityChecker, 'and');
 
-        if (this.isTrue(guard) && !schema && !additionalChecker) {
+        if (this.isTrue(guard) && !schema && !entityChecker) {
             // unconditionally allowed
             return;
         }
 
-        const additionalCheckerSelector = this.getAdditionalCheckerSelector(model, operation);
         let select = schema
             ? // need to validate against schema, need to fetch all fields
               undefined
             : // only fetch id fields
               this.makeIdSelection(model);
 
-        if (additionalCheckerSelector) {
+        if (entityChecker?.selector) {
             if (!select) {
                 select = this.makeAllScalarFieldSelect(model);
             }
-            select = { ...select, ...additionalCheckerSelector };
+            select = { ...select, ...entityChecker.selector };
         }
 
         let where = this.clone(uniqueFilter);
@@ -768,11 +787,11 @@ export class PolicyUtil extends QueryUtils {
             );
         }
 
-        if (additionalChecker) {
+        if (entityChecker) {
             if (this.logger.enabled('info')) {
-                this.logger.info(`[policy] running additional checker on ${model} for ${operation}`);
+                this.logger.info(`[policy] running entity checker on ${model} for ${operation}`);
             }
-            if (!additionalChecker({ user: this.user, preValue }, result)) {
+            if (!entityChecker.func(result, { user: this.user, preValue })) {
                 throw this.deniedByPolicy(
                     model,
                     operation,
@@ -801,14 +820,18 @@ export class PolicyUtil extends QueryUtils {
         }
     }
 
-    getAdditionalCheckerSelector(model: string, operation: PolicyOperationKind) {
+    getEntityChecker(model: string, operation: PolicyOperationKind, field?: string) {
         const def = this.getModelPolicyDef(model);
-        return def.modelLevel[operation].additionalCheckerSelector;
+        if (field) {
+            return def.fieldLevel?.[operation as 'read' | 'update']?.[field]?.entityChecker;
+        } else {
+            return def.modelLevel[operation].entityChecker;
+        }
     }
 
-    getAdditionalChecker(model: string, operation: PolicyOperationKind) {
+    getUpdateOverrideEntityCheckerForField(model: string, field: string) {
         const def = this.getModelPolicyDef(model);
-        return def.modelLevel[operation].additionalChecker;
+        return def.fieldLevel?.update?.[field]?.overrideEntityChecker;
     }
 
     private getFieldReadGuards(db: CrudContract, model: string, args: { select?: any; include?: any }) {
@@ -837,19 +860,20 @@ export class PolicyUtil extends QueryUtils {
     private getFieldUpdateGuards(db: CrudContract, model: string, args: any) {
         const allFieldGuards = [];
         const allOverrideFieldGuards = [];
+        let entityChecker: EntityChecker | undefined;
 
-        for (const [k, v] of Object.entries<any>(args.data ?? args)) {
-            if (typeof v === 'undefined') {
+        for (const [field, value] of Object.entries<any>(args.data ?? args)) {
+            if (typeof value === 'undefined') {
                 continue;
             }
 
-            const field = resolveField(this.modelMeta, model, k);
+            const fieldInfo = resolveField(this.modelMeta, model, field);
 
-            if (field?.isDataModel) {
+            if (fieldInfo?.isDataModel) {
                 // relation field update should be treated as foreign key update,
                 // fetch and merge all foreign key guards
-                if (field.isRelationOwner && field.foreignKeyMapping) {
-                    const foreignKeys = Object.values<string>(field.foreignKeyMapping);
+                if (fieldInfo.isRelationOwner && fieldInfo.foreignKeyMapping) {
+                    const foreignKeys = Object.values<string>(fieldInfo.foreignKeyMapping);
                     for (const fk of foreignKeys) {
                         const fieldGuard = this.getFieldUpdateAuthGuard(db, model, fk);
                         if (this.isFalse(fieldGuard)) {
@@ -865,18 +889,26 @@ export class PolicyUtil extends QueryUtils {
                     }
                 }
             } else {
-                const fieldGuard = this.getFieldUpdateAuthGuard(db, model, k);
+                const fieldGuard = this.getFieldUpdateAuthGuard(db, model, field);
                 if (this.isFalse(fieldGuard)) {
-                    return { guard: fieldGuard, rejectedByField: k };
+                    return { guard: fieldGuard, rejectedByField: field };
                 }
 
                 // add field guard
                 allFieldGuards.push(fieldGuard);
 
                 // add field override guard
-                const overrideFieldGuard = this.getFieldOverrideUpdateAuthGuard(db, model, k);
+                const overrideFieldGuard = this.getFieldOverrideUpdateAuthGuard(db, model, field);
                 allOverrideFieldGuards.push(overrideFieldGuard);
             }
+
+            // merge regular and override entity checkers with OR
+            let checker = this.getEntityChecker(model, 'update', field);
+            const overrideChecker = this.getUpdateOverrideEntityCheckerForField(model, field);
+            checker = this.combineEntityChecker(checker, overrideChecker, 'or');
+
+            // accumulate entity checker across fields
+            entityChecker = this.combineEntityChecker(entityChecker, checker, 'and');
         }
 
         const allFieldsCombined = this.and(...allFieldGuards);
@@ -887,6 +919,31 @@ export class PolicyUtil extends QueryUtils {
             guard: allFieldsCombined,
             overrideGuard: allOverrideFieldsCombined,
             rejectedByField: undefined,
+            entityChecker,
+        };
+    }
+
+    private combineEntityChecker(
+        left: EntityChecker | undefined,
+        right: EntityChecker | undefined,
+        combiner: 'and' | 'or'
+    ): EntityChecker | undefined {
+        if (!left) {
+            return right;
+        }
+
+        if (!right) {
+            return left;
+        }
+
+        const func =
+            combiner === 'and'
+                ? (entity: any, context: QueryContext) => left.func(entity, context) && right.func(entity, context)
+                : (entity: any, context: QueryContext) => left.func(entity, context) || right.func(entity, context);
+
+        return {
+            func,
+            selector: deepmerge(left.selector ?? {}, right.selector ?? {}),
         };
     }
 
@@ -969,7 +1026,7 @@ export class PolicyUtil extends QueryUtils {
 
     /**
      * Injects field selection needed for checking field-level read policy check and evaluating
-     * additional checker into query args.
+     * entity checker into query args.
      */
     injectReadCheckSelect(model: string, args: any) {
         // we need to recurse into relation fields before injecting the current level, because
@@ -992,9 +1049,9 @@ export class PolicyUtil extends QueryUtils {
             }
         }
 
-        const additionalCheckerSelector = this.getAdditionalCheckerSelector(model, 'read');
-        if (additionalCheckerSelector) {
-            this.doInjectReadCheckSelect(model, args, { select: additionalCheckerSelector });
+        const entityChecker = this.getEntityChecker(model, 'read');
+        if (entityChecker?.selector) {
+            this.doInjectReadCheckSelect(model, args, { select: entityChecker.selector });
         }
     }
 
@@ -1113,19 +1170,36 @@ export class PolicyUtil extends QueryUtils {
         return def.modelLevel.postUpdate.preUpdateSelector;
     }
 
+    // get a merged selector object for all field-level read policies
     private getFieldReadCheckSelector(model: string) {
         const def = this.getModelPolicyDef(model);
-        return def.fieldLevel?.read?.selector;
+        let result: any = {};
+        const fieldLevel = def.fieldLevel?.read;
+        if (fieldLevel) {
+            for (const def of Object.values(fieldLevel)) {
+                if (def.entityChecker?.selector) {
+                    result = deepmerge(result, def.entityChecker.selector);
+                }
+                if (def.overrideEntityChecker?.selector) {
+                    result = deepmerge(result, def.overrideEntityChecker.selector);
+                }
+            }
+        }
+        return Object.keys(result).length > 0 ? result : undefined;
     }
 
     private checkReadField(model: string, field: string, entity: any) {
         const def = this.getModelPolicyDef(model);
-        const guard = def.fieldLevel?.read?.checker?.[field];
 
-        if (guard === undefined) {
+        // combine regular and override field-level entity checkers with OR
+        const checker = def.fieldLevel?.read?.[field]?.entityChecker;
+        const overrideChecker = def.fieldLevel?.read?.[field]?.overrideEntityChecker;
+        const combinedChecker = this.combineEntityChecker(checker, overrideChecker, 'or');
+
+        if (combinedChecker === undefined) {
             return true;
         } else {
-            return guard(entity, { user: this.user });
+            return combinedChecker.func(entity, { user: this.user });
         }
     }
 
@@ -1135,7 +1209,7 @@ export class PolicyUtil extends QueryUtils {
 
     private hasFieldLevelPolicy(model: string) {
         const def = this.getModelPolicyDef(model);
-        return !!def.fieldLevel?.read?.checker;
+        return Object.keys(def.fieldLevel?.read ?? {}).length > 0;
     }
 
     /**
@@ -1176,18 +1250,16 @@ export class PolicyUtil extends QueryUtils {
         let filteredData = data;
         let filteredFullData = fullData;
 
-        const additionalChecker = this.getAdditionalChecker(model, 'read');
-        if (additionalChecker) {
+        const entityChecker = this.getEntityChecker(model, 'read');
+        if (entityChecker) {
             if (Array.isArray(data)) {
                 filteredData = [];
                 filteredFullData = [];
                 for (const [entityData, entityFullData] of zip(data, fullData)) {
-                    if (!additionalChecker({ user: this.user }, entityData)) {
+                    if (!entityChecker.func(entityData, { user: this.user })) {
                         if (this.shouldLogQuery) {
                             this.logger.info(
-                                `[policy] dropping ${model} entity${
-                                    path ? ' at ' + path : ''
-                                } due to additional checker`
+                                `[policy] dropping ${model} entity${path ? ' at ' + path : ''} due to entity checker`
                             );
                         }
                     } else {
@@ -1196,10 +1268,10 @@ export class PolicyUtil extends QueryUtils {
                     }
                 }
             } else {
-                if (!additionalChecker({ user: this.user }, data)) {
+                if (!entityChecker.func(data, { user: this.user })) {
                     if (this.shouldLogQuery) {
                         this.logger.info(
-                            `[policy] dropping ${model} entity${path ? ' at ' + path : ''} due to additional checker`
+                            `[policy] dropping ${model} entity${path ? ' at ' + path : ''} due to entity checker`
                         );
                     }
                     return null;

--- a/packages/runtime/src/enhancements/types.ts
+++ b/packages/runtime/src/enhancements/types.ts
@@ -86,6 +86,11 @@ export type InputCheckFunc = (args: any, context: QueryContext) => boolean;
 export type ReadFieldCheckFunc = (input: any, context: QueryContext) => boolean;
 
 /**
+ * Additional checker function for checking polices outside of Prisma
+ */
+export type AdditionalCheckerFunc = (input: any, context: QueryContext) => boolean;
+
+/**
  * Policy definition
  */
 export type PolicyDef = {
@@ -138,6 +143,16 @@ type ModelCrudCommon = {
     guard: PolicyFunc | boolean;
 
     /**
+     * Additional checker function for checking policies outside of Prisma
+     */
+    additionalChecker?: AdditionalCheckerFunc;
+
+    /**
+     * Field selections for evaluating `additionalChecker`
+     */
+    additionalCheckerSelector?: object;
+
+    /**
      * Permission checker function or a constant condition
      */
     permissionChecker?: CheckerFunc | boolean;
@@ -172,8 +187,7 @@ type ModelDeleteDef = ModelCrudCommon;
 /**
  * Policy definition for post-update checking a model
  */
-type ModelPostUpdateDef = {
-    guard: PolicyFunc | boolean;
+type ModelPostUpdateDef = Exclude<ModelCrudCommon, 'permissionChecker'> & {
     preUpdateSelector?: object;
 };
 

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -62,7 +62,7 @@ export type QueryContext = {
 /**
  * Context for checking operation allowability.
  */
-export type CheckerContext = {
+export type PermissionCheckerContext = {
     /**
      * Current user
      */

--- a/packages/schema/src/language-server/validator/expression-validator.ts
+++ b/packages/schema/src/language-server/validator/expression-validator.ts
@@ -1,11 +1,14 @@
 import {
     AstNode,
     BinaryExpr,
+    DataModelAttribute,
+    DataModelFieldAttribute,
     Expression,
     ExpressionType,
     isDataModel,
     isDataModelAttribute,
     isDataModelField,
+    isDataModelFieldAttribute,
     isEnum,
     isLiteralExpr,
     isMemberAccessExpr,
@@ -13,7 +16,12 @@ import {
     isReferenceExpr,
     isThisExpr,
 } from '@zenstackhq/language/ast';
-import { isAuthInvocation, isDataModelFieldReference, isEnumFieldReference } from '@zenstackhq/sdk';
+import {
+    getAttributeArgLiteral,
+    isAuthInvocation,
+    isDataModelFieldReference,
+    isEnumFieldReference,
+} from '@zenstackhq/sdk';
 import { ValidationAcceptor, streamAst } from 'langium';
 import { findUpAst, getContainingDataModel } from '../../utils/ast-utils';
 import { AstValidator } from '../types';
@@ -151,6 +159,7 @@ export default class ExpressionValidator implements AstValidator<Expression> {
                     accept('error', 'incompatible operand types', { node: expr });
                     break;
                 }
+
                 // not supported:
                 //   - foo.a == bar
                 //   - foo.user.id == userId
@@ -169,10 +178,26 @@ export default class ExpressionValidator implements AstValidator<Expression> {
                     // foo.user.id == null
                     // foo.user.id == EnumValue
                     if (!(this.isNotModelFieldExpr(expr.left) || this.isNotModelFieldExpr(expr.right))) {
-                        accept('error', 'comparison between fields of different models are not supported', {
-                            node: expr,
-                        });
-                        break;
+                        const containingPolicyAttr = findUpAst(
+                            expr,
+                            (node) =>
+                                (isDataModelAttribute(node) && ['@@allow', '@@deny'].includes(node.decl.$refText)) ||
+                                (isDataModelFieldAttribute(node) && ['@allow', '@deny'].includes(node.decl.$refText))
+                        ) as DataModelAttribute | DataModelFieldAttribute | undefined;
+
+                        if (containingPolicyAttr) {
+                            const operation = getAttributeArgLiteral<string>(containingPolicyAttr, 'operation');
+                            if (operation?.split(',').includes('all') || operation?.split(',').includes('all')) {
+                                accept(
+                                    'error',
+                                    'comparison between fields of different models is not supported in "read" rules',
+                                    {
+                                        node: expr,
+                                    }
+                                );
+                                break;
+                            }
+                        }
                     }
                 }
 
@@ -245,16 +270,6 @@ export default class ExpressionValidator implements AstValidator<Expression> {
         if (!expr.$resolvedType) {
             accept('error', 'collection predicate can only be used on an array of model type', { node: expr });
             return;
-        }
-
-        // TODO: revisit this when we implement lambda inside collection predicate
-        const thisExpr = streamAst(expr).find(isThisExpr);
-        if (thisExpr) {
-            accept(
-                'error',
-                'using `this` in collection predicate is not supported. To compare entity identity, use id field comparison instead.',
-                { node: thisExpr }
-            );
         }
     }
 

--- a/packages/schema/src/language-server/validator/expression-validator.ts
+++ b/packages/schema/src/language-server/validator/expression-validator.ts
@@ -187,7 +187,7 @@ export default class ExpressionValidator implements AstValidator<Expression> {
 
                         if (containingPolicyAttr) {
                             const operation = getAttributeArgLiteral<string>(containingPolicyAttr, 'operation');
-                            if (operation?.split(',').includes('all') || operation?.split(',').includes('all')) {
+                            if (operation?.split(',').includes('all') || operation?.split(',').includes('read')) {
                                 accept(
                                     'error',
                                     'comparison between fields of different models is not supported in "read" rules',

--- a/packages/schema/src/language-server/validator/expression-validator.ts
+++ b/packages/schema/src/language-server/validator/expression-validator.ts
@@ -2,13 +2,11 @@ import {
     AstNode,
     BinaryExpr,
     DataModelAttribute,
-    DataModelFieldAttribute,
     Expression,
     ExpressionType,
     isDataModel,
     isDataModelAttribute,
     isDataModelField,
-    isDataModelFieldAttribute,
     isEnum,
     isLiteralExpr,
     isMemberAccessExpr,
@@ -180,17 +178,15 @@ export default class ExpressionValidator implements AstValidator<Expression> {
                     if (!(this.isNotModelFieldExpr(expr.left) || this.isNotModelFieldExpr(expr.right))) {
                         const containingPolicyAttr = findUpAst(
                             expr,
-                            (node) =>
-                                (isDataModelAttribute(node) && ['@@allow', '@@deny'].includes(node.decl.$refText)) ||
-                                (isDataModelFieldAttribute(node) && ['@allow', '@deny'].includes(node.decl.$refText))
-                        ) as DataModelAttribute | DataModelFieldAttribute | undefined;
+                            (node) => isDataModelAttribute(node) && ['@@allow', '@@deny'].includes(node.decl.$refText)
+                        ) as DataModelAttribute | undefined;
 
                         if (containingPolicyAttr) {
                             const operation = getAttributeArgLiteral<string>(containingPolicyAttr, 'operation');
                             if (operation?.split(',').includes('all') || operation?.split(',').includes('read')) {
                                 accept(
                                     'error',
-                                    'comparison between fields of different models is not supported in "read" rules',
+                                    'comparison between fields of different models is not supported in model-level "read" rules',
                                     {
                                         node: expr,
                                     }

--- a/packages/schema/src/plugins/enhancer/policy/policy-guard-generator.ts
+++ b/packages/schema/src/plugins/enhancer/policy/policy-guard-generator.ts
@@ -31,10 +31,10 @@ import path from 'path';
 import { CodeBlockWriter, Project, SourceFile, VariableDeclarationKind, WriterFunction } from 'ts-morph';
 import { ConstraintTransformer } from './constraint-transformer';
 import {
+    generateEntityCheckerFunction,
     generateNormalizedAuthRef,
     generateQueryGuardFunction,
     generateSelectForRules,
-    generateTypeScriptCheckerFunction,
     getPolicyExpressions,
     isEnumReferenced,
 } from './utils';
@@ -86,8 +86,8 @@ export class PolicyGenerator {
                 { name: 'type CrudContract' },
                 { name: 'allFieldsEqual' },
                 { name: 'type PolicyDef' },
-                { name: 'type CheckerContext' },
-                { name: 'type CheckerConstraint' },
+                { name: 'type PermissionCheckerContext' },
+                { name: 'type PermissionCheckerConstraint' },
             ],
             moduleSpecifier: `${RUNTIME_PACKAGE}`,
         });
@@ -348,29 +348,51 @@ export class PolicyGenerator {
             this.writePermissionChecker(model, kind, policies, allows, denies, writer, sourceFile);
         }
 
-        this.writeAdditionalChecker(model, kind, writer, sourceFile);
+        // write cross-model comparison rules as entity checker functions
+        // because they cannot be checked inside Prisma
+        this.writeEntityChecker(model, kind, writer, sourceFile, true);
     }
 
-    private writeAdditionalChecker(
-        model: DataModel,
+    private writeEntityChecker(
+        target: DataModel | DataModelField,
         kind: PolicyOperationKind,
         writer: CodeBlockWriter,
-        sourceFile: SourceFile
+        sourceFile: SourceFile,
+        onlyCrossModelComparison = false,
+        forOverride = false
     ) {
-        const allows = getPolicyExpressions(model, 'allow', kind, false, 'onlyCrossModelComparison');
-        const denies = getPolicyExpressions(model, 'deny', kind, false, 'onlyCrossModelComparison');
+        const allows = getPolicyExpressions(
+            target,
+            'allow',
+            kind,
+            forOverride,
+            onlyCrossModelComparison ? 'onlyCrossModelComparison' : 'all'
+        );
+        const denies = getPolicyExpressions(
+            target,
+            'deny',
+            kind,
+            forOverride,
+            onlyCrossModelComparison ? 'onlyCrossModelComparison' : 'all'
+        );
 
         if (allows.length === 0 && denies.length === 0) {
             return;
         }
 
-        const additionalFunc = generateTypeScriptCheckerFunction(sourceFile, model, kind, allows, denies);
-        writer.write(`additionalChecker: ${additionalFunc.getName()!},`);
-
-        const additionalSelector = generateSelectForRules([...allows, ...denies], false, kind !== 'postUpdate');
-        if (additionalSelector) {
-            writer.write(`additionalCheckerSelector: ${JSON.stringify(additionalSelector)},`);
-        }
+        const model = isDataModel(target) ? target : (target.$container as DataModel);
+        const func = generateEntityCheckerFunction(
+            sourceFile,
+            model,
+            kind,
+            allows,
+            denies,
+            isDataModelField(target) ? target : undefined,
+            forOverride
+        );
+        const selector = generateSelectForRules([...allows, ...denies], false, kind !== 'postUpdate') ?? {};
+        const key = forOverride ? 'overrideEntityChecker' : 'entityChecker';
+        writer.write(`${key}: { func: ${func.getName()!}, selector: ${JSON.stringify(selector)} },`);
     }
 
     // writes `guard: ...` for a given policy operation kind
@@ -465,11 +487,11 @@ export class PolicyGenerator {
 
         const func = sourceFile.addFunction({
             name: `${model.name}$checker$${kind}`,
-            returnType: 'CheckerConstraint',
+            returnType: 'PermissionCheckerConstraint',
             parameters: [
                 {
                     name: 'context',
-                    type: 'CheckerContext',
+                    type: 'PermissionCheckerContext',
                 },
             ],
             statements,
@@ -492,132 +514,93 @@ export class PolicyGenerator {
     }
 
     private writeFieldReadDef(model: DataModel, writer: CodeBlockWriter, sourceFile: SourceFile) {
-        const fieldCheckers: Record<string, string> = {};
-        const overrideGuards: Record<string, string> = {};
-        const allFieldsAllows: Expression[] = [];
-        const allFieldsDenies: Expression[] = [];
+        writer.writeLine('read:');
+        writer.block(() => {
+            for (const field of model.fields) {
+                const policyAttrs = field.attributes.filter((attr) => ['@allow', '@deny'].includes(attr.decl.$refText));
 
-        // generate field read checkers
-        for (const field of model.fields) {
-            const allows = getPolicyExpressions(field, 'allow', 'read');
-            const denies = getPolicyExpressions(field, 'deny', 'read');
-            if (denies.length === 0 && allows.length === 0) {
-                continue;
-            }
+                if (policyAttrs.length === 0) {
+                    continue;
+                }
 
-            allFieldsAllows.push(...allows);
-            allFieldsDenies.push(...denies);
+                writer.write(`${field.name}:`);
 
-            const guardFunc = this.generateFieldReadCheckerFunction(sourceFile, field, allows, denies);
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            fieldCheckers[field.name] = guardFunc.getName()!;
+                writer.block(() => {
+                    // checker function
+                    // write all field-level rules as entity checker function
+                    this.writeEntityChecker(field, 'read', writer, sourceFile, false, false);
 
-            const overrideAllows = getPolicyExpressions(field, 'allow', 'read', true);
-            if (overrideAllows.length > 0) {
-                const denies = getPolicyExpressions(field, 'deny', 'read');
-                const overrideGuardFunc = generateQueryGuardFunction(
-                    sourceFile,
-                    model,
-                    'read',
-                    overrideAllows,
-                    denies,
-                    field,
-                    true
-                );
-                overrideGuards[field.name] = overrideGuardFunc.getName()!;
-            }
-        }
+                    const overrideAllows = getPolicyExpressions(field, 'allow', 'read', true);
+                    if (overrideAllows.length > 0) {
+                        // override guard function
+                        const denies = getPolicyExpressions(field, 'deny', 'read');
+                        const overrideGuardFunc = generateQueryGuardFunction(
+                            sourceFile,
+                            model,
+                            'read',
+                            overrideAllows,
+                            denies,
+                            field,
+                            true
+                        );
+                        writer.write(`overrideGuard: ${overrideGuardFunc.getName()},`);
 
-        if (Object.keys(fieldCheckers).length > 0 || Object.keys(overrideGuards).length > 0) {
-            writer.write('read:');
-            writer.block(() => {
-                if (Object.keys(fieldCheckers).length > 0) {
-                    writer.write('checker:');
-
-                    // write checkers
-                    writer.inlineBlock(() => {
-                        Object.entries(fieldCheckers).forEach(([fieldName, funcName]) => {
-                            writer.write(`${fieldName}: ${funcName},`);
-                        });
-                    });
-                    writer.writeLine(',');
-
-                    // write field selector
-                    const readFieldCheckSelect = generateSelectForRules([...allFieldsAllows, ...allFieldsDenies]);
-                    if (readFieldCheckSelect) {
-                        writer.write(`selector: ${JSON.stringify(readFieldCheckSelect)},`);
+                        // additional entity checker for override
+                        this.writeEntityChecker(field, 'read', writer, sourceFile, false, true);
                     }
-                }
-
-                if (Object.keys(overrideGuards).length > 0) {
-                    // write override guards
-                    writer.write('overrideGuard:');
-                    writer.inlineBlock(() => {
-                        Object.entries(overrideGuards).forEach(([fieldName, funcName]) => {
-                            writer.write(`${fieldName}: ${funcName},`);
-                        });
-                    });
-                    writer.writeLine(',');
-                }
-            });
-            writer.writeLine(',');
-        }
+                });
+                writer.writeLine(',');
+            }
+        });
+        writer.writeLine(',');
     }
 
     private writeFieldUpdateDef(model: DataModel, writer: CodeBlockWriter, sourceFile: SourceFile) {
-        const guards: Record<string, string> = {};
-        const overrideGuards: Record<string, string> = {};
+        writer.writeLine('update:');
+        writer.block(() => {
+            for (const field of model.fields) {
+                const allows = getPolicyExpressions(field, 'allow', 'update');
+                const denies = getPolicyExpressions(field, 'deny', 'update');
+                const overrideAllows = getPolicyExpressions(field, 'allow', 'update', true);
 
-        for (const field of model.fields) {
-            const allows = getPolicyExpressions(field, 'allow', 'update');
-            const denies = getPolicyExpressions(field, 'deny', 'update');
-
-            if (denies.length === 0 && allows.length === 0) {
-                continue;
-            }
-
-            const guardFunc = generateQueryGuardFunction(sourceFile, model, 'update', allows, denies, field);
-            guards[field.name] = guardFunc.getName()!;
-
-            const overrideAllows = getPolicyExpressions(field, 'allow', 'update', true);
-            if (overrideAllows.length > 0) {
-                const overrideGuardFunc = generateQueryGuardFunction(
-                    sourceFile,
-                    model,
-                    'update',
-                    overrideAllows,
-                    denies,
-                    field,
-                    true
-                );
-                overrideGuards[field.name] = overrideGuardFunc.getName()!;
-            }
-        }
-
-        if (Object.keys(guards).length > 0 || Object.keys(overrideGuards).length > 0) {
-            writer.write('update:');
-            writer.block(() => {
-                if (Object.keys(guards).length > 0) {
-                    writer.write('guard:');
-                    writer.inlineBlock(() => {
-                        Object.entries(guards).forEach(([fieldName, funcName]) => {
-                            writer.write(`${fieldName}: ${funcName},`);
-                        });
-                    });
-                    writer.writeLine(',');
+                if (allows.length === 0 && denies.length === 0 && overrideAllows.length === 0) {
+                    continue;
                 }
 
-                if (Object.keys(overrideGuards).length > 0) {
-                    writer.write('overrideGuard:');
-                    writer.inlineBlock(() => {
-                        Object.entries(overrideGuards).forEach(([fieldName, funcName]) => {
-                            writer.write(`${fieldName}: ${funcName},`);
-                        });
-                    });
-                    writer.writeLine(',');
-                }
-            });
-        }
+                writer.write(`${field.name}:`);
+
+                writer.block(() => {
+                    // guard
+                    const guardFunc = generateQueryGuardFunction(sourceFile, model, 'update', allows, denies, field);
+                    writer.write(`guard: ${guardFunc.getName()},`);
+
+                    // write cross-model comparison rules as entity checker functions
+                    // because they cannot be checked inside Prisma
+                    this.writeEntityChecker(field, 'update', writer, sourceFile, true, false);
+
+                    const overrideAllows = getPolicyExpressions(field, 'allow', 'update', true);
+                    if (overrideAllows.length > 0) {
+                        // override guard
+                        const overrideGuardFunc = generateQueryGuardFunction(
+                            sourceFile,
+                            model,
+                            'update',
+                            overrideAllows,
+                            denies,
+                            field,
+                            true
+                        );
+                        writer.write(`overrideGuard: ${overrideGuardFunc.getName()},`);
+
+                        // write cross-model comparison override rules as entity checker functions
+                        // because they cannot be checked inside Prisma
+                        this.writeEntityChecker(field, 'update', writer, sourceFile, true, true);
+                    }
+                });
+                writer.writeLine(',');
+            }
+        });
+        writer.writeLine(',');
     }
 
     private generateFieldReadCheckerFunction(

--- a/packages/schema/src/plugins/enhancer/policy/utils.ts
+++ b/packages/schema/src/plugins/enhancer/policy/utils.ts
@@ -199,13 +199,15 @@ export function generateSelectForRules(rules: Expression[], forAuthContext = fal
             }
         } else if (isCollectionPredicate(expr)) {
             const path = visit(expr.left);
+            // recurse into RHS
+            const rhs = collectReferencePaths(expr.right);
             if (path) {
-                // recurse into RHS
-                const rhs = collectReferencePaths(expr.right);
                 // combine path of LHS and RHS
                 return rhs.map((r) => [...path, ...r]);
             } else {
-                return [];
+                // LHS is not rooted from the current model,
+                // only keep RHS items that contains '$this'
+                return rhs.filter((r) => r.includes('$this'));
             }
         } else if (isInvocationExpr(expr)) {
             // recurse into function arguments

--- a/packages/schema/tests/schema/validation/attribute-validation.test.ts
+++ b/packages/schema/tests/schema/validation/attribute-validation.test.ts
@@ -699,7 +699,36 @@ describe('Attribute tests', () => {
             }
             
         `)
-        ).toContain('comparison between fields of different models are not supported');
+        ).toContain('comparison between fields of different models is not supported in "read" rules');
+
+        expect(
+            await loadModel(`
+            ${prelude}
+            model User {
+                id Int @id
+                lists List[]
+                todos Todo[]
+            }
+              
+            model List {
+                id Int @id
+                user User @relation(fields: [userId], references: [id])
+                userId Int
+                todos Todo[]
+            }
+              
+            model Todo {
+                id Int @id
+                user User @relation(fields: [userId], references: [id])
+                userId Int
+                list List @relation(fields: [listId], references: [id])
+                listId Int
+              
+                @@allow('create', list.user.id == userId)
+            }
+            
+        `)
+        ).toBeTruthy();
 
         expect(
             await loadModelWithError(`

--- a/packages/schema/tests/schema/validation/attribute-validation.test.ts
+++ b/packages/schema/tests/schema/validation/attribute-validation.test.ts
@@ -699,7 +699,7 @@ describe('Attribute tests', () => {
             }
             
         `)
-        ).toContain('comparison between fields of different models is not supported in "read" rules');
+        ).toContain('comparison between fields of different models is not supported in model-level "read" rules');
 
         expect(
             await loadModel(`

--- a/packages/schema/tests/schema/validation/datamodel-validation.test.ts
+++ b/packages/schema/tests/schema/validation/datamodel-validation.test.ts
@@ -88,7 +88,7 @@ describe('Data Model Validation Tests', () => {
                 @@allow('all', members?[this == auth()])
             }
         `)
-        ).toMatchObject(errorLike('using `this` in collection predicate is not supported'));
+        ).toBeTruthy();
 
         expect(
             await loadModel(`

--- a/packages/sdk/src/typescript-expression-transformer.ts
+++ b/packages/sdk/src/typescript-expression-transformer.ts
@@ -34,6 +34,7 @@ type Options = {
     isPostGuard?: boolean;
     fieldReferenceContext?: string;
     thisExprContext?: string;
+    futureRefContext?: string;
     context: ExpressionContext;
 };
 
@@ -116,7 +117,9 @@ export class TypeScriptExpressionTransformer {
             if (this.options?.isPostGuard !== true) {
                 throw new TypeScriptExpressionTransformerError(`future() is only supported in postUpdate rules`);
             }
-            return expr.member.ref.name;
+            return this.options.futureRefContext
+                ? `${this.options.futureRefContext}.${expr.member.ref.name}`
+                : expr.member.ref.name;
         } else {
             if (normalizeUndefined) {
                 // normalize field access to null instead of undefined to avoid accidentally use undefined in filter
@@ -449,7 +452,6 @@ export class TypeScriptExpressionTransformer {
             ...this.options,
             isPostGuard: false,
             fieldReferenceContext: '_item',
-            thisExprContext: '_item',
         });
         const predicate = innerTransformer.transform(expr.right, normalizeUndefined);
 

--- a/tests/integration/tests/enhancements/with-policy/cross-model-field-comparison.test.ts
+++ b/tests/integration/tests/enhancements/with-policy/cross-model-field-comparison.test.ts
@@ -1,0 +1,672 @@
+import { loadSchema } from '@zenstackhq/testtools';
+
+describe('Cross-model field comparison', () => {
+    it('to-one relation', async () => {
+        const { prisma, enhance } = await loadSchema(
+            `
+        model User {
+            id Int @id
+            profile Profile @relation(fields: [profileId], references: [id])
+            profileId Int  @unique
+            age Int
+                  
+            @@allow('read', true)
+            @@allow('create,update,delete', age == profile.age)
+            @@deny('update', future().age < future().profile.age && age > 0)
+        }
+        
+        model Profile {
+            id Int @id @default(autoincrement())
+            age Int
+            user User?
+        
+            @@allow('all', true)
+        }
+        `
+        );
+
+        const db = enhance();
+
+        const reset = async () => {
+            await prisma.user.deleteMany();
+            await prisma.profile.deleteMany();
+        };
+
+        // create
+        await expect(
+            db.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 20 } } } })
+        ).toBeRejectedByPolicy();
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).toResolveNull();
+        await expect(
+            db.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 18 } } } })
+        ).toResolveTruthy();
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).toResolveTruthy();
+        await reset();
+
+        // createMany
+        await expect(
+            db.user.createMany({ data: [{ id: 1, age: 18, profile: { create: { id: 1, age: 20 } } }] })
+        ).toBeRejectedByPolicy();
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).toResolveNull();
+        await expect(
+            db.user.createMany({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 18 } } } })
+        ).toResolveTruthy();
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).toResolveTruthy();
+        await reset();
+
+        // TODO: cross-model field comparison is not supported for read rules yet
+        // // read
+        // await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 18 } } } });
+        // await expect(db.user.findUnique({ where: { id: 1 } })).toResolveTruthy();
+        // await expect(db.user.findMany()).resolves.toHaveLength(1);
+        // await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        // await expect(db.user.findUnique({ where: { id: 1 } })).toResolveNull();
+        // await expect(db.user.findMany()).resolves.toHaveLength(0);
+        // await reset();
+
+        // update
+        await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 18 } } } });
+        await expect(db.user.update({ where: { id: 1 }, data: { age: 20 } })).toResolveTruthy();
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).resolves.toMatchObject({ age: 20 });
+        await expect(db.user.update({ where: { id: 1 }, data: { age: 18 } })).toBeRejectedByPolicy();
+        await reset();
+
+        // post update
+        await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 18 } } } });
+        await expect(db.user.update({ where: { id: 1 }, data: { age: 15 } })).toBeRejectedByPolicy();
+        await expect(db.user.update({ where: { id: 1 }, data: { age: 20 } })).toResolveTruthy();
+        await reset();
+
+        // upsert
+        await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 20 } } } });
+        await expect(
+            db.user.upsert({ where: { id: 1 }, create: { id: 1, age: 25 }, update: { age: 25 } })
+        ).toBeRejectedByPolicy();
+        await expect(
+            db.user.upsert({
+                where: { id: 2 },
+                create: { id: 2, age: 18, profile: { create: { age: 25 } } },
+                update: { age: 25 },
+            })
+        ).toBeRejectedByPolicy();
+        await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        await expect(
+            db.user.upsert({ where: { id: 1 }, create: { id: 1, age: 25 }, update: { age: 25 } })
+        ).toResolveTruthy();
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).resolves.toMatchObject({ age: 25 });
+        await expect(
+            db.user.upsert({
+                where: { id: 2 },
+                create: { id: 2, age: 25, profile: { create: { age: 25 } } },
+                update: { age: 25 },
+            })
+        ).toResolveTruthy();
+        await expect(prisma.user.findMany()).resolves.toHaveLength(2);
+        await reset();
+
+        // updateMany
+        await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 20 } } } });
+        // non updatable
+        await expect(db.user.updateMany({ data: { age: 18 } })).resolves.toMatchObject({ count: 0 });
+        await prisma.user.create({ data: { id: 2, age: 25, profile: { create: { id: 2, age: 25 } } } });
+        // one of the two is updatable
+        await expect(db.user.updateMany({ data: { age: 30 } })).resolves.toMatchObject({ count: 1 });
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).resolves.toMatchObject({ age: 18 });
+        await expect(prisma.user.findUnique({ where: { id: 2 } })).resolves.toMatchObject({ age: 30 });
+        await reset();
+
+        // delete
+        await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 20 } } } });
+        await expect(db.user.delete({ where: { id: 1 } })).toBeRejectedByPolicy();
+        await expect(prisma.user.findMany()).resolves.toHaveLength(1);
+        await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        await expect(db.user.delete({ where: { id: 1 } })).toResolveTruthy();
+        await expect(prisma.user.findMany()).resolves.toHaveLength(0);
+        await reset();
+
+        // deleteMany
+        await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 20 } } } });
+        await expect(db.user.deleteMany()).resolves.toMatchObject({ count: 0 });
+        await prisma.user.create({ data: { id: 2, age: 25, profile: { create: { id: 2, age: 25 } } } });
+        // one of the two is deletable
+        await expect(db.user.deleteMany()).resolves.toMatchObject({ count: 1 });
+        await expect(prisma.user.findMany()).resolves.toHaveLength(1);
+    });
+
+    it('nested inside to-one relation', async () => {
+        const { prisma, enhance } = await loadSchema(
+            `
+        model User {
+            id Int @id
+            profile Profile?
+            age Int
+                  
+            @@allow('all', true)
+        }
+        
+        model Profile {
+            id Int @id
+            age Int
+            user User? @relation(fields: [userId], references: [id])
+            userId Int? @unique
+        
+            @@allow('read', true)
+            @@allow('create,update,delete', user == null || age == user.age)
+            @@deny('update', future().user != null && future().age < future().user.age && age > 0)
+        }
+        `
+        );
+
+        const db = enhance();
+
+        const reset = async () => {
+            await prisma.profile.deleteMany();
+            await prisma.user.deleteMany();
+        };
+
+        // create
+        await expect(
+            db.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 20 } } } })
+        ).toBeRejectedByPolicy();
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).toResolveNull();
+        await expect(
+            db.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 18 } } } })
+        ).toResolveTruthy();
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).toResolveTruthy();
+        await reset();
+
+        // TODO: cross-model field comparison is not supported for read rules yet
+        // // read
+        // await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 18 } } } });
+        // await expect(db.user.findUnique({ where: { id: 1 }, include: { profile: true } })).resolves.toMatchObject({
+        //     age: 18,
+        //     profile: expect.objectContaining({ age: 18 }),
+        // });
+        // await expect(db.user.findMany({ include: { profile: true } })).resolves.toEqual(
+        //     expect.arrayContaining([
+        //         expect.objectContaining({
+        //             age: 18,
+        //             profile: expect.objectContaining({ age: 18 }),
+        //         }),
+        //     ])
+        // );
+        // await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        // let r = await db.user.findUnique({ where: { id: 1 }, include: { profile: true } });
+        // expect(r.profile).toBeUndefined();
+        // r = await db.user.findMany({ include: { profile: true } });
+        // expect(r[0].profile).toBeUndefined();
+        // await reset();
+
+        // update
+        await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 18 } } } });
+        await expect(
+            db.user.update({ where: { id: 1 }, data: { profile: { update: { age: 20 } } } })
+        ).toResolveTruthy();
+        let r = await prisma.user.findUnique({ where: { id: 1 }, include: { profile: true } });
+        expect(r.profile).toMatchObject({ age: 20 });
+        await expect(
+            db.user.update({ where: { id: 1 }, data: { profile: { update: { age: 18 } } } })
+        ).toBeRejectedByPolicy();
+        await reset();
+
+        // post update
+        await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 18 } } } });
+        await expect(
+            db.user.update({ where: { id: 1 }, data: { profile: { update: { age: 15 } } } })
+        ).toBeRejectedByPolicy();
+        await expect(
+            db.user.update({ where: { id: 1 }, data: { profile: { update: { age: 20 } } } })
+        ).toResolveTruthy();
+        await reset();
+
+        // upsert
+        await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 20 } } } });
+        await expect(
+            db.user.update({
+                where: { id: 1 },
+                data: {
+                    profile: {
+                        upsert: {
+                            create: { id: 1, age: 25 },
+                            update: { age: 25 },
+                        },
+                    },
+                },
+            })
+        ).toBeRejectedByPolicy();
+        await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        await expect(
+            db.user.update({
+                where: { id: 1 },
+                data: {
+                    profile: {
+                        upsert: {
+                            create: { id: 1, age: 25 },
+                            update: { age: 25 },
+                        },
+                    },
+                },
+            })
+        ).toResolveTruthy();
+        await prisma.user.create({ data: { id: 2, age: 18 } });
+        await expect(
+            db.user.update({
+                where: { id: 2 },
+                data: {
+                    profile: {
+                        upsert: {
+                            create: { id: 2, age: 25 },
+                            update: { age: 25 },
+                        },
+                    },
+                },
+            })
+        ).toBeRejectedByPolicy();
+        await expect(
+            db.user.update({
+                where: { id: 2 },
+                data: {
+                    profile: {
+                        upsert: {
+                            create: { id: 2, age: 18 },
+                            update: { age: 25 },
+                        },
+                    },
+                },
+            })
+        ).toResolveTruthy();
+        await reset();
+
+        // delete
+        await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 20 } } } });
+        await expect(db.user.update({ where: { id: 1 }, data: { profile: { delete: true } } })).toBeRejectedByPolicy();
+        await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        await expect(db.user.update({ where: { id: 1 }, data: { profile: { delete: true } } })).toResolveTruthy();
+        await expect(await prisma.profile.findMany()).toHaveLength(0);
+        await reset();
+
+        // connect/disconnect
+        await prisma.user.create({ data: { id: 1, age: 18, profile: { create: { id: 1, age: 20 } } } });
+        await expect(
+            db.user.update({ where: { id: 1 }, data: { profile: { disconnect: true } } })
+        ).toBeRejectedByPolicy();
+        await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        await expect(db.user.update({ where: { id: 1 }, data: { profile: { disconnect: true } } })).toResolveTruthy();
+        await prisma.user.create({ data: { id: 2, age: 25 } });
+        await expect(
+            db.user.update({ where: { id: 2 }, data: { profile: { connect: { id: 1 } } } })
+        ).toBeRejectedByPolicy();
+        await prisma.user.create({ data: { id: 3, age: 20 } });
+        await expect(db.user.update({ where: { id: 3 }, data: { profile: { connect: { id: 1 } } } })).toResolveTruthy();
+        await expect(prisma.profile.findFirst()).resolves.toMatchObject({ userId: 3 });
+        await reset();
+    });
+
+    it('to-many relation', async () => {
+        const { prisma, enhance } = await loadSchema(
+            `
+        model User {
+            id Int @id
+            profiles Profile[]
+            age Int
+                  
+            @@allow('read', true)
+            @@allow('create,update,delete', profiles![this.age == age])
+            @@deny('update', future().profiles?[this.age < age])
+        }
+        
+        model Profile {
+            id Int @id
+            age Int
+            user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+            userId Int
+        
+            @@allow('all', true)
+        }
+        `,
+            { preserveTsFiles: true }
+        );
+
+        const db = enhance();
+
+        const reset = async () => {
+            await prisma.user.deleteMany();
+        };
+
+        // create
+        await expect(
+            db.user.create({ data: { id: 1, age: 18, profiles: { create: [{ id: 1, age: 20 }] } } })
+        ).toBeRejectedByPolicy();
+        await expect(
+            db.user.create({
+                data: {
+                    id: 1,
+                    age: 18,
+                    profiles: {
+                        createMany: {
+                            data: [
+                                { id: 1, age: 18 },
+                                { id: 2, age: 20 },
+                            ],
+                        },
+                    },
+                },
+            })
+        ).toBeRejectedByPolicy();
+        await expect(
+            db.user.create({ data: { id: 1, age: 18, profiles: { create: [{ id: 1, age: 20 }] } } })
+        ).toBeRejectedByPolicy();
+        await expect(
+            db.user.create({
+                data: {
+                    id: 1,
+                    age: 18,
+                    profiles: {
+                        createMany: {
+                            data: [
+                                { id: 1, age: 18 },
+                                { id: 2, age: 18 },
+                            ],
+                        },
+                    },
+                },
+            })
+        ).toResolveTruthy();
+        await expect(
+            db.user.create({
+                data: { id: 2, age: 18 },
+            })
+        ).toResolveTruthy();
+        await reset();
+
+        // createMany
+        await expect(
+            db.user.createMany({
+                data: [
+                    { id: 1, age: 18, profiles: { create: { id: 1, age: 20 } } },
+                    { id: 2, age: 18, profiles: { create: { id: 2, age: 20 } } },
+                ],
+            })
+        ).toBeRejectedByPolicy();
+        await expect(
+            db.user.createMany({
+                data: [
+                    { id: 1, age: 18, profiles: { create: { id: 1, age: 18 } } },
+                    { id: 2, age: 19, profiles: { create: { id: 2, age: 19 } } },
+                ],
+            })
+        ).resolves.toEqual({ count: 2 });
+        await reset();
+
+        // TODO: cross-model field comparison is not supported for read rules yet
+        // // read
+        // await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 18 } } } });
+        // await expect(db.user.findUnique({ where: { id: 1 } })).toResolveTruthy();
+        // await expect(db.user.findMany()).resolves.toHaveLength(1);
+        // await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        // await expect(db.user.findUnique({ where: { id: 1 } })).toResolveNull();
+        // await expect(db.user.findMany()).resolves.toHaveLength(0);
+        // await reset();
+
+        // update
+        await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 18 } } } });
+        await expect(db.user.update({ where: { id: 1 }, data: { age: 20 } })).toResolveTruthy();
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).resolves.toMatchObject({ age: 20 });
+        await expect(db.user.update({ where: { id: 1 }, data: { age: 18 } })).toBeRejectedByPolicy();
+        await reset();
+
+        // post update
+        await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 18 } } } });
+        await expect(db.user.update({ where: { id: 1 }, data: { age: 15 } })).toBeRejectedByPolicy();
+        await expect(db.user.update({ where: { id: 1 }, data: { age: 20 } })).toResolveTruthy();
+        await reset();
+
+        // upsert
+        await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 20 } } } });
+        await expect(
+            db.user.upsert({ where: { id: 1 }, create: { id: 1, age: 25 }, update: { age: 25 } })
+        ).toBeRejectedByPolicy();
+        await expect(
+            db.user.upsert({
+                where: { id: 2 },
+                create: { id: 2, age: 18, profiles: { create: { id: 2, age: 25 } } },
+                update: { age: 25 },
+            })
+        ).toBeRejectedByPolicy();
+        await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        await expect(
+            db.user.upsert({ where: { id: 1 }, create: { id: 1, age: 25 }, update: { age: 25 } })
+        ).toResolveTruthy();
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).resolves.toMatchObject({ age: 25 });
+        await expect(
+            db.user.upsert({
+                where: { id: 2 },
+                create: { id: 2, age: 25, profiles: { create: { id: 2, age: 25 } } },
+                update: { age: 25 },
+            })
+        ).toResolveTruthy();
+        await expect(prisma.user.findMany()).resolves.toHaveLength(2);
+        await reset();
+
+        // updateMany
+        await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 20 } } } });
+        // non updatable
+        await expect(db.user.updateMany({ data: { age: 18 } })).resolves.toMatchObject({ count: 0 });
+        await prisma.user.create({ data: { id: 2, age: 25, profiles: { create: { id: 2, age: 25 } } } });
+        // one of the two is updatable
+        await expect(db.user.updateMany({ data: { age: 30 } })).resolves.toMatchObject({ count: 1 });
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).resolves.toMatchObject({ age: 18 });
+        await expect(prisma.user.findUnique({ where: { id: 2 } })).resolves.toMatchObject({ age: 30 });
+        await reset();
+
+        // delete
+        await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 20 } } } });
+        await expect(db.user.delete({ where: { id: 1 } })).toBeRejectedByPolicy();
+        await expect(prisma.user.findMany()).resolves.toHaveLength(1);
+        await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        await expect(db.user.delete({ where: { id: 1 } })).toResolveTruthy();
+        await expect(prisma.user.findMany()).resolves.toHaveLength(0);
+        await reset();
+
+        // deleteMany
+        await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 20 } } } });
+        await expect(db.user.deleteMany()).resolves.toMatchObject({ count: 0 });
+        await prisma.user.create({ data: { id: 2, age: 25, profiles: { create: { id: 2, age: 25 } } } });
+        // one of the two is deletable
+        await expect(db.user.deleteMany()).resolves.toMatchObject({ count: 1 });
+        await expect(prisma.user.findMany()).resolves.toHaveLength(1);
+    });
+
+    it('nested inside to-many relation', async () => {
+        const { prisma, enhance } = await loadSchema(
+            `
+        model User {
+            id Int @id
+            profiles Profile[]
+            age Int
+
+            @@allow('all', true)
+        }
+        
+        model Profile {
+            id Int @id
+            age Int
+            user User? @relation(fields: [userId], references: [id])
+            userId Int? @unique
+        
+            @@allow('read', true)
+            @@allow('create,update,delete', user == null || age == user.age)
+            @@deny('update', future().user != null && future().age < future().user.age && age > 0)
+        }
+        `
+        );
+
+        const db = enhance();
+
+        const reset = async () => {
+            await prisma.profile.deleteMany();
+            await prisma.user.deleteMany();
+        };
+
+        // create
+        await expect(
+            db.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 20 } } } })
+        ).toBeRejectedByPolicy();
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).toResolveNull();
+        await expect(
+            db.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 18 } } } })
+        ).toResolveTruthy();
+        await expect(prisma.user.findUnique({ where: { id: 1 } })).toResolveTruthy();
+        await reset();
+
+        // TODO: cross-model field comparison is not supported for read rules yet
+        // // read
+        // await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 18 } } } });
+        // await expect(db.user.findUnique({ where: { id: 1 }, include: { profiles: true } })).resolves.toMatchObject({
+        //     age: 18,
+        //     profiles: [expect.objectContaining({ age: 18 })],
+        // });
+        // await expect(db.user.findMany({ include: { profiles: true } })).resolves.toEqual(
+        //     expect.arrayContaining([
+        //         expect.objectContaining({
+        //             age: 18,
+        //             profiles: [expect.objectContaining({ age: 18 })],
+        //         }),
+        //     ])
+        // );
+        // await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        // let r = await db.user.findUnique({ where: { id: 1 }, include: { profiles: true } });
+        // expect(r.profiles).toHaveLength(0);
+        // r = await db.user.findMany({ include: { profiles: true } });
+        // expect(r[0].profiles).toHaveLength(0);
+        // await reset();
+
+        // update
+        await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 18 } } } });
+        await expect(
+            db.user.update({
+                where: { id: 1 },
+                data: { profiles: { update: { where: { id: 1 }, data: { age: 20 } } } },
+            })
+        ).toResolveTruthy();
+        let r = await prisma.user.findUnique({ where: { id: 1 }, include: { profiles: true } });
+        expect(r.profiles[0]).toMatchObject({ age: 20 });
+        await expect(
+            db.user.update({
+                where: { id: 1 },
+                data: { profiles: { update: { where: { id: 1 }, data: { age: 18 } } } },
+            })
+        ).toBeRejectedByPolicy();
+        await reset();
+
+        // post update
+        await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 18 } } } });
+        await expect(
+            db.user.update({
+                where: { id: 1 },
+                data: { profiles: { update: { where: { id: 1 }, data: { age: 15 } } } },
+            })
+        ).toBeRejectedByPolicy();
+        await expect(
+            db.user.update({
+                where: { id: 1 },
+                data: { profiles: { update: { where: { id: 1 }, data: { age: 20 } } } },
+            })
+        ).toResolveTruthy();
+        await reset();
+
+        // upsert
+        await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 20 } } } });
+        await expect(
+            db.user.update({
+                where: { id: 1 },
+                data: {
+                    profiles: {
+                        upsert: {
+                            where: { id: 1 },
+                            create: { id: 1, age: 25 },
+                            update: { age: 25 },
+                        },
+                    },
+                },
+            })
+        ).toBeRejectedByPolicy();
+        await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        await expect(
+            db.user.update({
+                where: { id: 1 },
+                data: {
+                    profiles: {
+                        upsert: {
+                            where: { id: 1 },
+                            create: { id: 1, age: 25 },
+                            update: { age: 25 },
+                        },
+                    },
+                },
+            })
+        ).toResolveTruthy();
+        await prisma.user.create({ data: { id: 2, age: 18 } });
+        await expect(
+            db.user.update({
+                where: { id: 2 },
+                data: {
+                    profiles: {
+                        upsert: {
+                            where: { id: 2 },
+                            create: { id: 2, age: 25 },
+                            update: { age: 25 },
+                        },
+                    },
+                },
+            })
+        ).toBeRejectedByPolicy();
+        await expect(
+            db.user.update({
+                where: { id: 2 },
+                data: {
+                    profiles: {
+                        upsert: {
+                            where: { id: 2 },
+                            create: { id: 2, age: 18 },
+                            update: { age: 25 },
+                        },
+                    },
+                },
+            })
+        ).toResolveTruthy();
+        await reset();
+
+        // delete
+        await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 20 } } } });
+        await expect(
+            db.user.update({ where: { id: 1 }, data: { profiles: { delete: { id: 1 } } } })
+        ).toBeRejectedByPolicy();
+        await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        await expect(db.user.update({ where: { id: 1 }, data: { profiles: { delete: { id: 1 } } } })).toResolveTruthy();
+        await expect(await prisma.profile.findMany()).toHaveLength(0);
+        await reset();
+
+        // connect/disconnect
+        await prisma.user.create({ data: { id: 1, age: 18, profiles: { create: { id: 1, age: 20 } } } });
+        await expect(
+            db.user.update({ where: { id: 1 }, data: { profiles: { disconnect: { id: 1 } } } })
+        ).toBeRejectedByPolicy();
+        await prisma.user.update({ where: { id: 1 }, data: { age: 20 } });
+        await expect(
+            db.user.update({ where: { id: 1 }, data: { profiles: { disconnect: { id: 1 } } } })
+        ).toResolveTruthy();
+        await prisma.user.create({ data: { id: 2, age: 25 } });
+        await expect(
+            db.user.update({ where: { id: 2 }, data: { profiles: { connect: { id: 1 } } } })
+        ).toBeRejectedByPolicy();
+        await prisma.user.create({ data: { id: 3, age: 20 } });
+        await expect(
+            db.user.update({ where: { id: 3 }, data: { profiles: { connect: { id: 1 } } } })
+        ).toResolveTruthy();
+        await expect(prisma.profile.findFirst()).resolves.toMatchObject({ userId: 3 });
+        await reset();
+    });
+
+    it('field-level', async () => {});
+});

--- a/tests/integration/tests/enhancements/with-policy/field-level-policy.test.ts
+++ b/tests/integration/tests/enhancements/with-policy/field-level-policy.test.ts
@@ -915,6 +915,10 @@ describe('Policy: field-level policy', () => {
                 data: { models: { connect: { id: 1 } } },
             })
         ).toBeRejectedByPolicy();
+        await prisma.user.update({
+            where: { id: 1 },
+            data: { models: { connect: { id: 1 } } },
+        });
         await expect(
             db.user.update({
                 where: { id: 1 },
@@ -1015,6 +1019,10 @@ describe('Policy: field-level policy', () => {
                 data: { model: { connect: { id: 1 } } },
             })
         ).toBeRejectedByPolicy();
+        await prisma.user.update({
+            where: { id: 1 },
+            data: { model: { connect: { id: 1 } } },
+        });
         await expect(
             db.user.update({
                 where: { id: 1 },


### PR DESCRIPTION
- Generate TS checker functions to evaluate rules in JS runtime
- Make sure fields needed in the checker are selected when reading entities

Only supporting mutation rules (create, update, post-update, delete) because:

1. Evaluating read in JS runtime may result in reading lots of rows and then discard
2. Don't know how to support aggregation without reading all rows

Fixes #1463 #786 