### PR TITLE
fix(tanstack-query): propagate TPageParam generic through useInfiniteFindMany

### DIFF
--- a/packages/clients/tanstack-query/src/react.ts
+++ b/packages/clients/tanstack-query/src/react.ts
@@ -119,15 +119,15 @@ export type ModelSuspenseQueryResult<T> = UseSuspenseQueryResult<WithOptimistic<
     queryKey: QueryKey;
 };
 
-export type ModelInfiniteQueryOptions<T> = Omit<
-    UseInfiniteQueryOptions<T, DefaultError, InfiniteData<T>>,
+export type ModelInfiniteQueryOptions<T, TPageParam = unknown> = Omit<
+    UseInfiniteQueryOptions<T, DefaultError, InfiniteData<T, TPageParam>, QueryKey, TPageParam>,
     'queryKey' | 'initialPageParam'
 >;
 
 export type ModelInfiniteQueryResult<T> = UseInfiniteQueryResult<T, DefaultError> & { queryKey: QueryKey };
 
-export type ModelSuspenseInfiniteQueryOptions<T> = Omit<
-    UseSuspenseInfiniteQueryOptions<T, DefaultError, InfiniteData<T>>,
+export type ModelSuspenseInfiniteQueryOptions<T, TPageParam = unknown> = Omit<
+    UseSuspenseInfiniteQueryOptions<T, DefaultError, InfiniteData<T, TPageParam>, QueryKey, TPageParam>,
     'queryKey' | 'initialPageParam'
 >;
 
@@ -263,15 +263,15 @@ export type ModelQueryHooks<
             options?: ModelSuspenseQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>,
         ): ModelSuspenseQueryResult<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>;
 
-        useInfiniteFindMany<T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>>(
+        useInfiniteFindMany<T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>, TPageParam = unknown>(
             args?: SelectSubset<T, FindManyArgs<Schema, Model, Options, {}, ExtResult>>,
-            options?: ModelInfiniteQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>,
-        ): ModelInfiniteQueryResult<InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>>;
+            options?: ModelInfiniteQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>,
+        ): ModelInfiniteQueryResult<InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>>;
 
-        useSuspenseInfiniteFindMany<T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>>(
+        useSuspenseInfiniteFindMany<T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>, TPageParam = unknown>(
             args?: SelectSubset<T, FindManyArgs<Schema, Model, Options, {}, ExtResult>>,
-            options?: ModelSuspenseInfiniteQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>,
-        ): ModelSuspenseInfiniteQueryResult<InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>>;
+            options?: ModelSuspenseInfiniteQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>,
+        ): ModelSuspenseInfiniteQueryResult<InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>>;
 
         useCreate<T extends CreateArgs<Schema, Model, Options, {}, ExtResult>>(
             options?: ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>, T>,
@@ -592,14 +592,14 @@ export function useInternalSuspenseQuery<TQueryFnData, TData>(
     };
 }
 
-export function useInternalInfiniteQuery<TQueryFnData, TData>(
+export function useInternalInfiniteQuery<TQueryFnData, TData, TPageParam = unknown>(
     _schema: SchemaDef,
     model: string,
     operation: string,
     args: unknown,
     options:
         | (Omit<
-              UseInfiniteQueryOptions<TQueryFnData, DefaultError, InfiniteData<TData>>,
+              UseInfiniteQueryOptions<TQueryFnData, DefaultError, InfiniteData<TData, TPageParam>, QueryKey, TPageParam>,
               'queryKey' | 'initialPageParam'
           > &
               QueryContext)
@@ -615,19 +615,19 @@ export function useInternalInfiniteQuery<TQueryFnData, TData>(
             queryFn: ({ pageParam, signal }) => {
                 return fetcher<TQueryFnData>(makeUrl(endpoint, model, operation, pageParam ?? args), { signal }, fetch);
             },
-            initialPageParam: args,
+            initialPageParam: args as TPageParam,
             ...options,
         }),
     };
 }
 
-export function useInternalSuspenseInfiniteQuery<TQueryFnData, TData>(
+export function useInternalSuspenseInfiniteQuery<TQueryFnData, TData, TPageParam = unknown>(
     _schema: SchemaDef,
     model: string,
     operation: string,
     args: unknown,
     options: Omit<
-        UseSuspenseInfiniteQueryOptions<TQueryFnData, DefaultError, InfiniteData<TData>> & QueryContext,
+        UseSuspenseInfiniteQueryOptions<TQueryFnData, DefaultError, InfiniteData<TData, TPageParam>, QueryKey, TPageParam> & QueryContext,
         'queryKey' | 'initialPageParam'
     >,
 ) {
@@ -640,7 +640,7 @@ export function useInternalSuspenseInfiniteQuery<TQueryFnData, TData>(
             queryFn: ({ pageParam, signal }) => {
                 return fetcher<TQueryFnData>(makeUrl(endpoint, model, operation, pageParam ?? args), { signal }, fetch);
             },
-            initialPageParam: args,
+            initialPageParam: args as TPageParam,
             ...options,
         }),
     };

--- a/packages/clients/tanstack-query/src/svelte/index.svelte.ts
+++ b/packages/clients/tanstack-query/src/svelte/index.svelte.ts
@@ -504,7 +504,7 @@ export function useInternalInfiniteQuery<TQueryFnData, TData, TPageParam = unkno
     _schema: SchemaDef,
     model: string,
     operation: string,
-    args: Accessor<unknown>,
+    args?: Accessor<unknown>,
     options?: Accessor<
         Omit<
             CreateInfiniteQueryOptions<
@@ -521,16 +521,16 @@ export function useInternalInfiniteQuery<TQueryFnData, TData, TPageParam = unkno
 ) {
     const { endpoint, fetch } = useFetchOptions(options);
 
-    const queryKey = $derived(getQueryKey(model, operation, args(), { infinite: true, optimisticUpdate: false }));
+    const queryKey = $derived(getQueryKey(model, operation, args?.(), { infinite: true, optimisticUpdate: false }));
 
     const finalOptions = () => {
         const queryFn: QueryFunction<TQueryFnData, QueryKey, TPageParam> = ({ pageParam, signal }) =>
-            fetcher<TQueryFnData>(makeUrl(endpoint, model, operation, pageParam ?? args()), { signal }, fetch);
+            fetcher<TQueryFnData>(makeUrl(endpoint, model, operation, pageParam ?? args?.()), { signal }, fetch);
         const optionsValue = options?.() ?? { getNextPageParam: () => undefined };
         return {
             queryKey,
             queryFn,
-            initialPageParam: args() as TPageParam,
+            initialPageParam: args?.() as TPageParam,
             ...optionsValue,
         };
     };

--- a/packages/clients/tanstack-query/src/svelte/index.svelte.ts
+++ b/packages/clients/tanstack-query/src/svelte/index.svelte.ts
@@ -125,8 +125,8 @@ export type ModelQueryOptions<T> = Omit<CreateQueryOptions<T, DefaultError>, 'qu
 
 export type ModelQueryResult<T> = CreateQueryResult<WithOptimistic<T>, DefaultError> & { queryKey: QueryKey };
 
-export type ModelInfiniteQueryOptions<T> = Omit<
-    CreateInfiniteQueryOptions<T, DefaultError, InfiniteData<T>>,
+export type ModelInfiniteQueryOptions<T, TPageParam = unknown> = Omit<
+    CreateInfiniteQueryOptions<T, DefaultError, InfiniteData<T, TPageParam>, QueryKey, TPageParam>,
     'queryKey' | 'initialPageParam'
 > &
     QueryContext;
@@ -147,7 +147,10 @@ export type ModelMutationModelResult<
     Array extends boolean = false,
     Options extends QueryOptions<Schema> = QueryOptions<Schema>,
     ExtResult extends ExtResultBase<Schema> = {},
-> = Omit<ModelMutationResult<SimplifiedResult<Schema, Model, TArgs, Options, false, Array, ExtResult>, TArgs>, 'mutateAsync'> & {
+> = Omit<
+    ModelMutationResult<SimplifiedResult<Schema, Model, TArgs, Options, false, Array, ExtResult>, TArgs>,
+    'mutateAsync'
+> & {
     mutateAsync<T extends TArgs>(
         args: T,
         options?: ModelMutationOptions<SimplifiedResult<Schema, Model, T, Options, false, Array, ExtResult>, T>,
@@ -159,7 +162,12 @@ export type ClientHooks<
     Options extends QueryOptions<Schema> = QueryOptions<Schema>,
     ExtResult extends ExtResultBase<Schema> = {},
 > = {
-    [Model in GetSlicedModels<Schema, Options> as `${Uncapitalize<Model>}`]: ModelQueryHooks<Schema, Model, Options, ExtResult>;
+    [Model in GetSlicedModels<Schema, Options> as `${Uncapitalize<Model>}`]: ModelQueryHooks<
+        Schema,
+        Model,
+        Options,
+        ExtResult
+    >;
 } & ProcedureHooks<Schema, Options>;
 
 type ProcedureHookGroup<Schema extends SchemaDef, Options extends QueryOptions<Schema>> = {
@@ -238,10 +246,14 @@ export type ModelQueryHooks<
             options?: Accessor<ModelQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>>,
         ): ModelQueryResult<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>;
 
-        useInfiniteFindMany<T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>>(
+        useInfiniteFindMany<T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>, TPageParam = unknown>(
             args?: Accessor<SelectSubset<T, FindManyArgs<Schema, Model, Options, {}, ExtResult>>>,
-            options?: Accessor<ModelInfiniteQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>>,
-        ): ModelInfiniteQueryResult<InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>>;
+            options?: Accessor<
+                ModelInfiniteQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>
+            >,
+        ): ModelInfiniteQueryResult<
+            InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>
+        >;
 
         useCreate<T extends CreateArgs<Schema, Model, Options, {}, ExtResult>>(
             options?: Accessor<ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>, T>>,
@@ -310,23 +322,20 @@ export type ModelQueryHooks<
  * const client = useClientQueries<DbType>(schema)
  * ```
  */
-export function useClientQueries<
-    SchemaOrClient extends SchemaDef | ClientContract<any, any, any, any, any>,
->(
+export function useClientQueries<SchemaOrClient extends SchemaDef | ClientContract<any, any, any, any, any>>(
     schema: InferSchema<SchemaOrClient>,
     options?: Accessor<QueryContext>,
-): ClientHooks<InferSchema<SchemaOrClient>, InferOptions<SchemaOrClient, InferSchema<SchemaOrClient>>, InferExtResult<SchemaOrClient> extends ExtResultBase<InferSchema<SchemaOrClient>> ? InferExtResult<SchemaOrClient> : {}> {
-    const result = Object.keys(schema.models).reduce(
-        (acc, model) => {
-            (acc as any)[lowerCaseFirst(model)] = useModelQueries(
-                schema as any,
-                model as any,
-                options,
-            );
-            return acc;
-        },
-        {} as any,
-    );
+): ClientHooks<
+    InferSchema<SchemaOrClient>,
+    InferOptions<SchemaOrClient, InferSchema<SchemaOrClient>>,
+    InferExtResult<SchemaOrClient> extends ExtResultBase<InferSchema<SchemaOrClient>>
+        ? InferExtResult<SchemaOrClient>
+        : {}
+> {
+    const result = Object.keys(schema.models).reduce((acc, model) => {
+        (acc as any)[lowerCaseFirst(model)] = useModelQueries(schema as any, model as any, options);
+        return acc;
+    }, {} as any);
 
     const procedures = (schema as any).procedures as Record<string, { mutation?: boolean }> | undefined;
     if (procedures) {
@@ -376,7 +385,11 @@ export function useModelQueries<
     Model extends GetModels<Schema>,
     Options extends QueryOptions<Schema>,
     ExtResult extends ExtResultBase<Schema> = {},
->(schema: Schema, model: Model, rootOptions?: Accessor<QueryContext>): ModelQueryHooks<Schema, Model, Options, ExtResult> {
+>(
+    schema: Schema,
+    model: Model,
+    rootOptions?: Accessor<QueryContext>,
+): ModelQueryHooks<Schema, Model, Options, ExtResult> {
     const modelDef = Object.values(schema.models).find((m) => m.name.toLowerCase() === model.toLowerCase());
     if (!modelDef) {
         throw new Error(`Model "${model}" not found in schema`);
@@ -487,14 +500,20 @@ export function useInternalQuery<TQueryFnData, TData>(
     return createQueryResult(query, queryKey);
 }
 
-export function useInternalInfiniteQuery<TQueryFnData, TData>(
+export function useInternalInfiniteQuery<TQueryFnData, TData, TPageParam = unknown>(
     _schema: SchemaDef,
     model: string,
     operation: string,
     args: Accessor<unknown>,
     options?: Accessor<
         Omit<
-            CreateInfiniteQueryOptions<TQueryFnData, DefaultError, InfiniteData<TData>>,
+            CreateInfiniteQueryOptions<
+                TQueryFnData,
+                DefaultError,
+                InfiniteData<TData, TPageParam>,
+                QueryKey,
+                TPageParam
+            >,
             'queryKey' | 'initialPageParam'
         > &
             QueryContext
@@ -505,18 +524,34 @@ export function useInternalInfiniteQuery<TQueryFnData, TData>(
     const queryKey = $derived(getQueryKey(model, operation, args(), { infinite: true, optimisticUpdate: false }));
 
     const finalOptions = () => {
-        const queryFn: QueryFunction<TQueryFnData, QueryKey, unknown> = ({ pageParam, signal }) =>
+        const queryFn: QueryFunction<TQueryFnData, QueryKey, TPageParam> = ({ pageParam, signal }) =>
             fetcher<TQueryFnData>(makeUrl(endpoint, model, operation, pageParam ?? args()), { signal }, fetch);
         const optionsValue = options?.() ?? { getNextPageParam: () => undefined };
         return {
             queryKey,
             queryFn,
-            initialPageParam: args(),
+            initialPageParam: args() as TPageParam,
             ...optionsValue,
         };
     };
 
-    const query = createInfiniteQuery<TQueryFnData, DefaultError, InfiniteData<TData>>(finalOptions);
+    const query = createInfiniteQuery<
+        TQueryFnData,
+        DefaultError,
+        InfiniteData<TData, TPageParam>,
+        QueryKey,
+        TPageParam
+    >(
+        finalOptions as unknown as Accessor<
+            CreateInfiniteQueryOptions<
+                TQueryFnData,
+                DefaultError,
+                InfiniteData<TData, TPageParam>,
+                QueryKey,
+                TPageParam
+            >
+        >,
+    );
     // svelte-ignore state_referenced_locally
     return createQueryResult(query, queryKey);
 }

--- a/packages/clients/tanstack-query/src/vue.ts
+++ b/packages/clients/tanstack-query/src/vue.ts
@@ -118,8 +118,11 @@ export type ModelQueryOptions<T> = MaybeRefOrGetter<
 
 export type ModelQueryResult<T> = UseQueryReturnType<WithOptimistic<T>, DefaultError> & { queryKey: Ref<QueryKey> };
 
-export type ModelInfiniteQueryOptions<T> = MaybeRefOrGetter<
-    Omit<UnwrapRef<UseInfiniteQueryOptions<T, DefaultError, InfiniteData<T>>>, 'queryKey' | 'initialPageParam'> &
+export type ModelInfiniteQueryOptions<T, TPageParam = unknown> = MaybeRefOrGetter<
+    Omit<
+        UnwrapRef<UseInfiniteQueryOptions<T, DefaultError, InfiniteData<T, TPageParam>, QueryKey, TPageParam>>,
+        'queryKey' | 'initialPageParam'
+    > &
         QueryContext
 >;
 
@@ -241,10 +244,10 @@ export type ModelQueryHooks<
             options?: MaybeRefOrGetter<ModelQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>>,
         ): ModelQueryResult<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>;
 
-        useInfiniteFindMany<T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>>(
+        useInfiniteFindMany<T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>, TPageParam = unknown>(
             args?: MaybeRefOrGetter<SelectSubset<T, FindManyArgs<Schema, Model, Options, {}, ExtResult>>>,
-            options?: MaybeRefOrGetter<ModelInfiniteQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>>,
-        ): ModelInfiniteQueryResult<InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>>;
+            options?: MaybeRefOrGetter<ModelInfiniteQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>>,
+        ): ModelInfiniteQueryResult<InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>>;
 
         useCreate<T extends CreateArgs<Schema, Model, Options, {}, ExtResult>>(
             options?: MaybeRefOrGetter<ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>, T>>,
@@ -510,14 +513,16 @@ export function useInternalQuery<TQueryFnData, TData>(
     return { queryKey, ...useQuery<TQueryFnData, DefaultError, TData>(finalOptions) };
 }
 
-export function useInternalInfiniteQuery<TQueryFnData, TData>(
+export function useInternalInfiniteQuery<TQueryFnData, TData, TPageParam = unknown>(
     _schema: SchemaDef,
     model: string,
     operation: string,
     args: MaybeRefOrGetter<unknown>,
     options: MaybeRefOrGetter<
         | (Omit<
-              UnwrapRef<UseInfiniteQueryOptions<TQueryFnData, DefaultError, InfiniteData<TData>>>,
+              UnwrapRef<
+                  UseInfiniteQueryOptions<TQueryFnData, DefaultError, InfiniteData<TData, TPageParam>, QueryKey, TPageParam>
+              >,
               'queryKey' | 'initialPageParam'
           > &
               QueryContext)
@@ -543,7 +548,7 @@ export function useInternalInfiniteQuery<TQueryFnData, TData>(
                 const reqUrl = makeUrl(endpoint, model, operation, argsValue);
                 return fetcher<TQueryFnData>(reqUrl, { signal }, fetch);
             },
-            initialPageParam: toValue(argsValue),
+            initialPageParam: toValue(argsValue) as TPageParam,
             ...toValue(options),
         };
     });

--- a/packages/clients/tanstack-query/test/react-typing.test-d.ts
+++ b/packages/clients/tanstack-query/test/react-typing.test-d.ts
@@ -37,6 +37,16 @@ describe('React client typing test', () => {
                 },
             ).data?.pages[1]?.[0]?.email,
         );
+
+        // TPageParam should be inferred from getNextPageParam, not typed as unknown
+        const infiniteResult = client.user.useInfiniteFindMany(
+            {},
+            {
+                getNextPageParam: (_lastPage, _allPages, lastPageParam: { cursor: string }) => lastPageParam,
+            },
+        );
+        check(infiniteResult.data?.pageParams[0]?.cursor);
+
         // @ts-expect-error
         check(client.user.useInfiniteFindMany().data?.pages[0]?.[0]?.$optimistic);
 

--- a/packages/clients/tanstack-query/test/svelte-typing-test.ts
+++ b/packages/clients/tanstack-query/test/svelte-typing-test.ts
@@ -43,6 +43,15 @@ check(
 // @ts-expect-error
 check(client.user.useInfiniteFindMany().data?.pages[0]?.[0]?.$optimistic);
 
+// TPageParam should be inferred from getNextPageParam, not typed as unknown
+const infiniteResult = client.user.useInfiniteFindMany(
+    () => ({}),
+    () => ({
+        getNextPageParam: (_lastPage: unknown, _allPages: unknown, lastPageParam: { cursor: string }) => lastPageParam,
+    }),
+);
+check(infiniteResult.data?.pageParams[0]?.cursor);
+
 check(client.user.useCount().data?.toFixed(2));
 check(client.user.useCount(() => ({ select: { email: true } })).data?.email.toFixed(2));
 

--- a/packages/clients/tanstack-query/test/vue-typing-test.ts
+++ b/packages/clients/tanstack-query/test/vue-typing-test.ts
@@ -38,6 +38,15 @@ check(
 // @ts-expect-error
 check(client.user.useInfiniteFindMany().data.value?.pages[0]?.[0]?.$optimistic);
 
+// TPageParam should be inferred from getNextPageParam, not typed as unknown
+const infiniteResult = client.user.useInfiniteFindMany(
+    {},
+    {
+        getNextPageParam: (_lastPage: unknown, _allPages: unknown, lastPageParam: { cursor: string }) => lastPageParam,
+    },
+);
+check(infiniteResult.data.value?.pageParams[0]?.cursor);
+
 check(client.user.useCount().data.value?.toFixed(2));
 check(client.user.useCount({ select: { email: true } }).data.value?.email.toFixed(2));
 


### PR DESCRIPTION
Adds TPageParam generic to ModelInfiniteQueryOptions, ModelSuspenseInfiniteQueryOptions, and the useInfiniteFindMany/useSuspenseInfiniteFindMany interface signatures across React, Vue, and Svelte adapters, so that lastPageParam and pageParams are properly typed instead of falling back to unknown.

Fixes #2426. Co-authored with @motopods (https://github.com/motopods/zenstack/pull/1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved TypeScript inference and typing for pagination parameters in infinite queries (React, Vue, Svelte), yielding safer paginated query results.
* **Tests**
  * Added typing tests to verify page-param inference for infinite queries across React, Vue, and Svelte.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->