### PR TITLE
fix: generated prisma schema contains error when using "@@unique" with base field

### DIFF
--- a/tests/regression/tests/issue-1758.test.ts
+++ b/tests/regression/tests/issue-1758.test.ts
@@ -1,0 +1,29 @@
+import { loadModelWithError } from '@zenstackhq/testtools';
+
+describe('issue 1758', () => {
+    it('regression', async () => {
+        await expect(
+            loadModelWithError(
+                `
+            model Organization {
+                id       String @id @default(cuid())
+                contents Content[] @relation("OrganizationContents")
+            }
+
+            model Content {
+                id             String @id @default(cuid())
+                contentType    String
+                organization   Organization @relation("OrganizationContents", fields: [organizationId], references: [id])
+                organizationId String
+                @@delegate(contentType)
+            }
+
+            model Store extends Content {
+                name      String
+                @@unique([organizationId, name])
+            }
+            `
+            )
+        ).resolves.toContain('Cannot use fields inherited from a polymorphic base model in `@@unique`');
+    });
+});


### PR DESCRIPTION
Fixes #1758