### PR TITLE
Don't expose foreign keys as attributes in openAPI spec

### DIFF
--- a/packages/plugins/openapi/src/rest-generator.ts
+++ b/packages/plugins/openapi/src/rest-generator.ts
@@ -868,7 +868,7 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
         const required: string[] = [];
 
         for (const field of fields) {
-            if (isForeignKeyField(field)) {
+            if (isForeignKeyField(field) && mode !== 'read') {
                 // foreign keys are not exposed as attributes
                 continue;
             }

--- a/packages/plugins/openapi/src/rest-generator.ts
+++ b/packages/plugins/openapi/src/rest-generator.ts
@@ -868,6 +868,10 @@ export class RESTfulOpenAPIGenerator extends OpenAPIGeneratorBase {
         const required: string[] = [];
 
         for (const field of fields) {
+            if (isForeignKeyField(field)) {
+                // foreign keys are not exposed as attributes
+                continue;
+            }
             if (isRelationshipField(field)) {
                 let relType: string;
                 if (mode === 'create' || mode === 'update') {

--- a/packages/plugins/openapi/tests/baseline/rest-3.0.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-3.0.0.baseline.yaml
@@ -2764,11 +2764,8 @@ components:
                         image:
                             type: string
                             nullable: true
-                        userId:
-                            type: string
                     required:
                         - image
-                        - userId
                 relationships:
                     type: object
                     properties:
@@ -2791,14 +2788,10 @@ components:
                             type: string
                         attributes:
                             type: object
-                            required:
-                                - userId
                             properties:
                                 image:
                                     type: string
                                     nullable: true
-                                userId:
-                                    type: string
                         relationships:
                             type: object
                             properties:
@@ -2830,8 +2823,6 @@ components:
                                 image:
                                     type: string
                                     nullable: true
-                                userId:
-                                    type: string
                         relationships:
                             type: object
                             properties:
@@ -2917,9 +2908,6 @@ components:
                             format: date-time
                         title:
                             type: string
-                        authorId:
-                            type: string
-                            nullable: true
                         published:
                             type: boolean
                         viewCount:
@@ -2931,7 +2919,6 @@ components:
                         - createdAt
                         - updatedAt
                         - title
-                        - authorId
                         - published
                         - viewCount
                         - notes
@@ -2974,9 +2961,6 @@ components:
                                     format: date-time
                                 title:
                                     type: string
-                                authorId:
-                                    type: string
-                                    nullable: true
                                 published:
                                     type: boolean
                                 viewCount:
@@ -3022,9 +3006,6 @@ components:
                                     format: date-time
                                 title:
                                     type: string
-                                authorId:
-                                    type: string
-                                    nullable: true
                                 published:
                                     type: boolean
                                 viewCount:
@@ -3108,16 +3089,6 @@ components:
                     type: string
                 type:
                     type: string
-                attributes:
-                    type: object
-                    properties:
-                        postId:
-                            type: string
-                        userId:
-                            type: string
-                    required:
-                        - postId
-                        - userId
                 relationships:
                     type: object
                     properties:

--- a/packages/plugins/openapi/tests/baseline/rest-3.0.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-3.0.0.baseline.yaml
@@ -2764,8 +2764,11 @@ components:
                         image:
                             type: string
                             nullable: true
+                        userId:
+                            type: string
                     required:
                         - image
+                        - userId
                 relationships:
                     type: object
                     properties:
@@ -2908,6 +2911,9 @@ components:
                             format: date-time
                         title:
                             type: string
+                        authorId:
+                            type: string
+                            nullable: true
                         published:
                             type: boolean
                         viewCount:
@@ -2919,6 +2925,7 @@ components:
                         - createdAt
                         - updatedAt
                         - title
+                        - authorId
                         - published
                         - viewCount
                         - notes
@@ -3089,6 +3096,16 @@ components:
                     type: string
                 type:
                     type: string
+                attributes:
+                    type: object
+                    properties:
+                        postId:
+                            type: string
+                        userId:
+                            type: string
+                    required:
+                        - postId
+                        - userId
                 relationships:
                     type: object
                     properties:

--- a/packages/plugins/openapi/tests/baseline/rest-3.1.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-3.1.0.baseline.yaml
@@ -2770,11 +2770,8 @@ components:
                             oneOf:
                                 - type: 'null'
                                 - type: string
-                        userId:
-                            type: string
                     required:
                         - image
-                        - userId
                 relationships:
                     type: object
                     properties:
@@ -2797,15 +2794,11 @@ components:
                             type: string
                         attributes:
                             type: object
-                            required:
-                                - userId
                             properties:
                                 image:
                                     oneOf:
                                         - type: 'null'
                                         - type: string
-                                userId:
-                                    type: string
                         relationships:
                             type: object
                             properties:
@@ -2838,8 +2831,6 @@ components:
                                     oneOf:
                                         - type: 'null'
                                         - type: string
-                                userId:
-                                    type: string
                         relationships:
                             type: object
                             properties:
@@ -2925,10 +2916,6 @@ components:
                             format: date-time
                         title:
                             type: string
-                        authorId:
-                            oneOf:
-                                - type: 'null'
-                                - type: string
                         published:
                             type: boolean
                         viewCount:
@@ -2941,7 +2928,6 @@ components:
                         - createdAt
                         - updatedAt
                         - title
-                        - authorId
                         - published
                         - viewCount
                         - notes
@@ -2984,10 +2970,6 @@ components:
                                     format: date-time
                                 title:
                                     type: string
-                                authorId:
-                                    oneOf:
-                                        - type: 'null'
-                                        - type: string
                                 published:
                                     type: boolean
                                 viewCount:
@@ -3034,10 +3016,6 @@ components:
                                     format: date-time
                                 title:
                                     type: string
-                                authorId:
-                                    oneOf:
-                                        - type: 'null'
-                                        - type: string
                                 published:
                                     type: boolean
                                 viewCount:
@@ -3122,16 +3100,6 @@ components:
                     type: string
                 type:
                     type: string
-                attributes:
-                    type: object
-                    properties:
-                        postId:
-                            type: string
-                        userId:
-                            type: string
-                    required:
-                        - postId
-                        - userId
                 relationships:
                     type: object
                     properties:

--- a/packages/plugins/openapi/tests/baseline/rest-3.1.0.baseline.yaml
+++ b/packages/plugins/openapi/tests/baseline/rest-3.1.0.baseline.yaml
@@ -2770,8 +2770,11 @@ components:
                             oneOf:
                                 - type: 'null'
                                 - type: string
+                        userId:
+                            type: string
                     required:
                         - image
+                        - userId
                 relationships:
                     type: object
                     properties:
@@ -2916,6 +2919,10 @@ components:
                             format: date-time
                         title:
                             type: string
+                        authorId:
+                            oneOf:
+                                - type: 'null'
+                                - type: string
                         published:
                             type: boolean
                         viewCount:
@@ -2928,6 +2935,7 @@ components:
                         - createdAt
                         - updatedAt
                         - title
+                        - authorId
                         - published
                         - viewCount
                         - notes
@@ -3100,6 +3108,16 @@ components:
                     type: string
                 type:
                     type: string
+                attributes:
+                    type: object
+                    properties:
+                        postId:
+                            type: string
+                        userId:
+                            type: string
+                    required:
+                        - postId
+                        - userId
                 relationships:
                     type: object
                     properties:


### PR DESCRIPTION
These attributes are handled as relationships, and as such don't need to be exposed as attributes.