### PR TITLE
fix(orm): fix _count returning 0 for self-referential relations on delegate models

### DIFF
--- a/packages/orm/src/client/crud/dialects/base-dialect.ts
+++ b/packages/orm/src/client/crud/dialects/base-dialect.ts
@@ -1292,25 +1292,29 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
             const fieldModel = fieldDef.type as GetModels<Schema>;
             let fieldCountQuery: SelectQueryBuilder<any, any, any>;
 
+            // Use a unique alias for the subquery to avoid ambiguous references when
+            // fieldModel === model (self-referential relation on a delegate model)
+            const subQueryAlias = tmpAlias(`${parentAlias}$_${field}$count`);
+
             // join conditions
             const m2m = getManyToManyRelation(this.schema, model, field);
             if (m2m) {
                 // many-to-many relation, count the join table
-                fieldCountQuery = this.buildModelSelect(fieldModel, fieldModel, value as any, false)
+                fieldCountQuery = this.buildModelSelect(fieldModel, subQueryAlias, value as any, false)
                     .innerJoin(m2m.joinTable, (join) =>
                         join
-                            .onRef(`${m2m.joinTable}.${m2m.otherFkName}`, '=', `${fieldModel}.${m2m.otherPKName}`)
+                            .onRef(`${m2m.joinTable}.${m2m.otherFkName}`, '=', `${subQueryAlias}.${m2m.otherPKName}`)
                             .onRef(`${m2m.joinTable}.${m2m.parentFkName}`, '=', `${parentAlias}.${m2m.parentPKName}`),
                     )
                     .select(eb.fn.countAll().as(`_count$${field}`));
             } else {
                 // build a nested query to count the number of records in the relation
-                fieldCountQuery = this.buildModelSelect(fieldModel, fieldModel, value as any, false).select(
+                fieldCountQuery = this.buildModelSelect(fieldModel, subQueryAlias, value as any, false).select(
                     eb.fn.countAll().as(`_count$${field}`),
                 );
 
                 // join conditions
-                const joinPairs = buildJoinPairs(this.schema, model, parentAlias, field, fieldModel);
+                const joinPairs = buildJoinPairs(this.schema, model, parentAlias, field, subQueryAlias);
                 for (const [left, right] of joinPairs) {
                     fieldCountQuery = fieldCountQuery.whereRef(left, '=', right);
                 }

--- a/tests/regression/test/issue-2452.test.ts
+++ b/tests/regression/test/issue-2452.test.ts
@@ -7,9 +7,9 @@ describe('Regression for issue 2452', () => {
         const db = await createTestClient(
             `
 enum ContentType {
-    POST
-    ARTICLE
-    QUESTION
+    Post
+    Article
+    Question
 }
 
 model Content {
@@ -24,6 +24,7 @@ model Post extends Content {
     parent   Post?   @relation("PostReplies", fields: [parentId], references: [id])
 }
         `,
+            { provider: 'postgresql' },
         );
 
         // Create a parent post with 2 replies

--- a/tests/regression/test/issue-2452.test.ts
+++ b/tests/regression/test/issue-2452.test.ts
@@ -1,0 +1,47 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2452
+describe('Regression for issue 2452', () => {
+    it('should return correct _count for self-referential relations in delegate models', async () => {
+        const db = await createTestClient(
+            `
+enum ContentType {
+    POST
+    ARTICLE
+    QUESTION
+}
+
+model Content {
+    id   Int         @id @default(autoincrement())
+    type ContentType
+    @@delegate(type)
+}
+
+model Post extends Content {
+    replies  Post[]  @relation("PostReplies")
+    parentId Int?
+    parent   Post?   @relation("PostReplies", fields: [parentId], references: [id])
+}
+        `,
+        );
+
+        // Create a parent post with 2 replies
+        const parent = await db.post.create({
+            data: {
+                replies: {
+                    create: [{}, {}],
+                },
+            },
+        });
+
+        // Query with _count should return the correct count
+        const result = await db.post.findFirst({
+            where: { id: parent.id },
+            include: { _count: { select: { replies: true } } },
+        });
+
+        expect(result).toBeTruthy();
+        expect(result._count.replies).toBe(2);
+    });
+});

--- a/tests/regression/test/issue-2452.test.ts
+++ b/tests/regression/test/issue-2452.test.ts
@@ -24,7 +24,6 @@ model Post extends Content {
     parent   Post?   @relation("PostReplies", fields: [parentId], references: [id])
 }
         `,
-            { provider: 'postgresql' },
         );
 
         // Create a parent post with 2 replies


### PR DESCRIPTION
## Summary

- `_count` aggregation always returned `0` for self-referential relations on `@@delegate` models (e.g. `Post.replies: Post[]` where `Post extends Content` with `@@delegate`)
- Root cause: `buildCountJson` used `fieldModel` as the subquery alias; for self-referential relations `fieldModel === model`, so both sides of the correlated `WHERE` clause resolved to the inner table — no rows matched
- Fix: generate a unique `subQueryAlias` via `tmpAlias()` for the subquery, so the correlated join correctly references the outer vs inner table (same pattern used by `buildToOneRelationFilter` and `buildRelationJoinFilter`)

Fixes #2452

## Test plan

- [x] Added regression test `tests/regression/test/issue-2452.test.ts` that reproduces the bug (creates a parent Post with 2 replies, asserts `_count.replies === 2`)
- [x] All 160 regression tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected relation count queries that could report wrong counts for self-referential and delegated relations, ensuring accurate _count results when including related records.

* **Tests**
  * Added a regression test that creates a self-referential scenario, inserts nested replies, and verifies _count returns the expected value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->