### PR TITLE
fix(orm): add webpack magic comment to suppress bundler warnings for optional dependencies

### DIFF
--- a/packages/orm/src/client/crud/dialects/postgresql.ts
+++ b/packages/orm/src/client/crud/dialects/postgresql.ts
@@ -37,7 +37,7 @@ export class PostgresCrudDialect<Schema extends SchemaDef> extends LateralJoinDi
             // override node-pg's default type parser to resolve the timezone handling issue
             // with "TIMESTAMP WITHOUT TIME ZONE" fields
             // https://github.com/brianc/node-postgres/issues/429
-            import('pg')
+            import(/* webpackIgnore: true */ 'pg') // suppress bundler analysis warnings
                 .then((pg) => {
                     pg.types.setTypeParser(pg.types.builtins.TIMESTAMP, (value) => {
                         if (typeof value !== 'string') {


### PR DESCRIPTION
fixes #2470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved bundler analysis warnings for database module imports while maintaining existing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->