### PR TITLE
fix: generated code fails to compile when prisma's output path overlaps with zenstack

### DIFF
--- a/packages/schema/src/plugins/enhancer/enhance/index.ts
+++ b/packages/schema/src/plugins/enhancer/enhance/index.ts
@@ -8,6 +8,7 @@ import {
     getLiteral,
     isDelegateModel,
     isDiscriminatorField,
+    normalizedRelative,
     type PluginOptions,
 } from '@zenstackhq/sdk';
 import {
@@ -159,7 +160,7 @@ ${
         const zodAbsPath = path.isAbsolute(zodCustomOutput)
             ? zodCustomOutput
             : path.resolve(schemaDir, zodCustomOutput);
-        return path.relative(this.outDir, zodAbsPath) || '.';
+        return normalizedRelative(this.outDir, zodAbsPath);
     }
 
     private createSimplePrismaImports(prismaImport: string) {

--- a/packages/schema/src/plugins/enhancer/index.ts
+++ b/packages/schema/src/plugins/enhancer/index.ts
@@ -1,4 +1,11 @@
-import { PluginError, RUNTIME_PACKAGE, createProject, resolvePath, type PluginFunction } from '@zenstackhq/sdk';
+import {
+    PluginError,
+    RUNTIME_PACKAGE,
+    createProject,
+    normalizedRelative,
+    resolvePath,
+    type PluginFunction,
+} from '@zenstackhq/sdk';
 import path from 'path';
 import { getDefaultOutputFolder } from '../plugin-utils';
 import { EnhancerGenerator } from './enhance';
@@ -31,7 +38,7 @@ const run: PluginFunction = async (model, options, _dmmf, globalOptions) => {
             const prismaClientPathAbs = path.resolve(outDir, 'models');
 
             // resolve it relative to the schema path
-            prismaClientPath = path.relative(path.dirname(options.schemaPath), prismaClientPathAbs);
+            prismaClientPath = normalizedRelative(path.dirname(options.schemaPath), prismaClientPathAbs);
         } else {
             prismaClientPath = `${RUNTIME_PACKAGE}/models`;
         }

--- a/packages/schema/src/plugins/prisma/index.ts
+++ b/packages/schema/src/plugins/prisma/index.ts
@@ -1,4 +1,11 @@
-import { PluginError, type PluginFunction, type PluginOptions, getLiteral, resolvePath } from '@zenstackhq/sdk';
+import {
+    PluginError,
+    type PluginFunction,
+    type PluginOptions,
+    getLiteral,
+    normalizedRelative,
+    resolvePath,
+} from '@zenstackhq/sdk';
 import { GeneratorDecl, isGeneratorDecl } from '@zenstackhq/sdk/ast';
 import { getDMMF } from '@zenstackhq/sdk/prisma';
 import colors from 'colors';
@@ -59,7 +66,7 @@ const run: PluginFunction = async (model, options, _dmmf, _globalOptions) => {
                 const absPath = path.resolve(path.dirname(output), clientOutput);
 
                 // then make it relative to the zmodel schema location
-                prismaClientPath = path.relative(path.dirname(options.schemaPath), absPath);
+                prismaClientPath = normalizedRelative(path.dirname(options.schemaPath), absPath);
             }
         }
     } else {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,6 +2,7 @@ export * from './code-gen';
 export * from './constants';
 export { generate as generateModelMeta } from './model-meta-generator';
 export * from './names';
+export * from './path';
 export * from './policy';
 export * from './types';
 export * from './typescript-expression-transformer';

--- a/packages/sdk/src/path.ts
+++ b/packages/sdk/src/path.ts
@@ -1,0 +1,9 @@
+import path from 'path';
+
+/**
+ * Gets the relative path from `from` to `to` and normalizes it to start it with `./`
+ */
+export function normalizedRelative(from: string, to: string) {
+    const result = path.relative(from, to);
+    return result.startsWith('.') ? result : `./${result}`;
+}

--- a/packages/sdk/src/prisma.ts
+++ b/packages/sdk/src/prisma.ts
@@ -9,6 +9,7 @@ import { Model } from './ast';
 import { RUNTIME_PACKAGE } from './constants';
 import type { PluginOptions } from './types';
 import { getDataSourceProvider } from './utils';
+import { normalizedRelative } from './path';
 
 /**
  * Given an import context directory and plugin options, compute the import spec for the Prisma Client.
@@ -34,12 +35,11 @@ export function getPrismaClientImportSpec(importingFromDir: string, options: Plu
     const resolvedPrismaClientOutput = path.resolve(path.dirname(options.schemaPath), options.prismaClientPath);
 
     // translate to path relative to the importing context directory
-    let result = path.relative(importingFromDir, resolvedPrismaClientOutput);
+    let result = normalizedRelative(importingFromDir, resolvedPrismaClientOutput);
 
     // remove leading `node_modules` (which may be provided by the user)
     result = result.replace(/^([./\\]*)?node_modules\//, '');
 
-    // compute prisma client absolute output dir relative to the importing file
     return normalizePath(result);
 }
 

--- a/tests/regression/tests/issue-1743.test.ts
+++ b/tests/regression/tests/issue-1743.test.ts
@@ -1,0 +1,34 @@
+import { loadSchema } from '@zenstackhq/testtools';
+describe('issue 1743', () => {
+    it('regression', async () => {
+        await loadSchema(
+            `
+            generator client {
+                provider = "prisma-client-js"
+                output = '../lib/zenstack/prisma'
+            }
+
+            datasource db {
+                provider = "sqlite"
+                url      = "file:./dev.db"
+            }
+
+            plugin enhancer {
+                provider = '@core/enhancer'
+                output = './lib/zenstack'
+                compile = false
+            }
+            
+            model User {
+                id Int @id
+            }
+            `,
+            {
+                addPrelude: false,
+                compile: true,
+                output: './lib/zenstack',
+                prismaLoadPath: './lib/zenstack/prisma',
+            }
+        );
+    });
+});


### PR DESCRIPTION
Fixes #1743