### PR TITLE
fix(policy): handle DefaultInsertValueNode in createManyAndReturn

### DIFF
--- a/packages/plugins/policy/src/policy-handler.ts
+++ b/packages/plugins/policy/src/policy-handler.ts
@@ -920,6 +920,10 @@ export class PolicyHandler<Schema extends SchemaDef> extends OperationNodeTransf
         for (let i = 0; i < data.length; i++) {
             const item = data[i]!;
             if (typeof item === 'object' && item && 'kind' in item) {
+                if (item.kind === 'DefaultInsertValueNode') {
+                    result.push({ node: ValueNode.create(null), raw: null });
+                    continue;
+                }
                 const fieldDef = QueryUtils.requireField(this.client.$schema, model, fields[i]!);
                 invariant(item.kind === 'ValueNode', 'expecting a ValueNode');
                 result.push({

--- a/tests/regression/test/issue-2460.test.ts
+++ b/tests/regression/test/issue-2460.test.ts
@@ -7,10 +7,10 @@ describe('Regression for issue #2460', () => {
     it('createManyAndReturn with asymmetric optional fields across rows', async () => {
         const db = await createPolicyTestClient(
             `
-type AuthUser {
-    id   String
+model User {
+    id   Int    @id @default(autoincrement())
     role String
-    @@auth
+    @@allow('all', true)
 }
 
 model Item {
@@ -20,13 +20,12 @@ model Item {
     @@allow('all', auth().role == 'admin')
 }
             `,
-            {
-                provider: 'postgresql',
-                auth: { id: '1', role: 'admin' },
-            },
+            { provider: 'postgresql' },
         );
 
-        const result = await db.item.createManyAndReturn({
+        const user = await db.user.create({ data: { role: 'admin' } });
+
+        const result = await db.$setAuth(user).item.createManyAndReturn({
             data: [
                 { key: 'a', note: 'hello' },
                 { key: 'b' },
@@ -34,6 +33,5 @@ model Item {
         });
 
         expect(result).toHaveLength(2);
-        await db.$disconnect();
     });
 });


### PR DESCRIPTION
## Summary

Fixes #2460

`createManyAndReturn` with PolicyPlugin crashes with `Invariant failed: expecting a ValueNode` when rows have asymmetric optional fields (one row provides a field, another omits it).

Kysely pads missing columns with `DefaultInsertValueNode`. The fix handles this node type in `PolicyHandler.unwrapCreateValueRow` by treating it as `null`.

## Changes

- `packages/plugins/policy/src/policy-handler.ts` — 4-line fix to handle `DefaultInsertValueNode`
- `tests/regression/test/issue-2460.test.ts` — regression test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default placeholders in create/value rows are now treated as null during processing, improving handling of optional fields in createManyAndReturn.

* **Tests**
  * Added a regression test to ensure createManyAndReturn handles asymmetric optional fields across rows without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->