### PR TITLE
fix(orm): handle self-referential relations in delegate models during schema push

### DIFF
--- a/packages/orm/src/client/helpers/schema-db-pusher.ts
+++ b/packages/orm/src/client/helpers/schema-db-pusher.ts
@@ -84,6 +84,10 @@ export class SchemaDbPusher<Schema extends SchemaDef> {
             for (const field of Object.values(model.fields)) {
                 // relation order
                 if (field.relation && field.relation.fields && field.relation.references) {
+                    // skip self-referential relations to avoid false cycle in toposort
+                    if (field.type === model.name) {
+                        continue;
+                    }
                     const targetModel = requireModel(this.schema, field.type);
                     // edge: fk side -> target model
                     graph.push([model, targetModel]);

--- a/tests/regression/test/issue-2435.test.ts
+++ b/tests/regression/test/issue-2435.test.ts
@@ -1,0 +1,37 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2435
+describe('Regression for issue 2435', () => {
+    it('should not throw cyclic dependency error when delegate model has a self-referential relation', async () => {
+        await expect(
+            createTestClient(
+                `
+enum ContentType {
+    POST
+    ARTICLE
+    QUESTION
+}
+
+model Content {
+    id   Int         @id @default(autoincrement())
+    type ContentType
+    @@delegate(type)
+}
+
+model Post extends Content {
+    post1s   Post1[]
+    replies  Post[]  @relation("PostReplies")
+    parentId Int?
+    parent   Post?   @relation("PostReplies", fields: [parentId], references: [id])
+}
+
+model Post1 extends Content {
+    post   Post @relation(fields: [postId], references: [id])
+    postId Int
+}
+        `,
+            ),
+        ).toResolveTruthy();
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes a cyclic dependency error thrown by `toposort` when a model uses `@@delegate` inheritance and also has a self-referential relation (e.g. a parent/replies pattern)
- Root cause: `SchemaDbPusher.sortModels` was adding a `[Post, Post]` edge to the dependency graph for self-referential FKs, which `toposort` correctly rejects as a cycle
- Fix: skip self-referential relations (`field.type === model.name`) when building the topological sort graph

## Test plan

- [x] Added regression test `tests/regression/test/issue-2435.test.ts` that reproduces the exact schema from the issue report
- [x] Test confirmed failing before fix, passing after fix

Closes #2435

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect cyclic dependency detection when models contain self-referential relations. These relations no longer trigger false cycle warnings that previously blocked schema compilation.

* **Tests**
  * Added regression test to ensure models with self-referential relations compile without cyclic dependency errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->