### PR TITLE
feat: create Zod's `default` function for entity's booleans

### DIFF
--- a/packages/schema/src/plugins/zod/utils/schema-gen.ts
+++ b/packages/schema/src/plugins/zod/utils/schema-gen.ts
@@ -20,6 +20,7 @@ import {
     isInvocationExpr,
     isNumberLiteral,
     isStringLiteral,
+    isBooleanLiteral
 } from '@zenstackhq/sdk/ast';
 import { upperCaseFirst } from 'upper-case-first';
 import { name } from '..';
@@ -281,6 +282,8 @@ export function getFieldSchemaDefault(field: DataModelField) {
         if (isStringLiteral(arg.value)) {
             return JSON.stringify(arg.value.value);
         } else if (isNumberLiteral(arg.value)) {
+            return arg.value.value;
+        } else if (isBooleanLiteral(arg.value)) {
             return arg.value.value;
         } else if (
             isInvocationExpr(arg.value) &&


### PR DESCRIPTION
I'm using [Superforms](https://superforms.rocks/default-values#default-values) in my Svelte project and it use the `default` function from the Zod schema to fulfill the default value of the form.

It was not implemented in the Zod plugin, so here is my PR !