### PR TITLE
.count use same flow as findMany

### DIFF
--- a/packages/runtime/src/enhancements/node/policy/handler.ts
+++ b/packages/runtime/src/enhancements/node/policy/handler.ts
@@ -1654,7 +1654,7 @@ export class PolicyProxyHandler<DbClient extends DbClientContract> implements Pr
     }
 
     count(args: any) {
-        return createDeferredPromise<unknown[]>(() => this.doFind(args, 'findMany', () => []));
+        return createDeferredPromise<unknown[]>(() => this.doFind(args, 'count', () => []));
     }
 
     //#endregion


### PR DESCRIPTION
The current .count implementation (and probably other aggregate functions) create a different .where clause to findMany - this means that doing a .count and .where with the same inputs, could (after zenstacks RLS implementation) cause be looking at different results - i.e. you might end up with 4 results from .findMany, but .count says there should be 10 results.