### PR TITLE
feat: option to include models tagged with @openapi.ignore in the spec file

### DIFF
--- a/packages/plugins/openapi/src/generator-base.ts
+++ b/packages/plugins/openapi/src/generator-base.ts
@@ -15,7 +15,14 @@ export abstract class OpenAPIGeneratorBase {
     abstract generate(): PluginResult;
 
     protected get includedModels() {
-        return getDataModels(this.model).filter((d) => !hasAttribute(d, '@@openapi.ignore'));
+        const includeApiIgnored = this.getOption<boolean>('includeApiIgnored', false);
+        if (includeApiIgnored) {
+            return getDataModels(this.model);
+        } else {
+            return getDataModels(this.model).filter(
+                (d) => !hasAttribute(d, '@@openapi.ignore')
+            );
+        }
     }
 
     protected wrapArray(

--- a/packages/plugins/openapi/src/generator-base.ts
+++ b/packages/plugins/openapi/src/generator-base.ts
@@ -15,14 +15,9 @@ export abstract class OpenAPIGeneratorBase {
     abstract generate(): PluginResult;
 
     protected get includedModels() {
-        const includeApiIgnored = this.getOption<boolean>('includeApiIgnored', false);
-        if (includeApiIgnored) {
-            return getDataModels(this.model);
-        } else {
-            return getDataModels(this.model).filter(
-                (d) => !hasAttribute(d, '@@openapi.ignore')
-            );
-        }
+        const includeOpenApiIgnored = this.getOption<boolean>('includeOpenApiIgnored', false);
+        const models = getDataModels(this.model);
+        return includeOpenApiIgnored ? models : models.filter((d) => !hasAttribute(d, '@@openapi.ignore'));
     }
 
     protected wrapArray(


### PR DESCRIPTION
Add option "includeOpenApiIgnored" to the OpenAPI-Plugin. If set to true, models tagged with @openapi.ignore are also included in the generated spec.

Our use case is to produce separate API specifications for internal and external audiences. By providing a flag in the OpenAPI plugin, we could easily generate two different spec files - one for internal use and one for customers. 