### PR TITLE
fix(policy): wrong table alias used when injecting for field policies

### DIFF
--- a/packages/plugins/policy/src/policy-handler.ts
+++ b/packages/plugins/policy/src/policy-handler.ts
@@ -660,7 +660,7 @@ export class PolicyHandler<Schema extends SchemaDef> extends OperationNodeTransf
             selections = [SelectionNode.create(SelectAllNode.create())];
         }
 
-        const modelPolicyFilter = this.buildPolicyFilter(model, alias, operation);
+        const modelPolicyFilter = this.buildPolicyFilter(model, model, operation);
         if (!isTrueNode(modelPolicyFilter)) {
             hasPolicies = true;
         }

--- a/tests/regression/test/issue-2385.test.ts
+++ b/tests/regression/test/issue-2385.test.ts
@@ -1,0 +1,53 @@
+import { createPolicyTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+describe('Regression for issue #2385', () => {
+    it('should not generate "missing FROM-clause entry" when including a relation with a static-value @@allow policy', async () => {
+        const db = await createPolicyTestClient(
+            `
+model User {
+    id           String        @id @default(uuid())
+    name         String
+    associations Association[]
+    createdAt    DateTime      @default(now())
+    updatedAt    DateTime      @updatedAt
+
+    @@allow("read", auth().id == id)
+}
+
+model Association {
+    id        String   @id @default(uuid())
+    name      String
+    userId    String   @db.VarChar @map("user_id")
+    user      User     @relation(fields: [userId], references: [id])
+    createdAt DateTime @default(now()) @allow("read", auth().id == userId)
+    updatedAt DateTime @updatedAt
+
+    @@allow("read", auth().id == userId)
+}
+            `,
+        );
+
+        const rawDb = db.$unuseAll();
+        const user = await rawDb.user.create({
+            data: {
+                name: 'John Doe',
+            },
+        });
+
+        await rawDb.association.create({
+            data: {
+                name: 'Association for John',
+                userId: user.id,
+            },
+        });
+
+        const userDb = db.$setAuth(user);
+
+        await expect(
+            userDb.user.findMany({
+                include: { associations: true },
+            }),
+        ).toResolveTruthy();
+    });
+});


### PR DESCRIPTION
fixes #2385


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where queries with included associations could fail under certain policy configurations.

* **Tests**
  * Added regression test to ensure policy-enforced data access works correctly when querying related data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->