### PR TITLE
fix(openapi): bugfix for compound id create and update

### DIFF
--- a/packages/plugins/openapi/src/rest-generator.ts
+++ b/packages/plugins/openapi/src/rest-generator.ts
@@ -860,7 +860,7 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
         // For compound ids each component is also exposed as a separate fields for read operations,
         // but not required for write operations
         const fields =
-            idFields.length > 1 && mode === 'read' ? model.fields : model.fields.filter((f) => !isIdField(f));
+            idFields.length > 1 && mode !== 'update' ? model.fields : model.fields.filter((f) => !isIdField(f));
 
         const attributes: Record<string, OAPI.SchemaObject> = {};
         const relationships: Record<string, OAPI.ReferenceObject | OAPI.SchemaObject> = {};
@@ -907,7 +907,7 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
         if (mode === 'create') {
             // 'id' is required if there's no default value
             const idFields = model.fields.filter((f) => isIdField(f));
-            if (idFields.length && idFields.every((f) => !hasAttribute(f, '@default'))) {
+            if (idFields.length === 1 && idFields.every((f) => !hasAttribute(f, '@default'))) {
                 properties = { id: { type: 'string' }, ...properties };
                 toplevelRequired.unshift('id');
             }

--- a/packages/plugins/openapi/src/rest-generator.ts
+++ b/packages/plugins/openapi/src/rest-generator.ts
@@ -905,7 +905,7 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
         if (mode === 'create') {
             // 'id' is required if there's no default value
             const idFields = model.fields.filter((f) => isIdField(f));
-            if (idFields.length === 1 && idFields.every((f) => !hasAttribute(f, '@default'))) {
+            if (idFields.length === 1 && !hasAttribute(idFields[0], '@default')) {
                 properties = { id: { type: 'string' }, ...properties };
                 toplevelRequired.unshift('id');
             }

--- a/packages/plugins/openapi/src/rest-generator.ts
+++ b/packages/plugins/openapi/src/rest-generator.ts
@@ -857,10 +857,8 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
 
     private generateModelEntity(model: DataModel, mode: 'read' | 'create' | 'update'): OAPI.SchemaObject {
         const idFields = model.fields.filter((f) => isIdField(f));
-        // For compound ids each component is also exposed as a separate fields for read operations,
-        // but not required for write operations
-        const fields =
-            idFields.length > 1 && mode !== 'update' ? model.fields : model.fields.filter((f) => !isIdField(f));
+        // For compound ids each component is also exposed as a separate fields.
+        const fields = idFields.length > 1 ? model.fields : model.fields.filter((f) => !isIdField(f));
 
         const attributes: Record<string, OAPI.SchemaObject> = {};
         const relationships: Record<string, OAPI.ReferenceObject | OAPI.SchemaObject> = {};

--- a/packages/plugins/openapi/tests/baseline/rest-3.0.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-3.0.0.baseline.yaml
@@ -3135,14 +3135,11 @@ components:
                     type: object
                     description: The "PostLike" model
                     required:
-                        - id
                         - type
                         - attributes
                     properties:
                         type:
                             type: string
-                        attributes:
-                            type: object
                         relationships:
                             type: object
                             properties:

--- a/packages/plugins/openapi/tests/baseline/rest-3.1.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-3.1.0.baseline.yaml
@@ -3149,7 +3149,6 @@ components:
                     type: object
                     description: The "PostLike" model
                     required:
-                        - id
                         - type
                         - attributes
                     properties:

--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -959,7 +959,7 @@ class RequestHandler extends APIHandlerBase {
                         return this.makeError('invalidRelationData');
                     }
                     updatePayload.data[key] = {
-                        set: {
+                        connect: {
                             [this.makePrismaIdKey(relationInfo.idFields)]: data.data.id,
                         },
                     };

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -1742,7 +1742,6 @@ describe('REST server tests', () => {
                         requestBody: {
                             data: {
                                 type: 'postLike',
-                                id: `1${idDivider}user1`,
                                 attributes: { userId: 'user1', postId: 1, superLike: false },
                             },
                         },

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -2006,6 +2006,31 @@ describe('REST server tests', () => {
                     expect(r.status).toBe(200);
                 });
 
+                it('update the id of an item with compound id', async () => {
+                    await prisma.user.create({ data: { myId: 'user1', email: 'user1@abc.com' } });
+                    await prisma.post.create({ data: { id: 1, title: 'Post1' } });
+                    await prisma.post.create({ data: { id: 2, title: 'Post2' } });
+                    await prisma.postLike.create({ data: { userId: 'user1', postId: 1, superLike: false } });
+
+                    const r = await handler({
+                        method: 'put',
+                        path: `/postLike/1${idDivider}user1`,
+                        query: {},
+                        requestBody: {
+                            data: {
+                                type: 'postLike',
+                                relationships: {
+                                    post: { data: { type: 'post', id: 2 } },
+                                },
+                            },
+                        },
+                        prisma,
+                    });
+
+                    expect(r.status).toBe(200);
+                    expect(r.body.data.id).toBe(`2${idDivider}user1`);
+                });
+
                 it('update a single relation', async () => {
                     await prisma.user.create({ data: { myId: 'user1', email: 'user1@abc.com' } });
                     await prisma.post.create({


### PR DESCRIPTION
When creating a record with a compound id, Prisma expects the parts of the compound id to be passed as attributes. This change reflects that.