### PR TITLE
fix: cast auth() string values to uuid on PostgreSQL when field has @db.Uuid

### DIFF
--- a/packages/plugins/policy/src/expression-transformer.ts
+++ b/packages/plugins/policy/src/expression-transformer.ts
@@ -40,6 +40,7 @@ import {
     ReferenceNode,
     SelectionNode,
     SelectQueryNode,
+    sql,
     TableNode,
     ValueListNode,
     ValueNode,
@@ -187,7 +188,8 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
         if (context.contextValue) {
             // if we're transforming against a value object, fields should be evaluated directly
             const fieldDef = QueryUtils.requireField(this.schema, context.modelOrType, expr.field);
-            return this.transformValue(context.contextValue[expr.field], fieldDef.type as BuiltinType);
+            const node = this.transformValue(context.contextValue[expr.field], fieldDef.type as BuiltinType);
+            return this.applyNativeTypeCast(node, fieldDef);
         }
 
         const fieldDef = QueryUtils.requireField(this.schema, context.modelOrType, expr.field);
@@ -802,13 +804,35 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                 curr = ValueNode.createImmediate(null);
                 break;
             }
-            currType = QueryUtils.requireField(this.schema, currType, field).type;
+            const fieldDef = QueryUtils.requireField(this.schema, currType, field);
+            currType = fieldDef.type;
             if (i === expr.members.length - 1) {
                 // last segment (which is the value), make sure it's transformed
                 curr = this.transformValue(curr, currType as BuiltinType);
+                // apply native type cast if needed (e.g., @db.Uuid on PostgreSQL)
+                curr = this.applyNativeTypeCast(curr, fieldDef);
             }
         }
         return curr;
+    }
+
+    /**
+     * Applies a native database type cast to a value node if needed.
+     *
+     * When policy expressions compare auth() member values against typed columns,
+     * the parameterized values are sent with their JavaScript types (e.g., text for strings).
+     * Some database-specific column types require explicit casting — for instance, PostgreSQL
+     * raises "operator does not exist: text = uuid" when comparing a text parameter against
+     * a uuid column. This method inspects the field's native type attributes (e.g., @db.Uuid)
+     * and wraps the node with an appropriate SQL cast.
+     */
+    private applyNativeTypeCast(node: OperationNode, fieldDef: FieldDef): OperationNode {
+        if (this.schema.provider.type === 'postgresql' && fieldDef.attributes) {
+            if (fieldDef.attributes.some((attr) => attr.name === '@db.Uuid')) {
+                return sql`${new ExpressionWrapper(node)}::uuid`.toOperationNode();
+            }
+        }
+        return node;
     }
 
     private transformRelationAccess(


### PR DESCRIPTION
## Problem

When using `auth()` in access policies with PostgreSQL and the auth model has fields annotated with `@db.Uuid`, the policy check fails with:

```
operator does not exist: text = uuid
```

This happens because parameterized string values from `auth()` are sent as `text` type, but the corresponding database columns are `uuid` type. PostgreSQL does not implicitly cast between these types.

### Reproduction

```zmodel
model User {
  userId String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
  email  String @unique
  // ...
  @@auth()
}

model Client {
  clientId     String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
  dealershipId String @db.Uuid
  // ...
  @@allow('read', auth().dealershipId == dealershipId)
}
```

The generated SQL compares `auth().dealershipId` (a `text` parameter) against the `dealershipId` column (`uuid` type), which PostgreSQL rejects.

## Root Cause

In `expression-transformer.ts`, the `valueMemberAccess` method resolves `auth()` member fields and calls `transformValue(curr, currType)` where `currType` is the ZModel type (`'String'`). The PostgreSQL dialect's `transformInput` for `String` is a no-op, so the value remains a plain text parameter. When Kysely parameterizes this as `$1`, PostgreSQL infers `text` type, causing the type mismatch.

The `@db.Uuid` native type attribute *is* available in the runtime schema via `FieldDef.attributes`, but was not being utilized during value transformation.

## Fix

Added an `applyNativeTypeCast` method that inspects the field's native type attributes and wraps the value node with an explicit `::uuid` SQL cast when:
1. The provider is PostgreSQL, AND
2. The field has the `@db.Uuid` attribute

The cast is applied in two code paths:
- **`valueMemberAccess`**: For `auth().field` member access in policies (the primary case)
- **`_field` with `contextValue`**: For field evaluation in collection predicates with value objects

### Changes

Only one file is modified: `packages/plugins/policy/src/expression-transformer.ts`
- Added `sql` to Kysely imports
- Modified `valueMemberAccess` to store the full `FieldDef` and apply native type cast after `transformValue`
- Modified `_field` with `contextValue` to also apply native type cast
- Added `applyNativeTypeCast` helper with JSDoc documentation

Fixes #2394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed policy expression evaluation to correctly handle UUID column comparisons in PostgreSQL databases. Policy expressions now properly cast values when evaluating against UUID-typed fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->