### PR TITLE
fix(api): support filtering with comma-separated values in rest handler

### DIFF
--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -1534,7 +1534,16 @@ class RequestHandler extends APIHandlerBase {
                     }
                     return { isEmpty: value === 'true' ? true : false };
                 default:
-                    return op ? { [op]: coerced } : { equals: coerced };
+                    if (op === undefined) {
+                        // regular filter, split value by comma
+                        const values = value
+                            .split(',')
+                            .filter((i) => i)
+                            .map((v) => this.coerce(fieldInfo.type, v));
+                        return values.length > 1 ? { in: values } : { equals: values[0] };
+                    } else {
+                        return { [op]: coerced };
+                    }
             }
         }
     }

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -368,6 +368,16 @@ describe('REST server tests', () => {
                     expect(r.body.data).toHaveLength(1);
                     expect(r.body.data[0]).toMatchObject({ id: 'user2' });
 
+                    // multi-id filter
+                    r = await handler({
+                        method: 'get',
+                        path: '/user',
+                        query: { ['filter[id]']: 'user1,user2' },
+                        prisma,
+                    });
+                    expect(r.status).toBe(200);
+                    expect(r.body.data).toHaveLength(2);
+
                     // String filter
                     r = await handler({
                         method: 'get',


### PR DESCRIPTION
Fixes #1573