### PR TITLE
docs: add contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,23 @@ Thank you for your generous support!
 # Community
 
 Join our [discord server](https://discord.gg/Ykhr738dUe) for chat and updates!
+
+# Contributors
+
+Thanks to all the contributors who have helped make ZenStack better!
+
+### Source
+
+<a href="https://github.com/zenstackhq/zenstack/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=zenstackhq/zenstack" />
+</a>
+
+### Docs
+
+<a href="https://github.com/zenstackhq/zenstack-docs/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=zenstackhq/zenstack-docs" />
+</a>
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary
- Add a Contributors section to the root README.md showcasing contributors to both the source repo and the docs repo using contrib.rocks
- Add a License section at the bottom

## Test plan
- [x] Verify the contributor images render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Community section with new Contributors subsection acknowledging project contributors
  * Added contributor statistics from source and documentation repositories
  * Added MIT License information to README

<!-- end of auto-generated comment: release notes by coderabbit.ai -->