### PR TITLE
test(regression): add regression test for issue #2410

### DIFF
--- a/tests/regression/test/issue-2410.test.ts
+++ b/tests/regression/test/issue-2410.test.ts
@@ -1,0 +1,74 @@
+import { createPolicyTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2410
+describe('Regression for issue #2410', () => {
+    it('should not generate invalid SQL when related models share identical @deny field names', async () => {
+        const db = await createPolicyTestClient(
+            `
+model User {
+    id   String @id @default(cuid())
+    role String
+
+    @@allow('all', true)
+}
+
+model Thread {
+    id         String     @id @default(cuid())
+    title      String
+    apiKeyId   String     @deny('all', auth().role != 'ADMIN')
+    questions  Question[]
+
+    @@allow('all', true)
+}
+
+model Question {
+    id        String  @id @default(cuid())
+    content   String
+    apiKeyId  String  @deny('all', auth().role != 'ADMIN')
+    threadId  String
+    thread    Thread  @relation(fields: [threadId], references: [id])
+
+    @@allow('all', true)
+}
+            `,
+        );
+
+        const admin = { id: 'admin-1', role: 'ADMIN' };
+        const user = { id: 'user-1', role: 'USER' };
+
+        const thread = await db.$setAuth(admin).thread.create({
+            data: {
+                title: 'Test Thread',
+                apiKeyId: 'key-1',
+                questions: {
+                    create: [{ content: 'Q1', apiKeyId: 'key-1' }],
+                },
+            },
+        });
+
+        // updating a non-denied field on the Thread should succeed for any role
+        await expect(
+            db.$setAuth(user).thread.update({
+                where: { id: thread.id },
+                data: { title: 'Updated Thread' },
+            }),
+        ).toResolveTruthy();
+
+        // updating a denied field should be rejected for non-admin
+        await expect(
+            db.$setAuth(user).thread.update({
+                where: { id: thread.id },
+                data: { apiKeyId: 'key-2' },
+            }),
+        ).toBeRejectedByPolicy();
+
+        // updating a denied field should succeed for admin
+        await expect(
+            db.$setAuth(admin).thread.update({
+                where: { id: thread.id },
+                data: { apiKeyId: 'key-2' },
+            }),
+        ).toResolveTruthy();
+    });
+});


### PR DESCRIPTION
## Summary
- Adds a regression test for zenstackhq/zenstack#2410
- Verifies that the PolicyPlugin generates valid SQL when a parent model (`Thread`) and a child model (`Question`) share an identical field name (`apiKeyId`) both protected by `@deny('all', auth().role != 'ADMIN')`
- Tests that non-denied field updates succeed, denied field updates are rejected for non-admins, and allowed for admins

## Test plan
- [ ] `TEST_DB_PROVIDER=sqlite vitest run test/issue-2410.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test verifying that policy enforcement correctly handles related models with identically-named denied fields, ensuring proper role-based access control for nested record operations and field updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->