### PR TITLE
fix(openapi): use ZModel AST array flag for TypeDef[] @json fields

### DIFF
--- a/packages/plugins/openapi/src/rpc-generator.ts
+++ b/packages/plugins/openapi/src/rpc-generator.ts
@@ -785,9 +785,11 @@ export class RPCOpenAPIGenerator extends OpenAPIGeneratorBase {
                 const field = dataModel.fields.find((f) => f.name === def.name);
                 if (field?.type.reference?.ref && isTypeDef(field.type.reference.ref)) {
                     // This Json field references a TypeDef
+                    // Use field.type.array from ZModel AST instead of def.isList from DMMF,
+                    // since Prisma treats TypeDef fields as plain Json and doesn't know about arrays
                     return this.wrapArray(
                         this.wrapNullable(this.ref(field.type.reference.ref.name, true), !def.isRequired),
-                        def.isList
+                        field.type.array
                     );
                 }
             }


### PR DESCRIPTION
## Summary

- Fixes array schema generation for `TypeDef[] @json` fields directly on model fields
- Uses `field.type.array` from ZModel AST instead of `def.isList` from DMMF
- Adds test case for array of TypeDef with enum directly on model field

## Problem

When a model field uses `TypeDef[] @json` directly:

```zmodel
type TranslatedField {
    language Language
    content String
}

model Article {
    title TranslatedField[] @json
}
```

The OpenAPI generator was producing:

```json
"title": { "$ref": "#/components/schemas/TranslatedField" }
```

Instead of the correct:

```json
"title": { "type": "array", "items": { "$ref": "#/components/schemas/TranslatedField" } }
```

## Root Cause

The code was using `def.isList` from Prisma's DMMF, but Prisma treats all `@json` fields as plain `Json` type and doesn't preserve the `[]` array notation from ZModel. The array information is only available in the ZModel AST via `field.type.array`.

## Test plan

- [x] Added new test case: `array of TypeDef with enum directly on model field`
- [x] All existing OpenAPI tests pass (24/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)