### PR TITLE
fix(policy): support now() default value in access policy evaluation

### DIFF
--- a/packages/orm/src/client/crud/operations/base.ts
+++ b/packages/orm/src/client/crud/operations/base.ts
@@ -1105,6 +1105,7 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
                     return this.formatGeneratedValue(generated, defaultValue.args?.[1]);
                 })
                 .with('ulid', () => this.formatGeneratedValue(ulid(), defaultValue.args?.[0]))
+                .with('now', () => new Date())
                 .otherwise(() => undefined);
         } else if (
             ExpressionUtils.isMember(defaultValue) &&

--- a/packages/orm/src/client/functions.ts
+++ b/packages/orm/src/client/functions.ts
@@ -109,7 +109,19 @@ export const isEmpty: ZModelFunction<any> = (eb, args, { dialect }: ZModelFuncti
     return eb(dialect.buildArrayLength(field), '=', sql.lit(0));
 };
 
-export const now: ZModelFunction<any> = () => sql.raw('CURRENT_TIMESTAMP');
+export const now: ZModelFunction<any> = (_eb, _args, context) =>
+    match(context.dialect.provider)
+        // SQLite stores DateTime as ISO 8601 text ('YYYY-MM-DDTHH:MM:SS.sssZ'), but
+        // CURRENT_TIMESTAMP returns 'YYYY-MM-DD HH:MM:SS'. Use strftime for ISO format.
+        .with('sqlite', () => sql.raw("strftime('%Y-%m-%dT%H:%M:%fZ')"))
+        // MySQL stores DateTime as ISO 8601 text ('YYYY-MM-DDTHH:MM:SS.sss+00:00').
+        // Use CONCAT + SUBSTRING to produce matching 3-digit millisecond ISO format.
+        .with('mysql', () =>
+            sql.raw("CONCAT(SUBSTRING(DATE_FORMAT(UTC_TIMESTAMP(3), '%Y-%m-%dT%H:%i:%s.%f'), 1, 23), '+00:00')"),
+        )
+        // PostgreSQL has native timestamp type that compares correctly.
+        .with('postgresql', () => sql.raw('CURRENT_TIMESTAMP'))
+        .exhaustive();
 
 export const currentModel: ZModelFunction<any> = (_eb, args, { model }: ZModelFunctionContext<any>) => {
     let result = model;

--- a/tests/e2e/orm/policy/now-function.test.ts
+++ b/tests/e2e/orm/policy/now-function.test.ts
@@ -1,0 +1,125 @@
+import { createPolicyTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+describe('now() function in policy tests', () => {
+    it('allows create when createdAt default now() is used in comparison', async () => {
+        const db = await createPolicyTestClient(
+            `
+model Post {
+    id Int @id @default(autoincrement())
+    title String
+    createdAt DateTime? @default(now())
+    @@allow('create', createdAt != null)
+    @@allow('read', true)
+}
+`,
+        );
+
+        // createdAt should be auto-filled with now(), satisfying the <= now() check
+        await expect(db.post.create({ data: { title: 'hello' } })).resolves.toMatchObject({ title: 'hello' });
+        const post = await db.post.findFirst();
+        expect(post.createdAt).toBeInstanceOf(Date);
+    });
+
+    it('uses now() in update policy to compare against DateTime field', async () => {
+        const db = await createPolicyTestClient(
+            `
+model Event {
+    id Int @id @default(autoincrement())
+    name String
+    scheduledAt DateTime
+    @@allow('create,read', true)
+    @@allow('update', scheduledAt > now())
+}
+`,
+        );
+
+        // create an event in the future - should be updatable
+        const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+        await db.event.create({ data: { name: 'future', scheduledAt: futureDate } });
+        await expect(db.event.update({ where: { id: 1 }, data: { name: 'updated' } })).resolves.toMatchObject({
+            name: 'updated',
+        });
+
+        // create an event in the past - should NOT be updatable
+        const pastDate = new Date(Date.now() - 60 * 60 * 1000);
+        await db.event.create({ data: { name: 'past', scheduledAt: pastDate } });
+        await expect(db.event.update({ where: { id: 2 }, data: { name: 'updated' } })).toBeRejectedNotFound();
+    });
+
+    it('uses now() in read policy to filter DateTime field', async () => {
+        const db = await createPolicyTestClient(
+            `
+model Article {
+    id Int @id @default(autoincrement())
+    title String
+    publishedAt DateTime
+    @@allow('create', true)
+    @@allow('read', publishedAt <= now())
+}
+`,
+        );
+
+        const rawDb = db.$unuseAll();
+        const pastDate = new Date(Date.now() - 60 * 60 * 1000);
+        const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+
+        await rawDb.article.create({ data: { title: 'published', publishedAt: pastDate } });
+        await rawDb.article.create({ data: { title: 'scheduled', publishedAt: futureDate } });
+
+        // only the past article should be readable
+        const articles = await db.article.findMany();
+        expect(articles).toHaveLength(1);
+        expect(articles[0].title).toBe('published');
+    });
+
+    it('uses now() in delete policy', async () => {
+        const db = await createPolicyTestClient(
+            `
+model Task {
+    id Int @id @default(autoincrement())
+    name String
+    expiresAt DateTime
+    @@allow('create,read', true)
+    @@allow('delete', expiresAt < now())
+}
+`,
+        );
+
+        // create an expired task - should be deletable
+        const pastDate = new Date(Date.now() - 60 * 60 * 1000);
+        await db.task.create({ data: { name: 'expired', expiresAt: pastDate } });
+        await expect(db.task.delete({ where: { id: 1 } })).resolves.toMatchObject({ name: 'expired' });
+
+        // create a non-expired task - should NOT be deletable
+        const futureDate = new Date(Date.now() + 60 * 60 * 1000);
+        await db.task.create({ data: { name: 'active', expiresAt: futureDate } });
+        await expect(db.task.delete({ where: { id: 2 } })).toBeRejectedNotFound();
+    });
+
+    it('combines now() default with auth in create policy', async () => {
+        const db = await createPolicyTestClient(
+            `
+type Auth {
+    id Int
+    @@auth
+}
+
+model Log {
+    id Int @id @default(autoincrement())
+    message String
+    createdAt DateTime @default(now())
+    @@allow('create', createdAt <= now() && auth() != null)
+    @@allow('read', true)
+}
+`,
+        );
+
+        // anonymous user - rejected
+        await expect(db.log.create({ data: { message: 'test' } })).toBeRejectedByPolicy();
+        // authenticated user with auto-filled createdAt - allowed
+        await expect(db.$setAuth({ id: 1 }).log.create({ data: { message: 'test' } })).resolves.toMatchObject({
+            message: 'test',
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Fill `now()` default in `evalGenerator` so `@default(now())` fields are populated before policy checks, preventing `DefaultInsertValueNode` from being treated as `null` during pre-create policy evaluation.
- Fix `now()` SQL function to produce ISO 8601 format matching each dialect's DateTime storage format (SQLite: `strftime`, MySQL: `DATE_FORMAT` with trimmed microseconds), ensuring correct comparisons in policy expressions.
- Add e2e tests for `now()` in create, read, update, and delete policies.

## Test plan
- [x] e2e test: create with `@default(now())` field used in policy rule
- [x] e2e test: update policy comparing DateTime field against `now()`
- [x] e2e test: read policy filtering by `publishedAt <= now()`
- [x] e2e test: delete policy filtering by `expiresAt < now()`
- [x] e2e test: `now()` default combined with `auth()` check in create policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `now()` as a default value generator for automatic timestamp population in models.
  * Expanded `now()` function with native dialect support for SQLite, MySQL, and PostgreSQL.

* **Tests**
  * Added comprehensive test coverage for `now()` functionality across CRUD operations and access policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->