### PR TITLE
fix: make ".zenstack/models" reexport the entire original PrismaClient module

### DIFF
--- a/tests/regression/tests/issue-2065.test.ts
+++ b/tests/regression/tests/issue-2065.test.ts
@@ -1,0 +1,31 @@
+import { loadSchema } from '@zenstackhq/testtools';
+
+describe('issue [...]', () => {
+    it('regression', async () => {
+        const { zodSchemas } = await loadSchema(
+            `
+            enum FooType {
+                Bar
+                Baz
+            }
+
+            type Meta {
+                test String?
+            }
+
+            model Foo {
+                id   String  @id @db.Uuid @default(uuid())
+                type FooType
+                meta Meta @json
+
+                @@validate(type == Bar, "FooType must be Bar")
+            }
+            `,
+            {
+                provider: 'postgresql',
+                pushDb: false,
+            }
+        );
+        expect(zodSchemas.models.FooSchema).toBeTruthy();
+    });
+});

--- a/tests/regression/tests/issue-foo.test.ts
+++ b/tests/regression/tests/issue-foo.test.ts
@@ -1,0 +1,36 @@
+import { loadSchema } from '@zenstackhq/testtools';
+
+describe('issue [...]', () => {
+    it('regression', async () => {
+        const { zodSchemas } = await loadSchema(
+            `
+            enum FooType {
+                Bar
+                Baz
+            }
+            type Meta {
+                test String?
+            }
+            model Foo {
+                id   String  @id @db.Uuid @default(uuid())
+                type FooType
+                meta Meta @json
+                @@validate(type == Bar, "FooType must be Bar")
+            }
+            `,
+            {
+                provider: 'postgresql',
+                pushDb: false,
+            }
+        );
+        expect(
+            zodSchemas.models.FooSchema.safeParse({
+                id: '123e4567-e89b-12d3-a456-426614174000',
+                type: 'Bar',
+                meta: { test: 'test' },
+            })
+        ).toMatchObject({
+            success: true,
+        });
+    });
+});


### PR DESCRIPTION
fixes #2065