### PR TITLE
fix: ignore file from typechecking

### DIFF
--- a/packages/schema/src/plugins/zod/generator.ts
+++ b/packages/schema/src/plugins/zod/generator.ts
@@ -326,6 +326,7 @@ export class ZodSchemaGenerator {
 
     private addPreludeAndImports(decl: DataModel | TypeDef, writer: CodeBlockWriter, output: string) {
         writer.writeLine('/* eslint-disable */');
+        writer.writeLine('// @ts-nocheck');
         writer.writeLine(`import { z } from 'zod';`);
 
         // import user-defined enums from Prisma as they might be referenced in the expressions


### PR DESCRIPTION
Generating the zod schemas in a project causes the schemas to be subject to typechecking.

There can be cases where the zod plugin adds an import which doens't end up being used. This raises typechecking errors.

I don't see a reason why these files need to be typechecked.