### PR TITLE
fix(zmodel): fields from base model cannot be accessed from `future().`

### DIFF
--- a/packages/schema/src/language-server/zmodel-scope.ts
+++ b/packages/schema/src/language-server/zmodel-scope.ts
@@ -204,7 +204,7 @@ export class ZModelScopeProvider extends DefaultScopeProvider {
     private createScopeForContainingModel(node: AstNode, globalScope: Scope) {
         const model = getContainerOfType(node, isDataModel);
         if (model) {
-            return this.createScopeForNodes(model.fields, globalScope);
+            return this.createScopeForModel(model, globalScope);
         } else {
             return EMPTY_SCOPE;
         }

--- a/tests/regression/tests/issue-1695.test.ts
+++ b/tests/regression/tests/issue-1695.test.ts
@@ -1,0 +1,21 @@
+import { loadModel } from '@zenstackhq/testtools';
+
+describe('issue 1695', () => {
+    it('regression', async () => {
+        await loadModel(
+            `
+            abstract model SoftDelete {
+                deleted Int @default(0) @omit
+            }
+
+            model MyModel extends SoftDelete {
+                id      String @id @default(cuid())
+                name    String
+
+                @@deny('update', deleted != 0 && future().deleted != 0)
+                @@deny('read', this.deleted != 0)
+            }
+            `
+        );
+    });
+});


### PR DESCRIPTION
Fixes #1695