### PR TITLE
refactor(proxy): change database driver packages to optional peer dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,7 +42,6 @@
         "@zenstackhq/orm": "workspace:*",
         "@zenstackhq/sdk": "workspace:*",
         "@zenstackhq/server": "workspace:*",
-        "better-sqlite3": "catalog:",
         "chokidar": "^5.0.0",
         "colors": "1.4.0",
         "commander": "^8.3.0",
@@ -53,10 +52,8 @@
         "jiti": "^2.6.1",
         "langium": "catalog:",
         "mixpanel": "^0.18.1",
-        "mysql2": "catalog:",
         "ora": "^5.4.1",
         "package-manager-detector": "^1.3.0",
-        "pg": "catalog:",
         "prisma": "catalog:",
         "semver": "^7.7.2",
         "ts-pattern": "catalog:"
@@ -73,6 +70,22 @@
         "@zenstackhq/typescript-config": "workspace:*",
         "@zenstackhq/vitest-config": "workspace:*",
         "tmp": "catalog:"
+    },
+    "peerDependencies": {
+        "pg": "catalog:",
+        "better-sqlite3": "catalog:",
+        "mysql2": "catalog:"
+    },
+    "peerDependenciesMeta": {
+        "pg": {
+            "optional": true
+        },
+        "better-sqlite3": {
+            "optional": true
+        },
+        "mysql2": {
+            "optional": true
+        }
     },
     "engines": {
         "node": ">=20"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Database drivers for PostgreSQL, MySQL, and SQLite are now optional dependencies. Install only those you need.
  - Enhanced error messages provide installation guidance for missing database drivers when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->