### PR TITLE
fix(orm): _count is not included in select clause's typing when querying from a to-one relation

### DIFF
--- a/packages/orm/src/client/crud-types.ts
+++ b/packages/orm/src/client/crud-types.ts
@@ -1215,7 +1215,7 @@ export type FindArgs<
               : {})
     : {}) &
     (AllowFilter extends true ? FilterArgs<Schema, Model, Options> : {}) &
-    SelectIncludeOmit<Schema, Model, Collection, Options>;
+    SelectIncludeOmit<Schema, Model, true, Options>;
 
 export type FindManyArgs<
     Schema extends SchemaDef,

--- a/tests/e2e/orm/client-api/find.test.ts
+++ b/tests/e2e/orm/client-api/find.test.ts
@@ -1120,6 +1120,27 @@ describe('Client find tests ', () => {
         ).resolves.toMatchObject({
             _count: { posts: 0 },
         });
+
+        // typing
+        // user select allows _count because it has to-many relations
+        client.user.findMany({
+            select: { _count: { select: { posts: true } } },
+        });
+        // nested author select allows _count because it has to-many relations
+        client.post.findMany({
+            select: {
+                author: {
+                    select: {
+                        _count: { select: { posts: true } },
+                    },
+                },
+            },
+        });
+        // comment select does not allow _count because it has no to-many relations
+        client.comment.findMany({
+            // @ts-expect-error
+            select: { _count: {} },
+        });
     });
 
     it('supports _count inside include', async () => {


### PR DESCRIPTION
#2343


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type behavior for include/omit operations to work consistently in all query contexts.

* **Tests**
  * Added TypeScript type-checking coverage for relation counting functionality in queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->