### PR TITLE
fix(runtime): properly re-export type declarations of model metadata

### DIFF
--- a/packages/runtime/res/model-meta.d.ts
+++ b/packages/runtime/res/model-meta.d.ts
@@ -1,1 +1,1 @@
-export * from '.zenstack/model-meta';
+export { default } from '.zenstack/model-meta';


### PR DESCRIPTION
`export * from` does not re-export default exports, which is how the metadata is exported.

```ts
import metadata from '@zenstackhq/runtime/model-meta`;
//       ^ this contains the correct metadata at runtime but typescript sees it as {}
```

This change fixes the type declaration and correctly aligns the `.d.ts` file with the existing `.js` file

https://github.com/zenstackhq/zenstack/blob/7c379402cab99e1914fb2c0bc28b7a3e037222ed/packages/runtime/res/model-meta.js#L5