### PR TITLE
fix: avoid build failures during CI

### DIFF
--- a/packages/ide/vscode/scripts/post-build.ts
+++ b/packages/ide/vscode/scripts/post-build.ts
@@ -6,13 +6,8 @@ dotenv.config({ path: './.env' });
 
 const telemetryToken = process.env.VSCODE_TELEMETRY_TRACKING_TOKEN;
 if (!telemetryToken) {
-    if (process.env.CI) {
-        console.error('Error: VSCODE_TELEMETRY_TRACKING_TOKEN environment variable is not set');
-        process.exit(1);
-    } else {
-        console.warn('Warning: VSCODE_TELEMETRY_TRACKING_TOKEN environment variable is not set, skipping token injection');
-        process.exit(0);
-    }
+    console.warn('Warning: VSCODE_TELEMETRY_TRACKING_TOKEN environment variable is not set, skipping token injection');
+    process.exit(0);
 }
 const file = 'dist/extension.js';
 let content = fs.readFileSync(file, 'utf-8');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent build behavior for the VS Code extension when telemetry tracking configuration is unavailable. The build process now exits consistently with a warning message across all environments, rather than using different exit codes and logging levels depending on whether it runs in CI or local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->