### PR TITLE
fix(orm): stricter validation in $setAuth and clean up imports

### DIFF
--- a/packages/orm/src/client/client-impl.ts
+++ b/packages/orm/src/client/client-impl.ts
@@ -41,15 +41,14 @@ import * as BuiltinFunctions from './functions';
 import { SchemaDbPusher } from './helpers/schema-db-pusher';
 import type { ClientOptions, ProceduresOptions } from './options';
 import type { AnyPlugin } from './plugin';
+import { createZenStackPromise, type ZenStackPromise } from './promise';
+import { fieldHasDefaultValue, getField, isUnsupportedField, requireModel } from './query-utils';
+import { ResultProcessor } from './result-processor';
 
 type ExtResultFieldDef = {
     needs: Record<string, true>;
     compute: (data: Record<string, any>) => unknown;
 };
-import { getField } from './query-utils';
-import { createZenStackPromise, type ZenStackPromise } from './promise';
-import { fieldHasDefaultValue, isUnsupportedField, requireModel } from './query-utils';
-import { ResultProcessor } from './result-processor';
 
 /**
  * ZenStack ORM client.
@@ -172,7 +171,8 @@ export class ClientImpl {
             if (modelDef.computedFields) {
                 for (const fieldName of Object.keys(modelDef.computedFields)) {
                     // check both uncapitalized (current) and original (backward compat) model name
-                    const modelConfig = computedFieldsConfig?.[lowerCaseFirst(modelName)] ?? computedFieldsConfig?.[modelName];
+                    const modelConfig =
+                        computedFieldsConfig?.[lowerCaseFirst(modelName)] ?? computedFieldsConfig?.[modelName];
                     const fieldConfig = modelConfig?.[fieldName];
                     // Check if the computed field has a configuration
                     if (fieldConfig === null || fieldConfig === undefined) {
@@ -426,7 +426,7 @@ export class ClientImpl {
     }
 
     $setAuth(auth: AuthType<SchemaDef> | undefined) {
-        if (auth !== undefined && typeof auth !== 'object') {
+        if (auth !== undefined && (typeof auth !== 'object' || auth === null || Array.isArray(auth))) {
             throw new Error('Invalid auth object');
         }
         const newClient = new ClientImpl(this.schema, this.$options, this);

--- a/packages/orm/src/client/contract.ts
+++ b/packages/orm/src/client/contract.ts
@@ -124,12 +124,13 @@ export type ClientContract<
     $queryRawUnsafe<T = unknown>(query: string, ...values: any[]): ZenStackPromise<Schema, T>;
 
     /**
-     * The current user identity.
+     * The current user identity. If the client is not bound to any user context, returns `undefined`.
      */
     get $auth(): AuthType<Schema> | undefined;
 
     /**
      * Returns a new client bound to the specified user identity. The original client remains unchanged.
+     * Pass `undefined` to return a client without any user context.
      *
      * @example
      * ```


### PR DESCRIPTION
## Summary
- Reject `null` and arrays in `$setAuth` — `typeof null === 'object'` in JS, so the previous check allowed invalid auth values
- Consolidate duplicate imports from `./query-utils` in `client-impl.ts`
- Improve `$auth` and `$setAuth` doc comments for clarity

## Test plan
- [ ] Verify `$setAuth(null)` now throws `Invalid auth object`
- [ ] Verify `$setAuth([])` now throws `Invalid auth object`
- [ ] Verify `$setAuth({ id: 1 })` still works as expected
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for authentication settings to properly reject null values, arrays, and other invalid input types.

* **Documentation**
  * Clarified authentication method behavior, specifically how authentication getters return undefined and setters accept undefined when there is no user context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->