### PR TITLE
fix: monorepo's wrong auth error

### DIFF
--- a/packages/schema/src/language-server/zmodel-linker.ts
+++ b/packages/schema/src/language-server/zmodel-linker.ts
@@ -55,7 +55,7 @@ import {
 } from 'langium';
 import { match } from 'ts-pattern';
 import { CancellationToken } from 'vscode-jsonrpc';
-import { getAllLoadedAndReachableDataModelsAndTypeDefs, getContainingDataModel } from '../utils/ast-utils';
+import { getContainingDataModel, getCurrentNodeAndReachableDataModelsAndTypeDefs } from '../utils/ast-utils';
 import { isMemberContainer } from './utils';
 import { mapBuiltinTypeToExpressionType } from './validator/utils';
 
@@ -283,9 +283,11 @@ export class ZModelLinker extends DefaultLinker {
             if (isAuthInvocation(node)) {
                 // auth() function is resolved against all loaded and reachable documents
 
-                // get all data models from loaded and reachable documents
-                const allDecls = getAllLoadedAndReachableDataModelsAndTypeDefs(
+                // get all data models from current node and reachable documents
+
+                const allDecls = getCurrentNodeAndReachableDataModelsAndTypeDefs(
                     this.langiumDocuments(),
+                    node,
                     getContainerOfType(node, isDataModel)
                 );
 

--- a/packages/schema/src/language-server/zmodel-scope.ts
+++ b/packages/schema/src/language-server/zmodel-scope.ts
@@ -34,7 +34,7 @@ import {
 import { match } from 'ts-pattern';
 import { CancellationToken } from 'vscode-jsonrpc';
 import {
-    getAllLoadedAndReachableDataModelsAndTypeDefs,
+    getCurrentNodeAndReachableDataModelsAndTypeDefs,
     isCollectionPredicate,
     isFutureInvocation,
     resolveImportUri,
@@ -135,7 +135,6 @@ export class ZModelScopeProvider extends DefaultScopeProvider {
         const referenceType = this.reflection.getReferenceType(context);
         const globalScope = this.getGlobalScope(referenceType, context);
         const node = context.container as MemberAccessExpr;
-
         // typedef's fields are only added to the scope if the access starts with `auth().`
         // or the member access resides inside a typedef
         const allowTypeDefScope = isAuthOrAuthMemberAccess(node.operand) || !!getContainerOfType(node, isTypeDef);
@@ -230,9 +229,11 @@ export class ZModelScopeProvider extends DefaultScopeProvider {
     }
 
     private createScopeForAuth(node: AstNode, globalScope: Scope) {
-        // get all data models and type defs from loaded and reachable documents
-        const decls = getAllLoadedAndReachableDataModelsAndTypeDefs(
+        // get all data models and type defs from current node and reachable documents
+
+        const decls = getCurrentNodeAndReachableDataModelsAndTypeDefs(
             this.services.shared.workspace.LangiumDocuments,
+            node,
             getContainerOfType(node, isDataModel)
         );
 

--- a/packages/schema/src/utils/ast-utils.ts
+++ b/packages/schema/src/utils/ast-utils.ts
@@ -286,6 +286,32 @@ export function getAllLoadedDataModelsAndTypeDefs(langiumDocuments: LangiumDocum
         .toArray();
 }
 
+export function getCurrentNodeAndReachableDataModelsAndTypeDefs(
+    langiumDocuments: LangiumDocuments,
+    node: AstNode,
+    fromModel?: DataModel
+) {
+    const document = getDocument(node);
+    const allDataModels = (document.parseResult.value as Model).declarations.filter(
+        (d): d is DataModel | TypeDef => isDataModel(d) || isTypeDef(d)
+    );
+
+    if (fromModel) {
+        // merge data models transitively reached from the current model
+        const model = getContainerOfType(fromModel, isModel);
+        if (model) {
+            const transitiveDataModels = getAllDataModelsIncludingImports(langiumDocuments, model);
+            transitiveDataModels.forEach((dm) => {
+                if (!allDataModels.includes(dm)) {
+                    allDataModels.push(dm);
+                }
+            });
+        }
+    }
+
+    return allDataModels;
+}
+
 /**
  * Gets all data models and type defs from loaded and reachable documents
  */


### PR DESCRIPTION
# Change

- add getCurrentNodeAndReachableDataModelsAndTypeDefs

When performing auth() expression validation, the current approach is to retrieve the relevant decl data from all documents. 

However, this is prone to errors in a monorepo, as described in the issue. 

Therefore, my improvement is to start from the current document, retrieve all documents corresponding to the imports, and then parse them.

related issue https://github.com/zenstackhq/zenstack/issues/1532

