### PR TITLE
fix(orm): use uncapitalized model names in OmitConfig and ComputedFieldsOptions

### DIFF
--- a/packages/orm/src/client/client-impl.ts
+++ b/packages/orm/src/client/client-impl.ts
@@ -164,7 +164,8 @@ export class ClientImpl {
         for (const [modelName, modelDef] of Object.entries(this.$schema.models)) {
             if (modelDef.computedFields) {
                 for (const fieldName of Object.keys(modelDef.computedFields)) {
-                    const modelConfig = computedFieldsConfig?.[modelName];
+                    // check both uncapitalized (current) and original (backward compat) model name
+                    const modelConfig = computedFieldsConfig?.[lowerCaseFirst(modelName)] ?? computedFieldsConfig?.[modelName];
                     const fieldConfig = modelConfig?.[fieldName];
                     // Check if the computed field has a configuration
                     if (fieldConfig === null || fieldConfig === undefined) {

--- a/packages/orm/src/client/crud-types.ts
+++ b/packages/orm/src/client/crud-types.ts
@@ -121,10 +121,10 @@ type OptionsLevelOmit<
     Model extends GetModels<Schema>,
     Field extends GetModelFields<Schema, Model>,
     Options extends QueryOptions<Schema>,
-> = Model extends keyof Options['omit']
-    ? Field extends keyof Options['omit'][Model]
-        ? Options['omit'][Model][Field] extends boolean
-            ? Options['omit'][Model][Field]
+> = Uncapitalize<Model> extends keyof Options['omit']
+    ? Field extends keyof Options['omit'][Uncapitalize<Model>]
+        ? Options['omit'][Uncapitalize<Model>][Field] extends boolean
+            ? Options['omit'][Uncapitalize<Model>][Field]
             : undefined
         : undefined
     : undefined;

--- a/packages/orm/src/client/crud/dialects/base-dialect.ts
+++ b/packages/orm/src/client/crud/dialects/base-dialect.ts
@@ -1,4 +1,4 @@
-import { enumerate, invariant, isPlainObject } from '@zenstackhq/common-helpers';
+import { enumerate, invariant, isPlainObject, lowerCaseFirst } from '@zenstackhq/common-helpers';
 import type { AliasableExpression, Expression, ExpressionBuilder, ExpressionWrapper, SqlBool, ValueNode } from 'kysely';
 import { expressionBuilder, sql, type SelectQueryBuilder } from 'kysely';
 import { match, P } from 'ts-pattern';
@@ -1160,12 +1160,12 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
             return (omit as any)[field];
         }
 
-        if (
-            this.options.omit?.[model] &&
-            typeof this.options.omit[model] === 'object' &&
-            typeof (this.options.omit[model] as any)[field] === 'boolean'
-        ) {
-            return (this.options.omit[model] as any)[field];
+        // client-level: check both uncapitalized (current) and original (backward compat) model name
+        const uncapModel = lowerCaseFirst(model);
+        const omitConfig = (this.options.omit as Record<string, any> | undefined)?.[uncapModel] ??
+            (this.options.omit as Record<string, any> | undefined)?.[model];
+        if (omitConfig && typeof omitConfig === 'object' && typeof omitConfig[field] === 'boolean') {
+            return omitConfig[field];
         }
 
         // schema-level
@@ -1355,7 +1355,9 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
             let computer: Function | undefined;
             if ('computedFields' in this.options) {
                 const computedFields = this.options.computedFields as Record<string, any>;
-                computer = computedFields?.[fieldDef.originModel ?? model]?.[field];
+                // check both uncapitalized (current) and original (backward compat) model name
+                const computedModel = fieldDef.originModel ?? model;
+                computer = computedFields?.[lowerCaseFirst(computedModel)]?.[field] ?? computedFields?.[computedModel]?.[field];
             }
             if (!computer) {
                 throw createConfigError(`Computed field "${field}" implementation not provided for model "${model}"`);

--- a/packages/orm/src/client/options.ts
+++ b/packages/orm/src/client/options.ts
@@ -252,13 +252,13 @@ export type ClientOptions<Schema extends SchemaDef> = QueryOptions<Schema> & {
  * Config for omitting fields in ORM query results.
  */
 export type OmitConfig<Schema extends SchemaDef> = {
-    [Model in GetModels<Schema>]?: {
+    [Model in GetModels<Schema> as Uncapitalize<Model>]?: {
         [Field in GetModelFields<Schema, Model> as Field extends ScalarFields<Schema, Model> ? Field : never]?: boolean;
     };
 };
 
 export type ComputedFieldsOptions<Schema extends SchemaDef> = {
-    [Model in GetModels<Schema> as 'computedFields' extends keyof GetModel<Schema, Model> ? Model : never]: {
+    [Model in GetModels<Schema> as 'computedFields' extends keyof GetModel<Schema, Model> ? Uncapitalize<Model> : never]: {
         [Field in keyof Schema['models'][Model]['computedFields']]: Schema['models'][Model]['computedFields'][Field] extends infer Func
             ? Func extends (...args: any[]) => infer R
                 ? (

--- a/samples/orm/main.ts
+++ b/samples/orm/main.ts
@@ -8,7 +8,7 @@ async function main() {
     const db = new ZenStackClient(schema, {
         dialect: new SqliteDialect({ database: new SQLite('./zenstack/dev.db') }),
         computedFields: {
-            User: {
+            user: {
                 postCount: (eb, { modelAlias }) =>
                     eb
                         .selectFrom('Post')

--- a/tests/e2e/orm/client-api/computed-fields.test.ts
+++ b/tests/e2e/orm/client-api/computed-fields.test.ts
@@ -191,7 +191,7 @@ model User {
 `,
             {
                 computedFields: {
-                    User: {
+                    user: {
                         upperName: (eb: any) => eb.fn('upper', ['name']),
                     },
                 },
@@ -204,7 +204,7 @@ async function main() {
     const client = new ZenStackClient(schema, {
         dialect: {} as any,
         computedFields: {
-            User: {
+            user: {
                 upperName: (eb) => eb.fn('upper', ['name']),
             },
         }
@@ -263,7 +263,7 @@ model User {
 `,
             {
                 computedFields: {
-                    User: {
+                    user: {
                         upperName: (eb: any) => eb.lit(null),
                     },
                 },
@@ -276,7 +276,7 @@ async function main() {
     const client = new ZenStackClient(schema, {
         dialect: {} as any,
         computedFields: {
-            User: {
+            user: {
                 upperName: (eb) => eb.lit(null),
             },
         }

--- a/tests/e2e/orm/client-api/omit.test.ts
+++ b/tests/e2e/orm/client-api/omit.test.ts
@@ -37,7 +37,7 @@ describe('Field omission tests', () => {
     });
 
     it('respects client omit options', async () => {
-        const options = { omit: { User: { name: true } }, dialect: {} as any } as const;
+        const options = { omit: { user: { name: true } }, dialect: {} as any } as const;
         const db = await createTestClient<typeof schema, typeof options>(schema, options);
 
         const user = await db.user.create({
@@ -66,7 +66,7 @@ describe('Field omission tests', () => {
 
     it('allows override at query options level', async () => {
         // override schema-level omit
-        const options = { omit: { User: { password: false } }, dialect: {} as any } as const;
+        const options = { omit: { user: { password: false } }, dialect: {} as any } as const;
         const db = await createTestClient<typeof schema, typeof options>(schema, options);
         const user1 = await db.user.create({
             data: {
@@ -114,7 +114,7 @@ describe('Field omission tests', () => {
 
     it('allows override at query level', async () => {
         // override options-level omit
-        const options = { omit: { User: { name: true } }, dialect: {} as any } as const;
+        const options = { omit: { user: { name: true } }, dialect: {} as any } as const;
         const db = await createTestClient<typeof schema, typeof options>(schema, options);
         const user5 = await db.user.create({
             data: { id: 2, name: 'User2', password: 'abc' },

--- a/tests/e2e/orm/schemas/typing/typecheck.ts
+++ b/tests/e2e/orm/schemas/typing/typecheck.ts
@@ -7,7 +7,7 @@ import { schema } from './schema';
 const client = new ZenStackClient(schema, {
     dialect: new SqliteDialect({ database: new SQLite('./zenstack/test.db') }),
     computedFields: {
-        User: {
+        user: {
             postCount: (eb) =>
                 eb
                     .selectFrom('Post')


### PR DESCRIPTION
## Summary
- Changed `OmitConfig` and `ComputedFieldsOptions` types to use `Uncapitalize<Model>` as config keys, consistent with other config types like `SlicingOptions`
- Updated `OptionsLevelOmit` type utility to resolve omit config using uncapitalized model names
- Runtime lookups in `shouldOmitField` and computed field resolution check both uncapitalized (current) and original (backward compat) model names

## Test plan
- [x] ORM package builds successfully
- [x] E2E typecheck (`tsc --noEmit`) passes with zero errors
- [ ] Run omit and computed-fields e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Updated ORM client configuration to use camelCase model names (e.g., `user` instead of `User`) for computed fields and omit options.
  * Added backward compatibility to support both new and legacy model naming formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->