### PR TITLE
fix(cli): exclude Prisma migrations from SQLite pull

### DIFF
--- a/packages/cli/src/actions/pull/provider/sqlite.ts
+++ b/packages/cli/src/actions/pull/provider/sqlite.ts
@@ -134,10 +134,11 @@ export const sqlite: IntrospectionProvider = {
 
             // List user tables and views from sqlite_schema (the master catalog).
             // sqlite_schema contains one row per table, view, index, and trigger.
-            // We filter to only tables/views and exclude internal sqlite_* objects.
+            // We filter to only tables/views and exclude internal sqlite_* objects
+            // and the Prisma migration tracking table.
             // The 'sql' column contains the original CREATE TABLE/VIEW statement.
             const tablesRaw = all<{ name: string; type: 'table' | 'view'; definition: string | null }>(
-                "SELECT name, type, sql AS definition FROM sqlite_schema WHERE type IN ('table','view') AND name NOT LIKE 'sqlite_%' ORDER BY name",
+                "SELECT name, type, sql AS definition FROM sqlite_schema WHERE type IN ('table','view') AND name NOT LIKE 'sqlite_%' AND name <> '_prisma_migrations' ORDER BY name",
             );
 
             // Detect AUTOINCREMENT by parsing the CREATE TABLE statement


### PR DESCRIPTION
Filters out the internal migration tracking table during the introspection process. This prevents the CLI from including system-level metadata in the generated schema, ensuring only user-defined tables and views are processed.

Fixes: #2420 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SQLite schema query handling by properly filtering out system migration tracking tables. This improvement ensures cleaner, more accurate database structure information by removing internal metadata, allowing users to see their actual database schema clearly without system tracking information that could complicate or obscure important schema details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->