### PR TITLE
fix(server): exclude stack trace from REST error responses

### DIFF
--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -1,4 +1,4 @@
-import { clone, enumerate, lowerCaseFirst, paramCase } from '@zenstackhq/common-helpers';
+import { clone, enumerate, lowerCaseFirst, paramCase, safeJSONStringify } from '@zenstackhq/common-helpers';
 import { ORMError, ORMErrorReason, type ClientContract } from '@zenstackhq/orm';
 import type { FieldDef, ModelDef, SchemaDef } from '@zenstackhq/orm/schema';
 import { Decimal } from 'decimal.js';
@@ -508,7 +508,13 @@ export class RestApiHandler<Schema extends SchemaDef = SchemaDef> implements Api
     }
 
     private handleGenericError(err: unknown): Response | PromiseLike<Response> {
-        return this.makeError('unknownError', err instanceof Error ? `${err.message}` : 'Unknown error');
+        const resp = this.makeError('unknownError', err instanceof Error ? `${err.message}` : 'Unknown error');
+        log(
+            this.options.log,
+            'debug',
+            () => `sending error response: ${safeJSONStringify(resp)}${err instanceof Error ? '\n' + err.stack : ''}`,
+        );
+        return resp;
     }
 
     private async processProcedureRequest({
@@ -585,14 +591,18 @@ export class RestApiHandler<Schema extends SchemaDef = SchemaDef> implements Api
 
     private makeProcBadInputErrorResponse(message: string): Response {
         const resp = this.makeError('invalidPayload', message, 400);
-        log(this.log, 'debug', () => `sending error response: ${JSON.stringify(resp)}`);
+        log(this.log, 'debug', () => `sending error response: ${safeJSONStringify(resp)}`);
         return resp;
     }
 
     private makeProcGenericErrorResponse(err: unknown): Response {
         const message = err instanceof Error ? err.message : 'unknown error';
         const resp = this.makeError('unknownError', message, 500);
-        log(this.log, 'debug', () => `sending error response: ${JSON.stringify(resp)}`);
+        log(
+            this.log,
+            'debug',
+            () => `sending error response: ${safeJSONStringify(resp)}${err instanceof Error ? '\n' + err.stack : ''}`,
+        );
         return resp;
     }
 


### PR DESCRIPTION
## Summary
- Remove stack trace from generic error messages returned to REST API clients to avoid leaking internal implementation details

## Test plan
- [ ] Verify REST API error responses no longer include stack traces
- [ ] Confirm error message content is still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced verbosity of API error responses by removing stack traces from user-facing messages.
  * Improved server-side error logging with safer serialization and inclusion of stack traces only in debug logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->