### PR TITLE
fix(zod): exclude computed and delegate fields from create/update schemas

### DIFF
--- a/packages/zod/src/factory.ts
+++ b/packages/zod/src/factory.ts
@@ -71,7 +71,8 @@ class SchemaFactory<Schema extends SchemaDef> {
         const fields: Record<string, z.ZodType> = {};
 
         for (const [fieldName, fieldDef] of Object.entries(modelDef.fields)) {
-            if (fieldDef.relation) {
+            // exclude relation, computed, delegate discriminator fields
+            if (fieldDef.relation || fieldDef.computed || fieldDef.isDiscriminator) {
                 continue;
             }
 
@@ -96,7 +97,8 @@ class SchemaFactory<Schema extends SchemaDef> {
         const fields: Record<string, z.ZodType> = {};
 
         for (const [fieldName, fieldDef] of Object.entries(modelDef.fields)) {
-            if (fieldDef.relation) {
+            // exclude relation, computed, delegate discriminator fields
+            if (fieldDef.relation || fieldDef.computed || fieldDef.isDiscriminator) {
                 continue;
             }
 

--- a/packages/zod/src/types.ts
+++ b/packages/zod/src/types.ts
@@ -1,6 +1,8 @@
 import type {
     FieldHasDefault,
     FieldIsArray,
+    FieldIsComputed,
+    FieldIsDelegateDiscriminator,
     FieldIsRelation,
     GetEnum,
     GetEnums,
@@ -51,7 +53,11 @@ export type GetModelFieldsShape<Schema extends SchemaDef, Model extends GetModel
 export type GetModelCreateFieldsShape<Schema extends SchemaDef, Model extends GetModels<Schema>> = {
     [Field in GetModelFields<Schema, Model> as FieldIsRelation<Schema, Model, Field> extends true
         ? never
-        : Field]: ZodOptionalIf<
+        : FieldIsComputed<Schema, Model, Field> extends true
+          ? never
+          : FieldIsDelegateDiscriminator<Schema, Model, Field> extends true
+            ? never
+            : Field]: ZodOptionalIf<
         ZodOptionalAndNullableIf<MapModelFieldToZod<Schema, Model, Field>, ModelFieldIsOptional<Schema, Model, Field>>,
         FieldHasDefault<Schema, Model, Field>
     >;
@@ -60,7 +66,11 @@ export type GetModelCreateFieldsShape<Schema extends SchemaDef, Model extends Ge
 export type GetModelUpdateFieldsShape<Schema extends SchemaDef, Model extends GetModels<Schema>> = {
     [Field in GetModelFields<Schema, Model> as FieldIsRelation<Schema, Model, Field> extends true
         ? never
-        : Field]: z.ZodOptional<
+        : FieldIsComputed<Schema, Model, Field> extends true
+          ? never
+          : FieldIsDelegateDiscriminator<Schema, Model, Field> extends true
+            ? never
+            : Field]: z.ZodOptional<
         ZodOptionalAndNullableIf<MapModelFieldToZod<Schema, Model, Field>, ModelFieldIsOptional<Schema, Model, Field>>
     >;
 };

--- a/packages/zod/test/factory.test.ts
+++ b/packages/zod/test/factory.test.ts
@@ -636,3 +636,213 @@ describe('SchemaFactory - makeEnumSchema', () => {
         expect(() => factory.makeEnumSchema('Unknown' as any)).toThrow();
     });
 });
+
+// --- Computed fields tests ---
+
+const validProduct = {
+    id: 'prod1',
+    name: 'Widget',
+    price: 10.0,
+    discount: 2.0,
+    finalPrice: 8.0,
+};
+
+describe('SchemaFactory - computed fields', () => {
+    describe('makeModelSchema includes computed fields', () => {
+        it('accepts a Product with computed field present', () => {
+            const productSchema = factory.makeModelSchema('Product');
+            expect(productSchema.safeParse(validProduct).success).toBe(true);
+        });
+
+        it('rejects a Product missing the computed field', () => {
+            const productSchema = factory.makeModelSchema('Product');
+            const { finalPrice: _, ...withoutComputed } = validProduct;
+            expect(productSchema.safeParse(withoutComputed).success).toBe(false);
+        });
+
+        it('infers computed field in model schema type', () => {
+            const _schema = factory.makeModelSchema('Product');
+            type Product = z.infer<typeof _schema>;
+            expectTypeOf<Product['finalPrice']>().toEqualTypeOf<number>();
+        });
+    });
+
+    describe('makeModelCreateSchema excludes computed fields', () => {
+        it('accepts a Product without the computed field', () => {
+            const createSchema = factory.makeModelCreateSchema('Product');
+            expect(createSchema.safeParse({ name: 'Widget', price: 10.0 }).success).toBe(true);
+        });
+
+        it('rejects a Product with the computed field (strict)', () => {
+            const createSchema = factory.makeModelCreateSchema('Product');
+            expect(createSchema.safeParse({ name: 'Widget', price: 10.0, finalPrice: 8.0 }).success).toBe(false);
+        });
+
+        it('does not include computed field in create schema type', () => {
+            const _schema = factory.makeModelCreateSchema('Product');
+            type ProductCreate = z.infer<typeof _schema>;
+            expectTypeOf<ProductCreate>().not.toHaveProperty('finalPrice');
+            // own fields are present
+            expectTypeOf<ProductCreate>().toHaveProperty('name');
+            expectTypeOf<ProductCreate['name']>().toEqualTypeOf<string>();
+            expectTypeOf<ProductCreate['price']>().toEqualTypeOf<number>();
+            // field with default is optional
+            expectTypeOf<ProductCreate>().toHaveProperty('discount');
+        });
+    });
+
+    describe('makeModelUpdateSchema excludes computed fields', () => {
+        it('accepts a Product update without the computed field', () => {
+            const updateSchema = factory.makeModelUpdateSchema('Product');
+            expect(updateSchema.safeParse({ price: 12.0 }).success).toBe(true);
+        });
+
+        it('rejects a Product update with the computed field (strict)', () => {
+            const updateSchema = factory.makeModelUpdateSchema('Product');
+            expect(updateSchema.safeParse({ price: 12.0, finalPrice: 10.0 }).success).toBe(false);
+        });
+
+        it('does not include computed field in update schema type', () => {
+            const _schema = factory.makeModelUpdateSchema('Product');
+            type ProductUpdate = z.infer<typeof _schema>;
+            expectTypeOf<ProductUpdate>().not.toHaveProperty('finalPrice');
+            // own fields are present (all optional in update)
+            expectTypeOf<ProductUpdate>().toHaveProperty('name');
+        });
+    });
+});
+
+// --- Delegate model tests ---
+
+const validVideo = {
+    id: 1,
+    createdAt: new Date(),
+    assetType: 'Video',
+    duration: 120,
+    url: 'https://example.com/video.mp4',
+};
+
+const validImage = {
+    id: 2,
+    createdAt: new Date(),
+    assetType: 'Image',
+    format: 'png',
+    width: 800,
+};
+
+describe('SchemaFactory - delegate models', () => {
+    describe('makeModelSchema for delegate base model', () => {
+        it('accepts a valid Asset', () => {
+            const assetSchema = factory.makeModelSchema('Asset');
+            expect(assetSchema.safeParse({ id: 1, createdAt: new Date(), assetType: 'Video' }).success).toBe(true);
+        });
+
+        it('includes discriminator field in model schema type', () => {
+            const _schema = factory.makeModelSchema('Asset');
+            type Asset = z.infer<typeof _schema>;
+            expectTypeOf<Asset['assetType']>().toEqualTypeOf<string>();
+            expectTypeOf<Asset['id']>().toEqualTypeOf<number>();
+        });
+    });
+
+    describe('makeModelSchema for derived models', () => {
+        it('accepts a valid Video (includes inherited + own fields)', () => {
+            const videoSchema = factory.makeModelSchema('Video');
+            expect(videoSchema.safeParse(validVideo).success).toBe(true);
+        });
+
+        it('accepts a valid Image (includes inherited + own fields)', () => {
+            const imageSchema = factory.makeModelSchema('Image');
+            expect(imageSchema.safeParse(validImage).success).toBe(true);
+        });
+
+        it('rejects Video missing own fields', () => {
+            const videoSchema = factory.makeModelSchema('Video');
+            const { duration: _, url: _u, ...withoutOwn } = validVideo;
+            expect(videoSchema.safeParse(withoutOwn).success).toBe(false);
+        });
+
+        it('infers correct types for derived model including inherited fields', () => {
+            const _schema = factory.makeModelSchema('Video');
+            type Video = z.infer<typeof _schema>;
+            // inherited fields
+            expectTypeOf<Video['id']>().toEqualTypeOf<number>();
+            expectTypeOf<Video['assetType']>().toEqualTypeOf<string>();
+            // own fields
+            expectTypeOf<Video['duration']>().toEqualTypeOf<number>();
+            expectTypeOf<Video['url']>().toEqualTypeOf<string>();
+        });
+    });
+
+    describe('makeModelCreateSchema excludes discriminator', () => {
+        it('accepts Video create without discriminator and inherited fields', () => {
+            const createSchema = factory.makeModelCreateSchema('Video');
+            // Only own non-inherited, non-discriminator fields should be required
+            expect(createSchema.safeParse({ duration: 120, url: 'https://example.com/video.mp4' }).success).toBe(true);
+        });
+
+        it('rejects Video create with discriminator field (strict)', () => {
+            const createSchema = factory.makeModelCreateSchema('Video');
+            expect(
+                createSchema.safeParse({
+                    duration: 120,
+                    url: 'https://example.com/video.mp4',
+                    assetType: 'Video',
+                }).success,
+            ).toBe(false);
+        });
+
+        it('does not include discriminator fields in create schema type', () => {
+            const _schema = factory.makeModelCreateSchema('Video');
+            type VideoCreate = z.infer<typeof _schema>;
+            // discriminator and originModel fields should be excluded
+            expectTypeOf<VideoCreate>().not.toHaveProperty('assetType');
+            // own fields should be present
+            expectTypeOf<VideoCreate>().toHaveProperty('duration');
+            expectTypeOf<VideoCreate>().toHaveProperty('url');
+            expectTypeOf<VideoCreate['duration']>().toEqualTypeOf<number>();
+            expectTypeOf<VideoCreate['url']>().toEqualTypeOf<string>();
+        });
+
+        it('excludes discriminator from base delegate create schema', () => {
+            const createSchema = factory.makeModelCreateSchema('Asset');
+            // discriminator should not be included
+            expect(createSchema.safeParse({ assetType: 'Video' }).success).toBe(false);
+            // empty create (id has default, createdAt has default, assetType is discriminator)
+            expect(createSchema.safeParse({}).success).toBe(true);
+        });
+
+        it('does not include discriminator in base delegate create schema type', () => {
+            const _schema = factory.makeModelCreateSchema('Asset');
+            type AssetCreate = z.infer<typeof _schema>;
+            expectTypeOf<AssetCreate>().not.toHaveProperty('assetType');
+        });
+    });
+
+    describe('makeModelUpdateSchema excludes discriminator and originModel fields', () => {
+        it('accepts Video update with only own fields', () => {
+            const updateSchema = factory.makeModelUpdateSchema('Video');
+            expect(updateSchema.safeParse({ duration: 180 }).success).toBe(true);
+        });
+
+        it('rejects Video update with discriminator field (strict)', () => {
+            const updateSchema = factory.makeModelUpdateSchema('Video');
+            expect(updateSchema.safeParse({ duration: 180, assetType: 'Video' }).success).toBe(false);
+        });
+
+        it('does not include discriminator fields in update schema type', () => {
+            const _schema = factory.makeModelUpdateSchema('Video');
+            type VideoUpdate = z.infer<typeof _schema>;
+            expectTypeOf<VideoUpdate>().not.toHaveProperty('assetType');
+            // own fields should be present (all optional in update)
+            expectTypeOf<VideoUpdate>().toHaveProperty('duration');
+            expectTypeOf<VideoUpdate>().toHaveProperty('url');
+        });
+
+        it('does not include discriminator in base delegate update schema type', () => {
+            const _schema = factory.makeModelUpdateSchema('Asset');
+            type AssetUpdate = z.infer<typeof _schema>;
+            expectTypeOf<AssetUpdate>().not.toHaveProperty('assetType');
+        });
+    });
+});

--- a/packages/zod/test/schema/schema.ts
+++ b/packages/zod/test/schema/schema.ts
@@ -145,6 +145,157 @@ export class SchemaType implements SchemaDef {
             uniqueFields: {
                 id: { type: "String" }
             }
+        },
+        Product: {
+            name: "Product",
+            fields: {
+                id: {
+                    name: "id",
+                    type: "String",
+                    id: true,
+                    attributes: [{ name: "@id" }, { name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }],
+                    default: ExpressionUtils.call("cuid")
+                },
+                name: {
+                    name: "name",
+                    type: "String"
+                },
+                price: {
+                    name: "price",
+                    type: "Float"
+                },
+                discount: {
+                    name: "discount",
+                    type: "Float",
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.literal(0) }] }],
+                    default: 0
+                },
+                finalPrice: {
+                    name: "finalPrice",
+                    type: "Float",
+                    attributes: [{ name: "@computed" }],
+                    computed: true
+                }
+            },
+            idFields: ["id"],
+            uniqueFields: {
+                id: { type: "String" }
+            },
+            computedFields: {
+                finalPrice(_context: {
+                    modelAlias: string;
+                }): number {
+                    throw new Error("This is a stub for computed field");
+                }
+            }
+        },
+        Asset: {
+            name: "Asset",
+            fields: {
+                id: {
+                    name: "id",
+                    type: "Int",
+                    id: true,
+                    attributes: [{ name: "@id" }, { name: "@default", args: [{ name: "value", value: ExpressionUtils.call("autoincrement") }] }],
+                    default: ExpressionUtils.call("autoincrement")
+                },
+                createdAt: {
+                    name: "createdAt",
+                    type: "DateTime",
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.call("now") }] }],
+                    default: ExpressionUtils.call("now")
+                },
+                assetType: {
+                    name: "assetType",
+                    type: "String",
+                    isDiscriminator: true
+                }
+            },
+            attributes: [
+                { name: "@@delegate", args: [{ name: "discriminator", value: ExpressionUtils.field("assetType") }] }
+            ],
+            idFields: ["id"],
+            uniqueFields: {
+                id: { type: "Int" }
+            },
+            isDelegate: true,
+            subModels: ["Video", "Image"]
+        },
+        Video: {
+            name: "Video",
+            baseModel: "Asset",
+            fields: {
+                id: {
+                    name: "id",
+                    type: "Int",
+                    id: true,
+                    attributes: [{ name: "@id" }, { name: "@default", args: [{ name: "value", value: ExpressionUtils.call("autoincrement") }] }],
+                    default: ExpressionUtils.call("autoincrement")
+                },
+                createdAt: {
+                    name: "createdAt",
+                    type: "DateTime",
+                    originModel: "Asset",
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.call("now") }] }],
+                    default: ExpressionUtils.call("now")
+                },
+                assetType: {
+                    name: "assetType",
+                    type: "String",
+                    originModel: "Asset",
+                    isDiscriminator: true
+                },
+                duration: {
+                    name: "duration",
+                    type: "Int"
+                },
+                url: {
+                    name: "url",
+                    type: "String"
+                }
+            },
+            idFields: ["id"],
+            uniqueFields: {
+                id: { type: "Int" }
+            }
+        },
+        Image: {
+            name: "Image",
+            baseModel: "Asset",
+            fields: {
+                id: {
+                    name: "id",
+                    type: "Int",
+                    id: true,
+                    attributes: [{ name: "@id" }, { name: "@default", args: [{ name: "value", value: ExpressionUtils.call("autoincrement") }] }],
+                    default: ExpressionUtils.call("autoincrement")
+                },
+                createdAt: {
+                    name: "createdAt",
+                    type: "DateTime",
+                    originModel: "Asset",
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.call("now") }] }],
+                    default: ExpressionUtils.call("now")
+                },
+                assetType: {
+                    name: "assetType",
+                    type: "String",
+                    originModel: "Asset",
+                    isDiscriminator: true
+                },
+                format: {
+                    name: "format",
+                    type: "String"
+                },
+                width: {
+                    name: "width",
+                    type: "Int"
+                }
+            },
+            idFields: ["id"],
+            uniqueFields: {
+                id: { type: "Int" }
+            }
         }
     } as const;
     typeDefs = {

--- a/packages/zod/test/schema/schema.zmodel
+++ b/packages/zod/test/schema/schema.zmodel
@@ -48,3 +48,31 @@ model Post {
     author    User?   @relation(fields: [authorId], references: [id])
     authorId  String?
 }
+
+// --- Computed fields ---
+model Product {
+    id          String @id @default(cuid())
+    name        String
+    price       Float
+    discount    Float  @default(0)
+    finalPrice  Float  @computed
+}
+
+// --- Delegate models ---
+model Asset {
+    id        Int      @id @default(autoincrement())
+    createdAt DateTime @default(now())
+    assetType String
+
+    @@delegate(assetType)
+}
+
+model Video extends Asset {
+    duration Int
+    url      String
+}
+
+model Image extends Asset {
+    format String
+    width  Int
+}

--- a/packages/zod/vitest.config.ts
+++ b/packages/zod/vitest.config.ts
@@ -1,4 +1,14 @@
 import base from '@zenstackhq/vitest-config/base';
 import { defineConfig, mergeConfig } from 'vitest/config';
 
-export default mergeConfig(base, defineConfig({}));
+export default mergeConfig(
+    base,
+    defineConfig({
+        test: {
+            typecheck: {
+                enabled: true,
+                include: ['test/**/*.ts'],
+            },
+        },
+    }),
+);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Computed fields are now properly excluded from create and update operations, ensuring they cannot be manually set.
  * Discriminator fields are now properly excluded from create and update operations for polymorphic models.

* **Tests**
  * Added comprehensive test coverage for computed field behavior in schema validation.
  * Added extensive tests for delegate model inheritance and discriminator field handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->