### PR TITLE
fix: auto-add "views" preview feature to generated Prisma schema (#2376)

### DIFF
--- a/packages/sdk/src/prisma/prisma-schema-generator.ts
+++ b/packages/sdk/src/prisma/prisma-schema-generator.ts
@@ -176,10 +176,23 @@ export class PrismaSchemaGenerator {
 
     private generateDefaultGenerator(prisma: PrismaModel) {
         const gen = prisma.addGenerator('client', [{ name: 'provider', text: '"prisma-client-js"' }]);
+
+        const previewFeatures: string[] = [];
+
         const dataSource = this.zmodel.declarations.find(isDataSource);
         if (dataSource?.fields.some((f) => f.name === 'extensions')) {
-            // enable "postgresqlExtensions" preview feature
-            gen.fields.push({ name: 'previewFeatures', text: '["postgresqlExtensions"]' });
+            previewFeatures.push('postgresqlExtensions');
+        }
+
+        if (this.zmodel.declarations.some((d) => isDataModel(d) && d.isView)) {
+            previewFeatures.push('views');
+        }
+
+        if (previewFeatures.length > 0) {
+            gen.fields.push({
+                name: 'previewFeatures',
+                text: JSON.stringify(previewFeatures),
+            });
         }
     }
 

--- a/tests/regression/test/issue-2376.test.ts
+++ b/tests/regression/test/issue-2376.test.ts
@@ -1,0 +1,42 @@
+import { PrismaSchemaGenerator } from '@zenstackhq/sdk';
+import { loadSchema } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2376
+describe('Regression for issue 2376', () => {
+    it('should include views preview feature when schema contains views', async () => {
+        const model = await loadSchema(`
+datasource db {
+    provider = 'sqlite'
+    url = 'file:./test.db'
+}
+
+model User {
+    id    Int     @id @default(autoincrement())
+    email String  @unique
+    name  String?
+    posts Post[]
+}
+
+model Post {
+    id       Int     @id @default(autoincrement())
+    title    String
+    author   User?   @relation(fields: [authorId], references: [id])
+    authorId Int?
+}
+
+view UserPostCount {
+    id        Int    @unique
+    name      String
+    postCount Int
+}
+        `);
+
+        const generator = new PrismaSchemaGenerator(model);
+        const prismaSchema = await generator.generate();
+
+        // The generated Prisma schema should include previewFeatures with "views"
+        expect(prismaSchema).toContain('previewFeatures');
+        expect(prismaSchema).toContain('views');
+    });
+});


### PR DESCRIPTION
When a ZModel schema contains `view` declarations without an explicit
generator block, the generated Prisma schema now automatically includes
`previewFeatures = ["views"]` in the default generator, preventing the
P1012 validation error during `db push` and `migrate`.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

fixes #2376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Prisma schema generation to dynamically compute preview features based on actual schema requirements (extensions and views) instead of statically enabling features.

* **Tests**
  * Added regression test to validate preview features are correctly included when schemas contain views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->