### PR TITLE
feat/bugfix: fixing-import-fixing-reactivity

### DIFF
--- a/packages/plugins/tanstack-query/src/generator.ts
+++ b/packages/plugins/tanstack-query/src/generator.ts
@@ -117,7 +117,10 @@ function generateQueryHook(
         const capOperation = upperCaseFirst(operation);
 
         const argsType = overrideInputType ?? `Prisma.${model}${capOperation}Args`;
-        const inputType = makeQueryArgsType(target, argsType);
+        let inputType = makeQueryArgsType(target, argsType);
+        if (target === 'angular') {
+            inputType = `${inputType} | (() => ${inputType})`;
+        }
 
         const infinite = generateMode.includes('Infinite');
         const suspense = generateMode.includes('Suspense');
@@ -673,7 +676,7 @@ function makeBaseImports(target: TargetFramework, version: TanStackVersion) {
         }
         case 'angular': {
             return [
-                `import type { CreateMutationOptions, CreateQueryOptions, CreateInfiniteQueryOptions, InfiniteData } from '@tanstack/angular-query-v5';`,
+                `import type { CreateMutationOptions, CreateQueryOptions, CreateInfiniteQueryOptions, InfiniteData } from '@tanstack/angular-query-experimental';`,
                 `import { getHooksContext } from '${runtimeImportBase}/${target}';`,
                 ...shared,
             ];


### PR DESCRIPTION
## Problem
Angular has a unique initialization timing issue where component inputs (route params, etc.) are not available during class initialization. This causes runtime errors when query hooks try to access these values immediately:

```typescript
// ❌ Runtime Error: NG0950 - Input "id" required but no value available
export class TestDetailPage {
  id = input.required({ transform: numberAttribute }); // From route
  
  findUniquePostQuery = useFindUniquePost({
    where: { id: this.id() } // ❌ id() not available yet
  });
}

Additionally, even when the input becomes available, the query doesn't react to changes since the args were evaluated only once at initialization.

##Solution
Allow query args to be passed as a function for Angular target, enabling deferred evaluation and reactivity:

```typescript
export class TestDetailPage {
  //Deferred evaluation + reactive to input/signal changes
  id = input.required({ transform: numberAttribute });
  
  findUniquePostQuery = useFindUniquePost(() => ({
    where: { id: this.id() }
  }));
}
```
what also works with this changes
```typescript
export class TestDetailPage {
  id = input.required({ transform: numberAttribute });
  
    findUniquePostArgs = computed(() => {
    const id = this.id();
    return { where: { id } };
  });

  findUniquePostQuery = useFindUniquePost(this.findUniquePostArgs);
  ```
  
## Changes

Modified generateQueryHook to accept args | (() => args) for Angular target
Updated Angular imports to use @tanstack/angular-query-experimental
Maintains backward compatibility for other frameworks
No breaking changes

Solves both timing issues and enables full reactivity with Angular signals.


## Other Changes

Fixed makeBaseImports for target Angular