### PR TITLE
feat(language): Allow including partial model in loadDocument when there is error

### DIFF
--- a/packages/language/src/document.ts
+++ b/packages/language/src/document.ts
@@ -141,6 +141,7 @@ export async function loadDocument(
     if (additionalErrors.length > 0) {
         return {
             success: false,
+            model: returnPartialModelForError ? (document.parseResult.value as Model) : undefined,
             errors: additionalErrors,
             warnings,
         };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document loader can now optionally include a partial model when parsing fails, improving error context for diagnostics and recovery workflows.
  * Error reports may now include partial parsing results alongside errors and warnings to aid troubleshooting and more robust handling of problematic documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->