### PR TITLE
fix(ide): only error on missing telemetry token in CI

### DIFF
--- a/packages/ide/vscode/scripts/post-build.ts
+++ b/packages/ide/vscode/scripts/post-build.ts
@@ -6,8 +6,13 @@ dotenv.config({ path: './.env' });
 
 const telemetryToken = process.env.VSCODE_TELEMETRY_TRACKING_TOKEN;
 if (!telemetryToken) {
-    console.error('Error: VSCODE_TELEMETRY_TRACKING_TOKEN environment variable is not set');
-    process.exit(1);
+    if (process.env.CI) {
+        console.error('Error: VSCODE_TELEMETRY_TRACKING_TOKEN environment variable is not set');
+        process.exit(1);
+    } else {
+        console.warn('Warning: VSCODE_TELEMETRY_TRACKING_TOKEN environment variable is not set, skipping token injection');
+        process.exit(0);
+    }
 }
 const file = 'dist/extension.js';
 let content = fs.readFileSync(file, 'utf-8');


### PR DESCRIPTION
## Summary
- The VSCode post-build script now only fails on a missing `VSCODE_TELEMETRY_TRACKING_TOKEN` when running in CI (`process.env.CI`)
- In local development, it warns and exits cleanly (code 0), skipping token injection

## Test plan
- [ ] Verify local build succeeds without the env var set
- [ ] Verify CI build still fails if the env var is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build process now succeeds in local development environments when telemetry configuration is unavailable, while maintaining strict validation in continuous integration pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->