### PR TITLE
Mark openapi attributes as required for reads

### DIFF
--- a/packages/plugins/openapi/src/rest-generator.ts
+++ b/packages/plugins/openapi/src/rest-generator.ts
@@ -875,7 +875,7 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
                 ) {
                     required.push(field.name);
                 } else if (mode === 'read') {
-                    // Until we support sparse fieldsets, all fields are required for read
+                    // Until we support sparse fieldsets, all fields are required for read operations
                     required.push(field.name);
                 }
             }

--- a/packages/plugins/openapi/src/rest-generator.ts
+++ b/packages/plugins/openapi/src/rest-generator.ts
@@ -874,6 +874,9 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
                     !(isDataModel(field.$resolvedType?.decl) && field.type.array)
                 ) {
                     required.push(field.name);
+                } else if (mode === 'read') {
+                    // Until we support sparse fieldsets, all fields are required for read
+                    required.push(field.name);
                 }
             }
         }

--- a/packages/plugins/openapi/tests/baseline/rest-3.0.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-3.0.0.baseline.yaml
@@ -2591,6 +2591,11 @@ components:
                             type: string
                         role:
                             $ref: '#/components/schemas/role'
+                    required:
+                        - createdAt
+                        - updatedAt
+                        - email
+                        - role
                 relationships:
                     type: object
                     properties:
@@ -2761,6 +2766,9 @@ components:
                             nullable: true
                         userId:
                             type: string
+                    required:
+                        - image
+                        - userId
                 relationships:
                     type: object
                     properties:
@@ -2919,6 +2927,14 @@ components:
                         notes:
                             type: string
                             nullable: true
+                    required:
+                        - createdAt
+                        - updatedAt
+                        - title
+                        - authorId
+                        - published
+                        - viewCount
+                        - notes
                 relationships:
                     type: object
                     properties:
@@ -3099,6 +3115,9 @@ components:
                             type: string
                         userId:
                             type: string
+                    required:
+                        - postId
+                        - userId
                 relationships:
                     type: object
                     properties:

--- a/packages/plugins/openapi/tests/baseline/rest-3.1.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-3.1.0.baseline.yaml
@@ -2596,6 +2596,11 @@ components:
                             type: string
                         role:
                             $ref: '#/components/schemas/role'
+                    required:
+                        - createdAt
+                        - updatedAt
+                        - email
+                        - role
                 relationships:
                     type: object
                     properties:
@@ -2767,6 +2772,9 @@ components:
                                 - type: string
                         userId:
                             type: string
+                    required:
+                        - image
+                        - userId
                 relationships:
                     type: object
                     properties:
@@ -2929,6 +2937,14 @@ components:
                             oneOf:
                                 - type: 'null'
                                 - type: string
+                    required:
+                        - createdAt
+                        - updatedAt
+                        - title
+                        - authorId
+                        - published
+                        - viewCount
+                        - notes
                 relationships:
                     type: object
                     properties:
@@ -3113,6 +3129,9 @@ components:
                             type: string
                         userId:
                             type: string
+                    required:
+                        - postId
+                        - userId
                 relationships:
                     type: object
                     properties:


### PR DESCRIPTION
Fixes #1744 by marking all fields as required for read requests. This allows for more accurate documentation and better type safety for generated clients, until sparse fieldsets are implemented.