### PR TITLE
Include relationships in REST result from creates and updates

### DIFF
--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -799,6 +799,9 @@ class RequestHandler extends APIHandlerBase {
             }
         }
 
+        // include IDs of relation fields so that they can be serialized.
+        this.includeRelationshipIds(type, createPayload, 'include');
+
         const entity = await prisma[type].create(createPayload);
         return {
             status: 201,
@@ -971,7 +974,6 @@ class RequestHandler extends APIHandlerBase {
         }
 
         // include IDs of relation fields so that they can be serialized.
-        // This ensures valid relationships are included in the result payload.
         this.includeRelationshipIds(type, updatePayload, 'include');
 
         const entity = await prisma[type].update(updatePayload);

--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -970,6 +970,10 @@ class RequestHandler extends APIHandlerBase {
             }
         }
 
+        // include IDs of relation fields so that they can be serialized.
+        // This ensures valid relationships are included in the result payload.
+        this.includeRelationshipIds(type, updatePayload, 'include');
+
         const entity = await prisma[type].update(updatePayload);
         return {
             status: 200,

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -305,6 +305,40 @@ describe('REST server tests', () => {
                     });
                 });
 
+                it('returns an empty data array when loading empty related resources', async () => {
+                    // Create a user first
+                    await prisma.user.create({
+                        data: { myId: 'user1', email: 'user1@abc.com' },
+                    });
+
+                    const r = await handler({
+                        method: 'get',
+                        path: '/user/user1',
+                        prisma,
+                    });
+
+                    expect(r.status).toBe(200);
+                    expect(r.body).toMatchObject({
+                        data: {
+                            type: 'user',
+                            id: 'user1',
+                            attributes: { email: 'user1@abc.com' },
+                            links: {
+                                self: 'http://localhost/api/user/user1',
+                            },
+                            relationships: {
+                                posts: {
+                                    links: {
+                                        self: 'http://localhost/api/user/user1/relationships/posts',
+                                        related: 'http://localhost/api/user/user1/posts',
+                                    },
+                                    data: [],
+                                },
+                            },
+                        },
+                    });
+                });
+
                 it('fetches a related resource with a compound ID', async () => {
                     await prisma.user.create({
                         data: {
@@ -1779,6 +1813,54 @@ describe('REST server tests', () => {
                                         { type: 'post', id: 1 },
                                         { type: 'post', id: 2 },
                                     ],
+                                },
+                            },
+                        },
+                    });
+                });
+
+                it("returns an empty data list in relationships if it's empty", async () => {
+                    await prisma.user.create({
+                        data: {
+                            myId: 'user1',
+                            email: 'user1@abc.com',
+                        },
+                    });
+
+                    const r = await handler({
+                        method: 'put',
+                        path: '/user/user1',
+                        query: {},
+                        requestBody: {
+                            data: {
+                                type: 'user',
+                                attributes: { email: 'user2@abc.com' },
+                            },
+                        },
+                        prisma,
+                    });
+
+                    expect(r.status).toBe(200);
+                    expect(r.body).toMatchObject({
+                        links: {
+                            self: 'http://localhost/api/user/user1',
+                        },
+                        data: {
+                            type: 'user',
+                            id: 'user1',
+                            attributes: {
+                                email: 'user2@abc.com',
+                            },
+                            links: {
+                                self: 'http://localhost/api/user/user1',
+                            },
+                            relationships: {
+                                posts: {
+                                    links: {
+                                        self: 'http://localhost/api/user/user1/relationships/posts',
+                                        related: 'http://localhost/api/user/user1/posts',
+                                    },
+                                    data: [],
                                 },
                             },
                         },

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -1461,7 +1461,21 @@ describe('REST server tests', () => {
                     expect(r.status).toBe(201);
                     expect(r.body).toMatchObject({
                         jsonapi: { version: '1.1' },
-                        data: { type: 'user', id: 'user1', attributes: { email: 'user1@abc.com' } },
+                        data: {
+                            type: 'user',
+                            id: 'user1',
+                            attributes: { email: 'user1@abc.com' },
+                            relationships: {
+                                posts: {
+                                    links: {
+                                        self: 'http://localhost/api/user/user1/relationships/posts',
+                                        related: 'http://localhost/api/user/user1/posts',
+                                    },
+                                    data: [],
+                                },
+                            },
+                            links: { self: 'http://localhost/api/user/user1' },
+                        },
                     });
                 });
 


### PR DESCRIPTION
Here are two test cases: For GET requests, we do get the expected empty data array in the relationship response. However, in the response of a PUT request, the data array is missing and the test fails before the included change.