### PR TITLE
fix(zod): Required fields with a default value should be optional in Typed JSON cases

### DIFF
--- a/packages/schema/src/plugins/zod/transformer.ts
+++ b/packages/schema/src/plugins/zod/transformer.ts
@@ -282,20 +282,22 @@ export default class Transformer {
 
         const fieldName = alternatives.some((alt) => alt.includes(':')) ? '' : `  ${field.name}:`;
 
-        const opt = !field.isRequired ? '.optional()' : '';
-
         let resString: string;
 
         if (alternatives.length === 1) {
-            resString = alternatives.join(',\r\n');
+            resString = alternatives[0];
         } else {
             if (alternatives.some((alt) => alt.includes('Unchecked'))) {
                 // if the union is for combining checked and unchecked input types, use `smartUnion`
                 // to parse with the best candidate at runtime
-                resString = this.wrapWithSmartUnion(...alternatives) + `${opt}`;
+                resString = this.wrapWithSmartUnion(...alternatives);
             } else {
-                resString = `z.union([${alternatives.join(',\r\n')}])${opt}`;
+                resString = `z.union([${alternatives.join(',\r\n')}])`;
             }
+        }
+
+        if (!field.isRequired) {
+            resString += '.optional()';
         }
 
         if (field.isNullable) {

--- a/tests/integration/tests/plugins/zod.test.ts
+++ b/tests/integration/tests/plugins/zod.test.ts
@@ -1097,4 +1097,28 @@ describe('Zod plugin tests', () => {
         expect(schemas.UserSchema.safeParse({ id: 1, email: 'a@b.com' }).success).toBeTruthy();
         expect(schemas.UserPrismaCreateSchema.safeParse({ email: 'a@b.com' }).success).toBeTruthy();
     });
+
+    it('@json fields with @default should be optional', async () => {
+        const { zodSchemas } = await loadSchema(
+            `
+            type Foo {
+                a String
+            }
+
+            model Bar {
+                id         Int   @id   @default(autoincrement())
+                foo        Foo      @json @default("{ \\"a\\": \\"a\\" }")
+                fooList    Foo[]    @json @default("[]")
+            }
+            `,
+            {
+                fullZod: true,
+                provider: 'postgresql',
+                pushDb: false,
+            }
+        );
+
+        // Ensure Zod Schemas correctly mark @default fields as optional
+        expect(zodSchemas.objects.BarCreateInputObjectSchema.safeParse({}).success).toBeTruthy();
+    });
 });


### PR DESCRIPTION
I believe this is just an edge case with Typed JSON fields again, but it did surface what appears to be a legitimate bug in the zod generator code. So I've tidied that section up slightly to fix the issue and improve readability a touch.

Apologies for not catching this with the last PR.

