### PR TITLE
fix(orm): unify zenstack v3 and prisma behavior on empty branches in OR filter

### DIFF
--- a/packages/orm/src/client/crud/dialects/base-dialect.ts
+++ b/packages/orm/src/client/crud/dialects/base-dialect.ts
@@ -265,14 +265,10 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
                 this.and(...enumerate(payload).map((subPayload) => this.buildFilter(model, modelAlias, subPayload))),
             )
             .with('OR', () => {
-                const allBranches = enumerate(payload).map((subPayload) =>
-                    this.buildFilter(model, modelAlias, subPayload)
-                );
-                const meaningfulBranches = allBranches.filter((expr) => !this.isTrue(expr));
-                if (meaningfulBranches.length === 0) {
-                    return allBranches.length > 0 ? this.true() : this.false();
-                }
-                return this.or(...meaningfulBranches);
+                const branches = enumerate(payload)
+                    .map((subPayload) => this.buildFilter(model, modelAlias, subPayload))
+                    .filter((expr) => !this.isTrue(expr));
+                return this.or(...branches);
             })
             .with('NOT', () => this.eb.not(this.buildCompositeFilter(model, modelAlias, 'AND', payload)))
             .exhaustive();

--- a/packages/orm/src/client/crud/dialects/base-dialect.ts
+++ b/packages/orm/src/client/crud/dialects/base-dialect.ts
@@ -264,9 +264,16 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
             .with('AND', () =>
                 this.and(...enumerate(payload).map((subPayload) => this.buildFilter(model, modelAlias, subPayload))),
             )
-            .with('OR', () =>
-                this.or(...enumerate(payload).map((subPayload) => this.buildFilter(model, modelAlias, subPayload))),
-            )
+            .with('OR', () => {
+                const allBranches = enumerate(payload).map((subPayload) =>
+                    this.buildFilter(model, modelAlias, subPayload)
+                );
+                const meaningfulBranches = allBranches.filter((expr) => !this.isTrue(expr));
+                if (meaningfulBranches.length === 0) {
+                    return allBranches.length > 0 ? this.true() : this.false();
+                }
+                return this.or(...meaningfulBranches);
+            })
             .with('NOT', () => this.eb.not(this.buildCompositeFilter(model, modelAlias, 'AND', payload)))
             .exhaustive();
     }

--- a/packages/orm/src/client/crud/dialects/base-dialect.ts
+++ b/packages/orm/src/client/crud/dialects/base-dialect.ts
@@ -24,10 +24,10 @@ import {
     flattenCompoundUniqueFilters,
     getDelegateDescendantModels,
     getManyToManyRelation,
+    getModelFields,
     getRelationForeignKeyFieldPairs,
     isEnum,
     isTypeDef,
-    getModelFields,
     makeDefaultOrderBy,
     requireField,
     requireIdFields,
@@ -260,17 +260,41 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
         key: (typeof LOGICAL_COMBINATORS)[number],
         payload: any,
     ): Expression<SqlBool> {
+        // Normalize payload: ensure array, remove empty objects and objects with
+        // only undefined fields values
+        const normalizedPayload = enumerate(payload).filter((el) => {
+            if (typeof el === 'object' && el !== null && !Array.isArray(el)) {
+                const entries = Object.entries(el);
+                return entries.some(([, v]) => v !== undefined);
+            } else {
+                return true;
+            }
+        });
+
+        const normalizedFilters = normalizedPayload.map((el) => this.buildFilter(model, modelAlias, el));
+
         return match(key)
-            .with('AND', () =>
-                this.and(...enumerate(payload).map((subPayload) => this.buildFilter(model, modelAlias, subPayload))),
-            )
-            .with('OR', () => {
-                const branches = enumerate(payload)
-                    .filter((subPayload) => !this.isAllUndefinedFilter(subPayload))
-                    .map((subPayload) => this.buildFilter(model, modelAlias, subPayload));
-                return this.or(...branches);
+            .with('AND', () => {
+                if (normalizedFilters.length === 0) {
+                    // AND of no conditions is a no-op, return true
+                    return this.true();
+                }
+                return this.and(...normalizedFilters);
             })
-            .with('NOT', () => this.eb.not(this.buildCompositeFilter(model, modelAlias, 'AND', payload)))
+            .with('OR', () => {
+                if (normalizedFilters.length === 0) {
+                    // OR of no conditions is always false, return false
+                    return this.false();
+                }
+                return this.or(...normalizedFilters);
+            })
+            .with('NOT', () => {
+                if (normalizedFilters.length === 0) {
+                    // NOT of no conditions is a no-op, return true
+                    return this.true();
+                }
+                return this.not(...normalizedFilters);
+            })
             .exhaustive();
     }
 
@@ -1308,14 +1332,6 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
 
     public false(): Expression<SqlBool> {
         return this.eb.lit<SqlBool>(this.transformInput(false, 'Boolean', false) as boolean);
-    }
-
-    private isAllUndefinedFilter(payload: unknown): boolean {
-        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-            return false;
-        }
-        const entries = Object.entries(payload);
-        return entries.length > 0 && entries.every(([, v]) => v === undefined);
     }
 
     public isTrue(expression: Expression<SqlBool>) {

--- a/packages/orm/src/client/crud/dialects/base-dialect.ts
+++ b/packages/orm/src/client/crud/dialects/base-dialect.ts
@@ -266,8 +266,8 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
             )
             .with('OR', () => {
                 const branches = enumerate(payload)
-                    .map((subPayload) => this.buildFilter(model, modelAlias, subPayload))
-                    .filter((expr) => !this.isTrue(expr));
+                    .filter((subPayload) => !this.isAllUndefinedFilter(subPayload))
+                    .map((subPayload) => this.buildFilter(model, modelAlias, subPayload));
                 return this.or(...branches);
             })
             .with('NOT', () => this.eb.not(this.buildCompositeFilter(model, modelAlias, 'AND', payload)))
@@ -803,6 +803,9 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
             if (excludeKeys.includes(op)) {
                 continue;
             }
+            if (value === undefined) {
+                continue;
+            }
             const rhs = Array.isArray(value) ? value.map(getRhs) : getRhs(value);
             const condition = match(op)
                 .with('equals', () => (rhs === null ? this.eb(lhs, 'is', null) : this.eb(lhs, '=', rhs)))
@@ -881,6 +884,10 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
             for (const [key, value] of Object.entries(payload)) {
                 if (key === 'mode' || consumedKeys.includes(key)) {
                     // already consumed
+                    continue;
+                }
+
+                if (value === undefined) {
                     continue;
                 }
 
@@ -1165,7 +1172,8 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
 
         // client-level: check both uncapitalized (current) and original (backward compat) model name
         const uncapModel = lowerCaseFirst(model);
-        const omitConfig = (this.options.omit as Record<string, any> | undefined)?.[uncapModel] ??
+        const omitConfig =
+            (this.options.omit as Record<string, any> | undefined)?.[uncapModel] ??
             (this.options.omit as Record<string, any> | undefined)?.[model];
         if (omitConfig && typeof omitConfig === 'object' && typeof omitConfig[field] === 'boolean') {
             return omitConfig[field];
@@ -1302,6 +1310,14 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
         return this.eb.lit<SqlBool>(this.transformInput(false, 'Boolean', false) as boolean);
     }
 
+    private isAllUndefinedFilter(payload: unknown): boolean {
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+            return false;
+        }
+        const entries = Object.entries(payload);
+        return entries.length > 0 && entries.every(([, v]) => v === undefined);
+    }
+
     public isTrue(expression: Expression<SqlBool>) {
         const node = expression.toOperationNode();
         if (node.kind !== 'ValueNode') {
@@ -1360,7 +1376,9 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
                 const computedFields = this.options.computedFields as Record<string, any>;
                 // check both uncapitalized (current) and original (backward compat) model name
                 const computedModel = fieldDef.originModel ?? model;
-                computer = computedFields?.[lowerCaseFirst(computedModel)]?.[field] ?? computedFields?.[computedModel]?.[field];
+                computer =
+                    computedFields?.[lowerCaseFirst(computedModel)]?.[field] ??
+                    computedFields?.[computedModel]?.[field];
             }
             if (!computer) {
                 throw createConfigError(`Computed field "${field}" implementation not provided for model "${model}"`);

--- a/packages/orm/src/client/crud/operations/base.ts
+++ b/packages/orm/src/client/crud/operations/base.ts
@@ -2531,17 +2531,11 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
 
     private doNormalizeArgs(args: unknown) {
         if (args && typeof args === 'object') {
-            if (Array.isArray(args)) {
-                for (const element of args) {
-                    this.doNormalizeArgs(element);
-                }
-            } else {
-                for (const [key, value] of Object.entries(args)) {
-                    if (value === undefined) {
-                        delete args[key as keyof typeof args];
-                    } else if (value && (isPlainObject(value) || Array.isArray(value))) {
-                        this.doNormalizeArgs(value);
-                    }
+            for (const [key, value] of Object.entries(args)) {
+                if (value === undefined) {
+                    delete args[key as keyof typeof args];
+                } else if (value && isPlainObject(value)) {
+                    this.doNormalizeArgs(value);
                 }
             }
         }

--- a/packages/orm/src/client/crud/operations/base.ts
+++ b/packages/orm/src/client/crud/operations/base.ts
@@ -2539,7 +2539,7 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
                 for (const [key, value] of Object.entries(args)) {
                     if (value === undefined) {
                         delete args[key as keyof typeof args];
-                    } else if (value && isPlainObject(value)) {
+                    } else if (value && (isPlainObject(value) || Array.isArray(value))) {
                         this.doNormalizeArgs(value);
                     }
                 }

--- a/packages/orm/src/client/crud/operations/base.ts
+++ b/packages/orm/src/client/crud/operations/base.ts
@@ -2531,11 +2531,17 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
 
     private doNormalizeArgs(args: unknown) {
         if (args && typeof args === 'object') {
-            for (const [key, value] of Object.entries(args)) {
-                if (value === undefined) {
-                    delete args[key as keyof typeof args];
-                } else if (value && isPlainObject(value)) {
-                    this.doNormalizeArgs(value);
+            if (Array.isArray(args)) {
+                for (const element of args) {
+                    this.doNormalizeArgs(element);
+                }
+            } else {
+                for (const [key, value] of Object.entries(args)) {
+                    if (value === undefined) {
+                        delete args[key as keyof typeof args];
+                    } else if (value && isPlainObject(value)) {
+                        this.doNormalizeArgs(value);
+                    }
                 }
             }
         }

--- a/packages/orm/src/client/crud/operations/base.ts
+++ b/packages/orm/src/client/crud/operations/base.ts
@@ -18,7 +18,7 @@ import * as uuid from 'uuid';
 import type { BuiltinType, Expression, FieldDef } from '../../../schema';
 import { ExpressionUtils, type GetModels, type ModelDef, type SchemaDef } from '../../../schema';
 import type { AnyKysely } from '../../../utils/kysely-utils';
-import { extractFields, fieldsToSelectObject } from '../../../utils/object-utils';
+import { extractFields, fieldsToSelectObject, isEmptyObject } from '../../../utils/object-utils';
 import { NUMERIC_FIELD_TYPES } from '../../constants';
 import { TransactionIsolationLevel, type ClientContract, type CRUD } from '../../contract';
 import type { FindArgs, SelectIncludeOmit, WhereInput } from '../../crud-types';
@@ -1152,7 +1152,7 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
 
         const parentWhere = await this.buildUpdateParentRelationFilter(kysely, fromRelation);
 
-        let combinedWhere: Record<string, unknown> = where ?? {};
+        let combinedWhere: Record<string, unknown> = where ?? true;
         if (Object.keys(parentWhere).length > 0) {
             combinedWhere = Object.keys(combinedWhere).length > 0 ? { AND: [parentWhere, combinedWhere] } : parentWhere;
         }
@@ -1574,7 +1574,7 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
         }
 
         const parentWhere = await this.buildUpdateParentRelationFilter(kysely, fromRelation);
-        let combinedWhere: WhereInput<Schema, GetModels<Schema>, any, false> = where ?? {};
+        let combinedWhere: WhereInput<Schema, GetModels<Schema>, any, false> = where ?? true;
         if (Object.keys(parentWhere).length > 0) {
             combinedWhere = Object.keys(combinedWhere).length > 0 ? { AND: [parentWhere, combinedWhere] } : parentWhere;
         }
@@ -1890,12 +1890,12 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
                 }
 
                 case 'delete': {
-                    await this.deleteRelation(kysely, fieldModel, value, fromRelationContext, true);
+                    await this.deleteRelation(kysely, fieldModel, value, fromRelationContext, true, true);
                     break;
                 }
 
                 case 'deleteMany': {
-                    await this.deleteRelation(kysely, fieldModel, value, fromRelationContext, false);
+                    await this.deleteRelation(kysely, fieldModel, value, fromRelationContext, false, false);
                     break;
                 }
 
@@ -2031,6 +2031,9 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
             } else {
                 disconnectConditions = [true];
             }
+        } else if (isEmptyObject(data)) {
+            // empty object means true
+            disconnectConditions = [true];
         } else {
             disconnectConditions = this.normalizeRelationManipulationInput(model, data);
 
@@ -2235,15 +2238,24 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
         model: GetModels<Schema>,
         data: any,
         fromRelation: FromRelationContext,
+        uniqueDelete: boolean,
         throwForNotFound: boolean,
     ) {
         let deleteConditions: any[] = [];
-        let expectedDeleteCount: number;
+        let expectedDeleteCount = -1; // -1 means no expected delete count check
         if (typeof data === 'boolean') {
             if (data === false) {
                 return;
             } else {
                 deleteConditions = [true];
+                if (uniqueDelete) {
+                    expectedDeleteCount = 1;
+                }
+            }
+        } else if (isEmptyObject(data)) {
+            // empty object means true
+            deleteConditions = [true];
+            if (uniqueDelete) {
                 expectedDeleteCount = 1;
             }
         } else {
@@ -2251,7 +2263,10 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
             if (deleteConditions.length === 0) {
                 return;
             }
-            expectedDeleteCount = deleteConditions.length;
+            if (uniqueDelete) {
+                // each delete condition is one unique match
+                expectedDeleteCount = deleteConditions.length;
+            }
         }
 
         let deleteResult: Awaited<ReturnType<typeof this.delete>>;
@@ -2319,7 +2334,7 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
         }
 
         // validate result
-        if (throwForNotFound && expectedDeleteCount > (deleteResult.numAffectedRows ?? 0)) {
+        if (throwForNotFound && expectedDeleteCount >= 0 && expectedDeleteCount > (deleteResult.numAffectedRows ?? 0)) {
             // some entities were not deleted
             throw createNotFoundError(deleteFromModel);
         }

--- a/packages/orm/src/utils/object-utils.ts
+++ b/packages/orm/src/utils/object-utils.ts
@@ -1,3 +1,5 @@
+import { isPlainObject } from '@zenstackhq/common-helpers';
+
 /**
  * Extract fields from an object.
  */
@@ -10,4 +12,11 @@ export function extractFields(obj: any, fields: readonly string[]) {
  */
 export function fieldsToSelectObject(fields: readonly string[]): Record<string, boolean> {
     return Object.fromEntries(fields.map((f) => [f, true]));
+}
+
+/**
+ * Checks if the given value is an empty plain object.
+ */
+export function isEmptyObject(x: unknown) {
+    return isPlainObject(x) && Object.keys(x as object).length === 0;
 }

--- a/tests/e2e/orm/client-api/filter.test.ts
+++ b/tests/e2e/orm/client-api/filter.test.ts
@@ -801,7 +801,7 @@ describe('Client filter tests ', () => {
         await expect(client.user.findMany({ where: { id: undefined } })).toResolveWithLength(1);
     });
 
-    it('ignores undefined branch inside OR filter', async () => {
+    it('ignores undefined branch inside OR filters', async () => {
         await createUser('u1@test.com', {
             name: 'First',
             role: 'ADMIN',
@@ -827,9 +827,16 @@ describe('Client filter tests ', () => {
             orderBy: { createdAt: 'asc' },
         });
 
+        const onlyUndefinedBranch = await client.user.findFirst({
+            where: {
+                OR: [{ id: undefined }],
+            } as any,
+            orderBy: { createdAt: 'asc' },
+        });
+
         expect(baseline?.email).toBe(user2.email);
         expect(withUndefinedBranch?.email).toBe(baseline?.email);
+        expect(onlyUndefinedBranch).toBeNull();
     });
-
     // TODO: filter for bigint, decimal, bytes
 });

--- a/tests/e2e/orm/client-api/filter.test.ts
+++ b/tests/e2e/orm/client-api/filter.test.ts
@@ -838,5 +838,20 @@ describe('Client filter tests ', () => {
         expect(withUndefinedBranch?.email).toBe(baseline?.email);
         expect(onlyUndefinedBranch).toBeNull();
     });
+
+    it('strips undefined filter operators inside OR branches', async () => {
+        await createUser('alice@test.com', { name: 'Alice', role: 'ADMIN' });
+        await createUser('bob@test.com', { name: 'Bob', role: 'USER' });
+
+        const result = await client.user.findMany({
+            where: {
+                OR: [{ name: { startsWith: 'A', contains: undefined } }],
+            } as any,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0]!.name).toBe('Alice');
+    });
+
     // TODO: filter for bigint, decimal, bytes
 });

--- a/tests/e2e/orm/client-api/filter.test.ts
+++ b/tests/e2e/orm/client-api/filter.test.ts
@@ -801,5 +801,35 @@ describe('Client filter tests ', () => {
         await expect(client.user.findMany({ where: { id: undefined } })).toResolveWithLength(1);
     });
 
+    it('ignores undefined branch inside OR filter', async () => {
+        await createUser('u1@test.com', {
+            name: 'First',
+            role: 'ADMIN',
+            profile: { create: { id: 'p1', bio: 'bio1' } },
+        });
+        const user2 = await createUser('u2@test.com', {
+            name: 'Second',
+            role: 'USER',
+            profile: { create: { id: 'p2', bio: 'bio2' } },
+        });
+
+        const baseline = await client.user.findFirst({
+            where: {
+                OR: [{ id: user2.id }],
+            } as any,
+            orderBy: { createdAt: 'asc' },
+        });
+
+        const withUndefinedBranch = await client.user.findFirst({
+            where: {
+                OR: [{ id: undefined }, { id: user2.id }],
+            } as any,
+            orderBy: { createdAt: 'asc' },
+        });
+
+        expect(baseline?.email).toBe(user2.email);
+        expect(withUndefinedBranch?.email).toBe(baseline?.email);
+    });
+
     // TODO: filter for bigint, decimal, bytes
 });

--- a/tests/e2e/orm/client-api/filter.test.ts
+++ b/tests/e2e/orm/client-api/filter.test.ts
@@ -853,5 +853,29 @@ describe('Client filter tests ', () => {
         expect(result[0]!.name).toBe('Alice');
     });
 
+    describe('AND/OR/NOT with no-op filters', () => {
+        beforeEach(async () => {
+            await createUser('u1@test.com', { name: 'Alice', role: 'ADMIN' });
+            await createUser('u2@test.com', { name: 'Bob', role: 'USER' });
+        });
+
+        it('AND is no-op for empty array, array with all-undefined object, and plain all-undefined object', async () => {
+            await expect(client.user.findMany({ where: { AND: [] } })).toResolveWithLength(2);
+            await expect(client.user.findMany({ where: { AND: [{ id: undefined }] } })).toResolveWithLength(2);
+            await expect(client.user.findMany({ where: { AND: { id: undefined } } as any })).toResolveWithLength(2);
+        });
+
+        it('OR returns no records for empty array, array with all-undefined object, and plain all-undefined object', async () => {
+            await expect(client.user.findMany({ where: { OR: [] } })).toResolveWithLength(0);
+            await expect(client.user.findMany({ where: { OR: [{ id: undefined }] } })).toResolveWithLength(0);
+        });
+
+        it('NOT is no-op for empty array, array with all-undefined object, and plain all-undefined object', async () => {
+            await expect(client.user.findMany({ where: { NOT: [] } })).toResolveWithLength(2);
+            await expect(client.user.findMany({ where: { NOT: [{ id: undefined }] } })).toResolveWithLength(2);
+            await expect(client.user.findMany({ where: { NOT: { id: undefined } } })).toResolveWithLength(2);
+        });
+    });
+
     // TODO: filter for bigint, decimal, bytes
 });

--- a/tests/e2e/orm/client-api/find.test.ts
+++ b/tests/e2e/orm/client-api/find.test.ts
@@ -479,7 +479,7 @@ describe('Client find tests ', () => {
         ).toResolveFalsy();
 
         // NOT
-        await expect(client.user.findMany({ where: { NOT: [] } })).resolves.toHaveLength(0);
+        await expect(client.user.findMany({ where: { NOT: [] } })).resolves.toHaveLength(2);
         await expect(
             client.user.findFirst({
                 where: {


### PR DESCRIPTION
# Summary

I found this issue in our migration to v3 where behavior differed from previous prisma based v2 version.
For example queries such as:
```
await client.testItem.findMany({
    where: { OR: [{ name: undefined }] },
  });
```
Is treated by zenstack as: 
```
select "TestItem"."id" as "id", "TestItem"."name" as "name", "TestItem"."createdAt" as "createdAt" from "TestItem" where 1 
```
but prisma interpreted it as:
```
SELECT `main`.`TestItem`.`id`, `main`.`TestItem`.`name`, `main`.`TestItem`.`createdAt` FROM `main`.`TestItem` WHERE 1=0 LIMIT ? OFFSET ?
```

# Work done
- Added test to verify such case
- Added fix in code to unify the behavior to how prisma treated such cases
- Ran all tests locally and they passed

# Possible further discussions

The way zenstack interprets these queries seems more intuitive than prisma. Question is whether project aims for 1:1 behavior parity with how prisma queries data (I assume so)?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Query filters now ignore wholly-undefined branches and skip undefined operator values; AND/OR/NOT with no effective branches behave consistently (AND/NOT act as no-op/true, OR yields no matches).
  * Relation operations: empty relation payloads are treated as “match all” for disconnect/delete; single-delete vs multi-delete behavior and validation tightened so delete vs delete-many act predictably.

* **Tests**
  * Added/updated E2E tests covering these filter and relation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->