### PR TITLE
fix(orm): preserve array mutation shape for optional typed-JSON fields

### DIFF
--- a/packages/orm/src/client/zod/factory.ts
+++ b/packages/orm/src/client/zod/factory.ts
@@ -613,8 +613,9 @@ export class ZodSchemaFactory<
     // For optional typed JSON fields, allow DbNull, JsonNull, and null.
     // z.union doesn't work here because `z.any()` (returned by `makeScalarSchema`)
     // always wins, so we create a wrapper superRefine instead.
-    private makeNullableTypedJsonMutationSchema(type: string, attributes?: readonly AttributeApplication[]) {
-        const baseSchema = this.makeScalarSchema(type, attributes);
+    // The caller must pass the already-built fieldSchema so that array/list
+    // mutation shapes (set, push, etc.) are preserved.
+    private makeNullableTypedJsonMutationSchema(fieldSchema: z.ZodTypeAny) {
         return z
             .any()
             .superRefine((value, ctx) => {
@@ -626,7 +627,7 @@ export class ZodSchemaFactory<
                 ) {
                     return;
                 }
-                const parseResult = baseSchema.safeParse(value);
+                const parseResult = fieldSchema.safeParse(value);
                 if (!parseResult.success) {
                     parseResult.error.issues.forEach((issue) => ctx.addIssue(issue as any));
                 }
@@ -1337,7 +1338,7 @@ export class ZodSchemaFactory<
                         // DbNull for Json fields
                         fieldSchema = z.union([fieldSchema, z.instanceof(DbNullClass)]);
                     } else if (this.isTypeDefType(fieldDef.type)) {
-                        fieldSchema = this.makeNullableTypedJsonMutationSchema(fieldDef.type, fieldDef.attributes);
+                        fieldSchema = this.makeNullableTypedJsonMutationSchema(fieldSchema);
                     } else {
                         fieldSchema = fieldSchema.nullable();
                     }
@@ -1697,7 +1698,7 @@ export class ZodSchemaFactory<
                         // DbNull for Json fields
                         fieldSchema = z.union([fieldSchema, z.instanceof(DbNullClass)]);
                     } else if (this.isTypeDefType(fieldDef.type)) {
-                        fieldSchema = this.makeNullableTypedJsonMutationSchema(fieldDef.type, fieldDef.attributes);
+                        fieldSchema = this.makeNullableTypedJsonMutationSchema(fieldSchema);
                     } else {
                         fieldSchema = fieldSchema.nullable();
                     }


### PR DESCRIPTION
## Summary

- `makeNullableTypedJsonMutationSchema` was calling `makeScalarSchema(type, attributes)` internally, which discarded the already-built `fieldSchema` passed by callers — including any array/list mutation shape (`{ set }` on create, `{ set, push }` on update)
- Changed the function to accept a `fieldSchema: z.ZodTypeAny` parameter and use it directly in `safeParse` instead of reconstructing from scratch
- Updated both callers (create schema and update schema) to pass the pre-built `fieldSchema`

## Test plan

- [ ] Verify optional typed-JSON array fields accept `{ set: [...] }` on create
- [ ] Verify optional typed-JSON array fields accept `{ set, push }` operators on update
- [ ] Verify null / `DbNull` / `JsonNull` sentinels still pass validation for optional typed-JSON fields
- [ ] Run existing regression tests: `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal schema validation handling to improve efficiency and consistency in data mutation processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->