### PR TITLE
fix(zod): support `@default` for `BigInt` values

### DIFF
--- a/packages/schema/src/plugins/zod/utils/schema-gen.ts
+++ b/packages/schema/src/plugins/zod/utils/schema-gen.ts
@@ -152,7 +152,13 @@ export function makeFieldSchema(field: DataModelField) {
     } else {
         const schemaDefault = getFieldSchemaDefault(field);
         if (schemaDefault !== undefined) {
-            schema += `.default(${schemaDefault})`;
+            if (field.type.type === 'BigInt') {
+                // we can't use the `n` BigInt literal notation, since it needs
+                // ES2020 or later, which TypeScript doesn't use by default
+                schema += `.default(BigInt("${schemaDefault}"))`;
+            } else {
+                schema += `.default(${schemaDefault})`;
+            }
         }
 
         if (field.type.optional) {

--- a/tests/integration/tests/plugins/zod.test.ts
+++ b/tests/integration/tests/plugins/zod.test.ts
@@ -61,6 +61,7 @@ describe('Zod plugin tests', () => {
             authorId Int?
             published Boolean @default(false)
             viewCount Int @default(0)
+            viewMilliseconds BigInt @default(0)
         }
         `,
             { addPrelude: false, pushDb: false }
@@ -188,11 +189,13 @@ describe('Zod plugin tests', () => {
         expect(schemas.PostPrismaCreateSchema.safeParse({ title: 'a' }).success).toBeFalsy();
         expect(schemas.PostPrismaCreateSchema.safeParse({ title: 'abcde' }).success).toBeTruthy();
         expect(schemas.PostPrismaCreateSchema.safeParse({ viewCount: 1 }).success).toBeTruthy();
+        expect(schemas.PostPrismaCreateSchema.safeParse({ viewMilliseconds: 1n }).success).toBeTruthy();
 
         expect(schemas.PostPrismaUpdateSchema.safeParse({ title: 'a' }).success).toBeFalsy();
         expect(schemas.PostPrismaUpdateSchema.safeParse({ title: 'abcde' }).success).toBeTruthy();
         expect(schemas.PostPrismaUpdateSchema.safeParse({ viewCount: 1 }).success).toBeTruthy();
         expect(schemas.PostPrismaUpdateSchema.safeParse({ viewCount: { increment: 1 } }).success).toBeTruthy();
+        expect(schemas.PostPrismaUpdateSchema.safeParse({ viewMilliseconds: 1n }).success).toBeTruthy();
     });
 
     it('mixed casing', async () => {


### PR DESCRIPTION
Zod schemas fail to generate when using a `BigInt` type and a `@default` field, since the generated Zod `.schema.ts` files use a `number` literal instead of a `BigInt` for the default value.

### Example

Currently, a ZenStack schema like:

```zenstack
model Post {
  viewMilliseconds BigInt @default(0)
}
```

would get converted to the following, which throws a TypeScript error

```ts
const baseSchema = z.object({
    // Argument of type 'number' is not assignable to parameter of type 'bigint'.
    viewMilliseconds: z.bigint().default(0)
});
```

Now, it would instead be converted to:

```ts
const baseSchema = z.object({
    // we're not using .default(0n) since that syntax only works if
    // TypeScript is setup to target ES2020 or later
    viewMilliseconds: z.bigint().default(BigInt("0"))
});
```

## Failing test

```console
user@pc:~/zenstack/tests/integration (dev)$ pnpm exec jest plugins/zod.test.ts
<---SNIP---->
  ● Zod plugin tests › basic generation

    Command failed: npx zenstack generate --no-version-check --no-dependency-check
    WARNING: Multiple versions of Zenstack packages detected. Run "zenstack info" to see details.
    - Generating Prisma schema
    ✔ Generating Prisma schema
    - Generating PrismaClient enhancer
    ✔ Generating PrismaClient enhancer
    - Generating Zod schemas
    ✔ Generating Zod schemas
    Error compiling generated code:
    node_modules/.zenstack/zod/models/Post.schema.ts:9:35 - error TS2769: No overload matches this call.
      Overload 1 of 2, '(def: bigint): ZodDefault<ZodBigInt>', gave the following error.
        Argument of type 'number' is not assignable to parameter of type 'bigint'.
      Overload 2 of 2, '(def: () => bigint): ZodDefault<ZodBigInt>', gave the following error.
        Argument of type 'number' is not assignable to parameter of type '() => bigint'.

    9     viewCount: z.bigint().default(0),
                                        ~

    node_modules/.zenstack/zod/models/Post.schema.ts:50:32 - error TS2769: No overload matches this call.
      Overload 1 of 2, '(def: bigint): ZodDefault<ZodBigInt>', gave the following error.
        Argument of type 'number' is not assignable to parameter of type 'bigint'.
      Overload 2 of 2, '(def: () => bigint): ZodDefault<ZodBigInt>', gave the following error.
        Argument of type 'number' is not assignable to parameter of type '() => bigint'.

    50  viewCount: z.bigint().default(0)
                                      ~


    : Error compiling generated code

      45 | export function run(cmd: string, env?: Record<string, string>, cwd?: string) {
      46 |     try {
    > 47 |         execSync(cmd, {
         |                 ^
      48 |             stdio: 'pipe',
      49 |             encoding: 'utf-8',
      50 |             env: { ...process.env, DO_NOT_TRACK: '1', ...env },

      at run (../../packages/testtools/src/schema.ts:47:17)
      at ../../packages/testtools/src/schema.ts:233:9
      at ../../packages/testtools/dist/schema.js:31:71
      at Object.<anonymous>.__awaiter (../../packages/testtools/dist/schema.js:27:12)
      at loadSchema (../../packages/testtools/dist/schema.js:149:12)
      at Object.<anonymous> (tests/plugins/zod.test.ts:22:48)
```

