### PR TITLE
Fix(JSON): Allow JSON types to be skipped through Prisma.skip

### DIFF
--- a/packages/schema/src/plugins/enhancer/enhance/index.ts
+++ b/packages/schema/src/plugins/enhancer/enhance/index.ts
@@ -824,12 +824,21 @@ export type Enhanced<Client> =
         };
 
         const replacePrismaJson = (source: string, field: DataModelField) => {
-            return source.replace(
-                new RegExp(`(${field.name}\\??\\s*):[^\\n]+`),
-                `$1: ${field.type.reference!.$refText}${field.type.array ? '[]' : ''}${
-                    field.type.optional ? ' | null' : ''
-                }`
-            );
+            let replaceValue = `$1: ${field.type.reference!.$refText}`;
+            if (field.type.array) {
+                replaceValue += '[]';
+            }
+            if (field.type.optional) {
+                replaceValue += ' | null';
+            }
+
+            // Check if the field in the source is optional (has a `?`)
+            const isOptionalInSource = new RegExp(`(${field.name}\\?\\s*):`).test(source);
+            if (isOptionalInSource) {
+                replaceValue += ' | $Types.Skip';
+            }
+
+            return source.replace(new RegExp(`(${field.name}\\??\\s*):[^\\n]+`), replaceValue);
         };
 
         // fix "$[Model]Payload" type


### PR DESCRIPTION
Another JSON edge case!

When the `strictUndefinedChecks` Prisma Preview feature is enabled, `Prisma.skip` is required to be used over `undefined`. The types generated for `@Json` fields misses this typing in cases where the field is optional in the Prisma type, for example within `UpdateInput` types

Note this doesn't allow using `Prisma.skip` on a field within the JSON type, as that doesn't appear to be supported by Prisma.