### PR TITLE
feat: add ability to map model names in the URLS/JSON response

### DIFF
--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -276,16 +276,27 @@ class RequestHandler extends APIHandlerBase {
         return this.modelNameMapping[modelName] ?? modelName;
     }
 
-    private matchUrlPattern(path: string, routeType: UrlPatterns): Match {
+    private matchUrlPattern(path: string, routeType: UrlPatterns): Match | undefined {
         const pattern = this.urlPatternMap[routeType];
         if (!pattern) {
             throw new InvalidValueError(`Unknown route type: ${routeType}`);
         }
 
         const match = pattern.match(path);
-        if (match) {
-            match.type = this.reverseModelNameMapping[match.type] ?? match.type;
+        if (!match) {
+            return;
         }
+
+        if (match.type in this.modelNameMapping) {
+            throw new InvalidValueError(
+                `use the mapped model name: ${this.modelNameMapping[match.type]} and not ${match.type}`
+            );
+        }
+
+        if (match.type in this.reverseModelNameMapping) {
+            match.type = this.reverseModelNameMapping[match.type];
+        }
+
         return match;
     }
 

--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -245,7 +245,12 @@ class RequestHandler extends APIHandlerBase {
         const segmentCharset = options.urlSegmentCharset ?? 'a-zA-Z0-9-_~ %';
 
         this.modelNameMapping = options.modelNameMapping ?? {};
-        this.reverseModelNameMapping = Object.fromEntries(Object.entries(this.modelNameMapping).map(([k, v]) => [v, k]));
+        this.modelNameMapping = Object.fromEntries(
+            Object.entries(this.modelNameMapping).map(([k, v]) => [lowerCaseFirst(k), v])
+        );
+        this.reverseModelNameMapping = Object.fromEntries(
+            Object.entries(this.modelNameMapping).map(([k, v]) => [v, k])
+        );
         this.urlPatternMap = this.buildUrlPatternMap(segmentCharset);
     }
 

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -3013,4 +3013,65 @@ describe('REST server tests', () => {
             expect(r.body.data.attributes.enabled).toBe(false);
         });
     });
+
+    describe('REST server tests - model name mapping', () => {
+        const schema = `
+    model User {
+        id String @id @default(cuid())
+        name String
+        posts Post[]
+    }
+    
+    model Post {
+        id String @id @default(cuid())
+        title String
+        author User? @relation(fields: [authorId], references: [id])
+        authorId String?
+    }
+    `;
+        beforeAll(async () => {
+            const params = await loadSchema(schema);
+            prisma = params.prisma;
+            zodSchemas = params.zodSchemas;
+            modelMeta = params.modelMeta;
+
+            const _handler = makeHandler({
+                endpoint: 'http://localhost/api',
+                modelNameMapping: {
+                    myUser: 'user',
+                    myPost: 'post',
+                },
+            });
+            handler = (args) =>
+                _handler({ ...args, zodSchemas, modelMeta, url: new URL(`http://localhost/${args.path}`) });
+        });
+
+        it('works with name mapping', async () => {
+            // using original model name
+            await expect(
+                handler({
+                    method: 'post',
+                    path: '/user',
+                    query: {},
+                    requestBody: { data: { type: 'user', attributes: { name: 'User1' } } },
+                    prisma,
+                })
+            ).resolves.toMatchObject({
+                status: 400,
+            });
+
+            // using mapped model name
+            await expect(
+                handler({
+                    method: 'post',
+                    path: '/myUser',
+                    query: {},
+                    requestBody: { data: { type: 'user', attributes: { name: 'User1' } } },
+                    prisma,
+                })
+            ).resolves.toMatchObject({
+                status: 201,
+            });
+        });
+    });
 });

--- a/packages/server/tests/api/rest.test.ts
+++ b/packages/server/tests/api/rest.test.ts
@@ -3038,8 +3038,8 @@ describe('REST server tests', () => {
             const _handler = makeHandler({
                 endpoint: 'http://localhost/api',
                 modelNameMapping: {
-                    myUser: 'user',
-                    myPost: 'post',
+                    user: 'myUser',
+                    post: 'myPost',
                 },
             });
             handler = (args) =>


### PR DESCRIPTION
implements https://github.com/zenstackhq/zenstack/issues/2178

this PR also adds support for a `prefix` similar to the openapi plugin. note openapi plugin itself still needs to be updated, to also use this model name mapping.

also we did not add any new tests. would appreciate any hints on that.

finally we will of course also be happy to provide documentation for this.

/cc @tobiasbrugger 
