### PR TITLE
fix: don't set default value in nested writes when set through FK

### DIFF
--- a/tests/regression/tests/issue-1989.test.ts
+++ b/tests/regression/tests/issue-1989.test.ts
@@ -1,0 +1,121 @@
+import { loadSchema } from '@zenstackhq/testtools';
+
+describe('issue 1989', () => {
+    it('regression', async () => {
+        const { prisma, enhance } = await loadSchema(
+            `
+            model Tenant {
+                id            String          @id @default(uuid())
+            
+                users         User[]
+                posts         Post[]
+                comments      Comment[]
+                postUserLikes PostUserLikes[]
+            }
+            
+            model User {
+                id       String          @id @default(uuid())
+                tenantId String          @default(auth().tenantId)
+                tenant   Tenant          @relation(fields: [tenantId], references: [id])
+                posts    Post[]
+                likes    PostUserLikes[]
+            
+                @@allow('all', true)
+            }
+            
+            model Post {
+                tenantId String          @default(auth().tenantId)
+                tenant   Tenant          @relation(fields: [tenantId], references: [id])
+                id       String          @default(uuid())
+                author   User            @relation(fields: [authorId], references: [id])
+                authorId String          @default(auth().id)
+            
+                comments Comment[]
+                likes    PostUserLikes[]
+            
+                @@id([tenantId, id])
+            
+                @@allow('all', true)
+            }
+            
+            model PostUserLikes {
+                tenantId String @default(auth().tenantId)
+                tenant   Tenant @relation(fields: [tenantId], references: [id])
+                id       String @default(uuid())
+            
+                userId   String
+                user     User   @relation(fields: [userId], references: [id])
+            
+                postId   String
+                post     Post   @relation(fields: [tenantId, postId], references: [tenantId, id])
+            
+                @@id([tenantId, id])
+                @@unique([tenantId, userId, postId])
+            
+                @@allow('all', true)
+            }
+            
+            model Comment {
+                tenantId String @default(auth().tenantId)
+                tenant   Tenant @relation(fields: [tenantId], references: [id])
+                id       String @default(uuid())
+                postId   String
+                post     Post   @relation(fields: [tenantId, postId], references: [tenantId, id])
+            
+                @@id([tenantId, id])
+            
+                @@allow('all', true)
+            }
+            `,
+            { logPrismaQuery: true }
+        );
+
+        const tenant = await prisma.tenant.create({
+            data: {},
+        });
+        const user = await prisma.user.create({
+            data: { tenantId: tenant.id },
+        });
+
+        const db = enhance({ id: user.id, tenantId: tenant.id });
+
+        await expect(db.post.create({
+            data: {
+                likes: {
+                    createMany: {
+                        data: [{
+                            userId: user.id
+                        }]
+                    }
+                }
+            },
+            include: {
+                likes: true
+            }
+        })).resolves.toMatchObject({
+            authorId: user.id,
+            likes: [{
+                tenantId: tenant.id,
+                userId: user.id
+            }]
+        });
+
+        await expect(db.post.create({
+            data: {
+                comments: {
+                    createMany: {
+                        data: [{}]
+                    }
+                }
+            },
+            include: {
+                comments: true
+            }
+        })).resolves.toMatchObject({
+            authorId: user.id,
+            comments: [{
+                tenantId: tenant.id
+            }]
+        });
+    });
+});

--- a/tests/regression/tests/issue-1997.test.ts
+++ b/tests/regression/tests/issue-1997.test.ts
@@ -1,6 +1,6 @@
 import { loadSchema } from '@zenstackhq/testtools';
 
-describe('issue 1989', () => {
+describe('issue 1997', () => {
     it('regression', async () => {
         const { prisma, enhance } = await loadSchema(
             `
@@ -79,43 +79,53 @@ describe('issue 1989', () => {
 
         const db = enhance({ id: user.id, tenantId: tenant.id });
 
-        await expect(db.post.create({
-            data: {
-                likes: {
-                    createMany: {
-                        data: [{
-                            userId: user.id
-                        }]
-                    }
-                }
-            },
-            include: {
-                likes: true
-            }
-        })).resolves.toMatchObject({
+        await expect(
+            db.post.create({
+                data: {
+                    likes: {
+                        createMany: {
+                            data: [
+                                {
+                                    userId: user.id,
+                                },
+                            ],
+                        },
+                    },
+                },
+                include: {
+                    likes: true,
+                },
+            })
+        ).resolves.toMatchObject({
             authorId: user.id,
-            likes: [{
-                tenantId: tenant.id,
-                userId: user.id
-            }]
+            likes: [
+                {
+                    tenantId: tenant.id,
+                    userId: user.id,
+                },
+            ],
         });
 
-        await expect(db.post.create({
-            data: {
-                comments: {
-                    createMany: {
-                        data: [{}]
-                    }
-                }
-            },
-            include: {
-                comments: true
-            }
-        })).resolves.toMatchObject({
+        await expect(
+            db.post.create({
+                data: {
+                    comments: {
+                        createMany: {
+                            data: [{}],
+                        },
+                    },
+                },
+                include: {
+                    comments: true,
+                },
+            })
+        ).resolves.toMatchObject({
             authorId: user.id,
-            comments: [{
-                tenantId: tenant.id
-            }]
+            comments: [
+                {
+                    tenantId: tenant.id,
+                },
+            ],
         });
     });
 });


### PR DESCRIPTION
```ts
const result = db.post.create({
    data: {
        likes: {
            createMany: {
                data: [{
                    userId: user.id
                }]
            }
        }
    },
    include: {
        likes: true
    }
});

// results in ↓

const result = await db[model].create({
    data: {
        likes: {
            createMany: {
                data: [
                    {
                        userId: "48a96b75-882e-48bc-92eb-2ec266067b6d",
                        tenantId: "fa9c2cd6-ae4f-457a-b556-9089f25d67d4"
                    }
                ]
            }
        },
        tenant: {
            connect: {
                id: "fa9c2cd6-ae4f-457a-b556-9089f25d67d4"
            }
        },
        author: {
            connect: {
                id: "48a96b75-882e-48bc-92eb-2ec266067b6d"
            }
        }
    },
    select: {
        tenantId: true,
        id: true,
        likes: {
            select: {
                tenantId: true,
                id: true
            }
        }
    }
})

// Prisma error: Unknown argument `tenantId`. Available options are marked with ?.]
```