### PR TITLE
chore: bump pnpm to 10.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "url": "https://github.com/zenstackhq/zenstack"
     },
     "license": "MIT",
-    "packageManager": "pnpm@10.23.0",
+    "packageManager": "pnpm@10.33.0",
     "scripts": {
         "build": "turbo run build",
         "watch": "turbo run watch build",


### PR DESCRIPTION
## Summary

- Bumps `packageManager` field in `package.json` from `pnpm@10.23.0` to `pnpm@10.33.0`

## Test plan

- [ ] CI passes with the updated pnpm version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager version to improve tooling stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->