### PR TITLE
Improve working with entities related to entities that uses compound ids

### DIFF
--- a/packages/plugins/openapi/src/rest-generator.ts
+++ b/packages/plugins/openapi/src/rest-generator.ts
@@ -847,7 +847,8 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
 
     private generateModelEntity(model: DataModel, mode: 'read' | 'create' | 'update'): OAPI.SchemaObject {
         const idFields = model.fields.filter((f) => isIdField(f));
-        // For compound ids, each component is also exposed as a separate fields for read operations
+        // For compound ids each component is also exposed as a separate fields for read operations,
+        // but not required for write operations
         const fields =
             idFields.length > 1 && mode === 'read' ? model.fields : model.fields.filter((f) => !isIdField(f));
 

--- a/packages/plugins/openapi/src/rest-generator.ts
+++ b/packages/plugins/openapi/src/rest-generator.ts
@@ -847,8 +847,9 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
 
     private generateModelEntity(model: DataModel, mode: 'read' | 'create' | 'update'): OAPI.SchemaObject {
         const idFields = model.fields.filter((f) => isIdField(f));
-        // For compound ids, each component is also exposed as a separate field
-        const fields = idFields.length > 1 ? model.fields : model.fields.filter((f) => !isIdField(f));
+        // For compound ids, each component is also exposed as a separate fields for read operations
+        const fields =
+            idFields.length > 1 && mode === 'read' ? model.fields : model.fields.filter((f) => !isIdField(f));
 
         const attributes: Record<string, OAPI.SchemaObject> = {};
         const relationships: Record<string, OAPI.ReferenceObject | OAPI.SchemaObject> = {};

--- a/packages/plugins/openapi/tests/baseline/rest-3.0.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-3.0.0.baseline.yaml
@@ -3143,14 +3143,6 @@ components:
                             type: string
                         attributes:
                             type: object
-                            required:
-                                - postId
-                                - userId
-                            properties:
-                                postId:
-                                    type: string
-                                userId:
-                                    type: string
                         relationships:
                             type: object
                             properties:
@@ -3178,13 +3170,6 @@ components:
                             type: string
                         type:
                             type: string
-                        attributes:
-                            type: object
-                            properties:
-                                postId:
-                                    type: string
-                                userId:
-                                    type: string
                         relationships:
                             type: object
                             properties:

--- a/packages/plugins/openapi/tests/baseline/rest-3.1.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-3.1.0.baseline.yaml
@@ -3155,16 +3155,6 @@ components:
                     properties:
                         type:
                             type: string
-                        attributes:
-                            type: object
-                            required:
-                                - postId
-                                - userId
-                            properties:
-                                postId:
-                                    type: string
-                                userId:
-                                    type: string
                         relationships:
                             type: object
                             properties:
@@ -3192,13 +3182,6 @@ components:
                             type: string
                         type:
                             type: string
-                        attributes:
-                            type: object
-                            properties:
-                                postId:
-                                    type: string
-                                userId:
-                                    type: string
                         relationships:
                             type: object
                             properties:

--- a/packages/schema/src/plugins/zod/generator.ts
+++ b/packages/schema/src/plugins/zod/generator.ts
@@ -10,6 +10,7 @@ import {
     isEnumFieldReference,
     isForeignKeyField,
     isFromStdlib,
+    isIdField,
     parseOptionAsStrings,
     resolvePath,
 } from '@zenstackhq/sdk';
@@ -291,8 +292,10 @@ export class ZodSchemaGenerator {
         sf.replaceWithText((writer) => {
             const scalarFields = model.fields.filter(
                 (field) =>
+                    // id fields are always included
+                    isIdField(field) ||
                     // regular fields only
-                    !isDataModel(field.type.reference?.ref) && !isForeignKeyField(field)
+                    (!isDataModel(field.type.reference?.ref) && !isForeignKeyField(field))
             );
 
             const relations = model.fields.filter((field) => isDataModel(field.type.reference?.ref));

--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -723,7 +723,7 @@ class RequestHandler extends APIHandlerBase {
         if (parsed.data.relationships) {
             for (const [key, data] of Object.entries<any>(parsed.data.relationships)) {
                 const typeInfo = this.typeMap[key];
-                if (typeInfo.idFields.length > 1) {
+                if (typeInfo && typeInfo.idFields.length > 1) {
                     typeInfo.idFields.forEach((field, index) => {
                         attributes[field.name] = this.coerce(field.type, data.data.id.split(this.idDivider)[index]);
                     });
@@ -773,7 +773,7 @@ class RequestHandler extends APIHandlerBase {
             // Remove attributes that are present in compound id relationships, as they are not expected by Prisma
             for (const [key] of Object.entries<any>(relationships)) {
                 const typeInfo = this.typeMap[key];
-                if (typeInfo.idFields.length > 1) {
+                if (typeInfo && typeInfo.idFields.length > 1) {
                     typeInfo.idFields.forEach((field) => {
                         delete attributes[field.name];
                     });

--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -719,21 +719,10 @@ class RequestHandler extends APIHandlerBase {
         const parsed = this.createUpdatePayloadSchema.parse(body);
         const attributes: any = parsed.data.attributes;
 
-        // Map in the compound id relationships as attributes, as they are expected by the zod schema
-        if (parsed.data.relationships) {
-            for (const [key, data] of Object.entries<any>(parsed.data.relationships)) {
-                const typeInfo = this.typeMap[key];
-                if (typeInfo && typeInfo.idFields.length > 1) {
-                    typeInfo.idFields.forEach((field, index) => {
-                        attributes[field.name] = this.coerce(field.type, data.data.id.split(this.idDivider)[index]);
-                    });
-                }
-            }
-        }
-
         if (attributes) {
-            const schemaName = `${upperCaseFirst(type)}${upperCaseFirst(mode)}Schema`;
-            // zod-parse attributes if a schema is provided
+            // use the zod schema (that only contains non-relation fields) to validate the payload,
+            // if available
+            const schemaName = `${upperCaseFirst(type)}${upperCaseFirst(mode)}ScalarSchema`;
             const payloadSchema = zodSchemas?.models?.[schemaName];
             if (payloadSchema) {
                 const parsed = payloadSchema.safeParse(attributes);
@@ -768,18 +757,6 @@ class RequestHandler extends APIHandlerBase {
         }
 
         const { error, attributes, relationships } = this.processRequestBody(type, requestBody, zodSchemas, 'create');
-
-        if (relationships) {
-            // Remove attributes that are present in compound id relationships, as they are not expected by Prisma
-            for (const [key] of Object.entries<any>(relationships)) {
-                const typeInfo = this.typeMap[key];
-                if (typeInfo && typeInfo.idFields.length > 1) {
-                    typeInfo.idFields.forEach((field) => {
-                        delete attributes[field.name];
-                    });
-                }
-            }
-        }
 
         if (error) {
             return error;


### PR DESCRIPTION
1. Fixes an issue where adding entities related to entities with compound id (see `makeIdConnect`)
1. Fixes validation of entities with compound id, given that zod schemas expect the attributes separately
  1. This is not super elegant, happy to get suggestions on improvements
1. Update openAPI spec generation to match the previous point, making generate clients behave as expected