### PR TITLE
Configurable REST API id divider

### DIFF
--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -47,10 +47,11 @@ export type Options = {
     idDivider?: string;
 
     /**
-     * The charset used for URL segment values. Defaults to `a-zA-Z0-9-_~ %`.
-     * If the idDivider is set to a different value, it should be included in the charset.
+     * The charset used for URL segment values. Defaults to `a-zA-Z0-9-_~ %`. You can change it if your entity's ID values
+     * allow different characters. Specifically, if your models use compound IDs and the idDivider is set to a different value,
+     * it should be included in the charset.
      */
-    urlSegmentNameCharset?: string;
+    urlSegmentCharset?: string;
 };
 
 type RelationshipInfo = {
@@ -219,7 +220,7 @@ class RequestHandler extends APIHandlerBase {
     constructor(private readonly options: Options) {
         super();
         this.idDivider = options.idDivider ?? prismaIdDivider;
-        const segmentCharset = options.urlSegmentNameCharset ?? 'a-zA-Z0-9-_~ %';
+        const segmentCharset = options.urlSegmentCharset ?? 'a-zA-Z0-9-_~ %';
         this.urlPatterns = this.buildUrlPatterns(this.idDivider, segmentCharset);
     }
 

--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -45,6 +45,12 @@ export type Options = {
      * Defaults to '_'.
      */
     idDivider?: string;
+
+    /**
+     * The charset used for URL segment values. Defaults to `a-zA-Z0-9-_~ %`.
+     * If the idDivider is set to a different value, it should be included in the charset.
+     */
+    urlSegmentNameCharset?: string;
 };
 
 type RelationshipInfo = {
@@ -202,18 +208,21 @@ class RequestHandler extends APIHandlerBase {
 
     // all known types and their metadata
     private typeMap: Record<string, ModelInfo>;
-    public idDivider;
+
+    // divider used to separate compound ID fields
+    private idDivider;
 
     private urlPatterns;
 
     constructor(private readonly options: Options) {
         super();
         this.idDivider = options.idDivider ?? '_';
-        this.urlPatterns = this.buildUrlPatterns(this.idDivider);
+        const segmentCharset = options.urlSegmentNameCharset ?? 'a-zA-Z0-9-_~ %';
+        this.urlPatterns = this.buildUrlPatterns(this.idDivider, segmentCharset);
     }
 
-    buildUrlPatterns(idDivider: string) {
-        const options = { segmentValueCharset: `a-zA-Z0-9-_~ %${idDivider}` };
+    buildUrlPatterns(idDivider: string, urlSegmentNameCharset: string) {
+        const options = { segmentValueCharset: urlSegmentNameCharset };
         return {
             // collection operations
             collection: new UrlPattern('/:type', options),

--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -33,8 +33,6 @@ const urlPatterns = {
     relationship: new UrlPattern('/:type/:id/relationships/:relationship'),
 };
 
-export const idDivider = '_';
-
 /**
  * Request handler options
  */
@@ -52,6 +50,12 @@ export type Options = {
      * Defaults to 100. Set to Infinity to disable pagination.
      */
     pageSize?: number;
+
+    /**
+     * The divider used to separate compound ID fields in the URL.
+     * Defaults to '_'.
+     */
+    idDivider?: string;
 };
 
 type RelationshipInfo = {
@@ -209,9 +213,11 @@ class RequestHandler extends APIHandlerBase {
 
     // all known types and their metadata
     private typeMap: Record<string, ModelInfo>;
+    public idDivider;
 
     constructor(private readonly options: Options) {
         super();
+        this.idDivider = options.idDivider ?? '_';
     }
 
     async handleRequest({
@@ -1110,7 +1116,7 @@ class RequestHandler extends APIHandlerBase {
         if (ids.length === 0) {
             return undefined;
         } else {
-            return data[ids.map((id) => id.name).join(idDivider)];
+            return data[ids.map((id) => id.name).join(this.idDivider)];
         }
     }
 
@@ -1211,10 +1217,10 @@ class RequestHandler extends APIHandlerBase {
             return { [idFields[0].name]: this.coerce(idFields[0].type, resourceId) };
         } else {
             return {
-                [idFields.map((idf) => idf.name).join(idDivider)]: idFields.reduce(
+                [idFields.map((idf) => idf.name).join(this.idDivider)]: idFields.reduce(
                     (acc, curr, idx) => ({
                         ...acc,
-                        [curr.name]: this.coerce(curr.type, resourceId.split(idDivider)[idx]),
+                        [curr.name]: this.coerce(curr.type, resourceId.split(this.idDivider)[idx]),
                     }),
                     {}
                 ),
@@ -1230,11 +1236,11 @@ class RequestHandler extends APIHandlerBase {
     }
 
     private makeIdKey(idFields: FieldInfo[]) {
-        return idFields.map((idf) => idf.name).join(idDivider);
+        return idFields.map((idf) => idf.name).join(this.idDivider);
     }
 
     private makeCompoundId(idFields: FieldInfo[], item: any) {
-        return idFields.map((idf) => item[idf.name]).join(idDivider);
+        return idFields.map((idf) => item[idf.name]).join(this.idDivider);
     }
 
     private includeRelationshipIds(model: string, args: any, mode: 'select' | 'include') {

--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -92,6 +92,8 @@ const FilterOperations = [
 
 type FilterOperationType = (typeof FilterOperations)[number] | undefined;
 
+const prismaIdDivider = '_';
+
 registerCustomSerializers();
 
 /**
@@ -216,7 +218,7 @@ class RequestHandler extends APIHandlerBase {
 
     constructor(private readonly options: Options) {
         super();
-        this.idDivider = options.idDivider ?? '_';
+        this.idDivider = options.idDivider ?? prismaIdDivider;
         const segmentCharset = options.urlSegmentNameCharset ?? 'a-zA-Z0-9-_~ %';
         this.urlPatterns = this.buildUrlPatterns(this.idDivider, segmentCharset);
     }
@@ -1131,7 +1133,7 @@ class RequestHandler extends APIHandlerBase {
         if (ids.length === 0) {
             return undefined;
         } else {
-            return data[ids.map((id) => id.name).join(this.idDivider)];
+            return data[this.makeIdKey(ids)];
         }
     }
 
@@ -1233,7 +1235,7 @@ class RequestHandler extends APIHandlerBase {
         } else {
             return {
                 // TODO: support `@@id` with custom name
-                [idFields.map((idf) => idf.name).join('_')]: idFields.reduce(
+                [idFields.map((idf) => idf.name).join(prismaIdDivider)]: idFields.reduce(
                     (acc, curr, idx) => ({
                         ...acc,
                         [curr.name]: this.coerce(curr.type, resourceId.split(this.idDivider)[idx]),
@@ -1257,7 +1259,7 @@ class RequestHandler extends APIHandlerBase {
 
     private makePrismaIdKey(idFields: FieldInfo[]) {
         // TODO: support `@@id` with custom name
-        return idFields.map((idf) => idf.name).join('_');
+        return idFields.map((idf) => idf.name).join(prismaIdDivider);
     }
 
     private makeCompoundId(idFields: FieldInfo[], item: any) {

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -2561,7 +2561,7 @@ describe('REST server tests', () => {
         });
 
         afterAll(async () => {
-            dropPostgresDb(dbName);
+            await dropPostgresDb(dbName);
         });
 
         it('POST', async () => {

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -5,7 +5,9 @@ import { CrudFailureReason, type ModelMeta } from '@zenstackhq/runtime';
 import { loadSchema, run } from '@zenstackhq/testtools';
 import { Decimal } from 'decimal.js';
 import SuperJSON from 'superjson';
-import makeHandler, { idDivider } from '../../src/api/rest';
+import makeHandler from '../../src/api/rest';
+
+const idDivider = '_';
 
 describe('REST server tests', () => {
     let prisma: any;
@@ -83,7 +85,7 @@ describe('REST server tests', () => {
             zodSchemas = params.zodSchemas;
             modelMeta = params.modelMeta;
 
-            const _handler = makeHandler({ endpoint: 'http://localhost/api', pageSize: 5 });
+            const _handler = makeHandler({ endpoint: 'http://localhost/api', pageSize: 5, idDivider });
             handler = (args) =>
                 _handler({ ...args, zodSchemas, modelMeta, url: new URL(`http://localhost/${args.path}`) });
         });

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -2532,6 +2532,7 @@ describe('REST server tests', () => {
     model User {
         email String
         role Role
+        enabled Boolean @default(true)
 
         @@id([email, role])
     }
@@ -2553,7 +2554,7 @@ describe('REST server tests', () => {
                 endpoint: 'http://localhost/api',
                 pageSize: 5,
                 idDivider,
-                urlSegmentNameCharset: 'a-zA-Z0-9-_~ %@.',
+                urlSegmentNameCharset: 'a-zA-Z0-9-_~ %@.:',
             });
             handler = (args) =>
                 _handler({ ...args, zodSchemas, modelMeta, url: new URL(`http://localhost/${args.path}`) });
@@ -2624,13 +2625,14 @@ describe('REST server tests', () => {
                 requestBody: {
                     data: {
                         type: 'user',
-                        attributes: { role: 'ADMIN_USER' },
+                        attributes: { enabled: false },
                     },
                 },
                 prisma,
             });
 
             expect(r.status).toBe(200);
+            expect(r.body.data.attributes.enabled).toBe(false);
         });
     });
 });

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -2549,7 +2549,12 @@ describe('REST server tests', () => {
             zodSchemas = params.zodSchemas;
             modelMeta = params.modelMeta;
 
-            const _handler = makeHandler({ endpoint: 'http://localhost/api', pageSize: 5, idDivider });
+            const _handler = makeHandler({
+                endpoint: 'http://localhost/api',
+                pageSize: 5,
+                idDivider,
+                urlSegmentNameCharset: 'a-zA-Z0-9-_~ %@.',
+            });
             handler = (args) =>
                 _handler({ ...args, zodSchemas, modelMeta, url: new URL(`http://localhost/${args.path}`) });
         });

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -2561,6 +2561,9 @@ describe('REST server tests', () => {
         });
 
         afterAll(async () => {
+            if (prisma) {
+                await prisma.$disconnect();
+            }
             await dropPostgresDb(dbName);
         });
 

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -2554,7 +2554,7 @@ describe('REST server tests', () => {
                 endpoint: 'http://localhost/api',
                 pageSize: 5,
                 idDivider,
-                urlSegmentNameCharset: 'a-zA-Z0-9-_~ %@.:',
+                urlSegmentCharset: 'a-zA-Z0-9-_~ %@.:',
             });
             handler = (args) =>
                 _handler({ ...args, zodSchemas, modelMeta, url: new URL(`http://localhost/${args.path}`) });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,7 +706,7 @@ importers:
         version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.9)
       '@nestjs/testing':
         specifier: ^10.3.7
-        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.9))
+        version: 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.9)(@nestjs/platform-express@10.3.9)
       '@sveltejs/kit':
         specifier: 1.21.0
         version: 1.21.0(svelte@4.2.18)(vite@5.3.2(@types/node@20.14.9)(terser@5.31.1))
@@ -3986,7 +3986,7 @@ packages:
     engines: {node: '>= 14'}
 
   concat-map@0.0.1:
-    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -4424,7 +4424,7 @@ packages:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
-    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   electron-to-chromium@1.4.814:
     resolution: {integrity: sha512-GVulpHjFu1Y9ZvikvbArHmAhZXtm3wHlpjTMcXNGKl4IQ4jMQjlnz8yMQYYqdLHKi/jEL2+CBC2akWVCoIGUdw==}
@@ -6100,7 +6100,7 @@ packages:
     resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
 
   media-typer@0.3.0:
-    resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
   merge-descriptors@1.0.1:
@@ -8260,7 +8260,7 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   utils-merge@1.0.1:
-    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
   uuid@10.0.0:
@@ -10080,7 +10080,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/testing@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.9))':
+  '@nestjs/testing@10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.3.9)(@nestjs/platform-express@10.3.9)':
     dependencies:
       '@nestjs/common': 10.3.9(reflect-metadata@0.2.2)(rxjs@7.8.1)
       '@nestjs/core': 10.3.9(@nestjs/common@10.3.9(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.3.9)(encoding@0.1.13)(reflect-metadata@0.2.2)(rxjs@7.8.1)


### PR DESCRIPTION
Make id divider in the REST API generator configurable, in case the values contain the default `_` divider.