### PR TITLE
Fix for filtering by compound id

### DIFF
--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -1602,8 +1602,8 @@ class RequestHandler extends APIHandlerBase {
                 const values = value.split(',').filter((i) => i);
                 const filterValue =
                     values.length > 1
-                        ? { OR: values.map((v) => this.makePrismaIdFilter(info.idFields, v)) }
-                        : this.makePrismaIdFilter(info.idFields, value);
+                        ? { OR: values.map((v) => this.makePrismaIdFilter(info.idFields, v, false)) }
+                        : this.makePrismaIdFilter(info.idFields, value, false);
                 return { some: filterValue };
             } else {
                 return { is: this.makePrismaIdFilter(info.idFields, value, false) };


### PR DESCRIPTION
In some cases Prisma doesn’t expect these to be nested under the compound id key. I don't have a full overview of where this is (just the example I hit myself), so I added it just where I can confirm it's needed. 