### PR TITLE
docs: add @zenstackhq/schema to manual install command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Alternatively, you can set it up manually:
 
 ```bash
 npm install -D @zenstackhq/cli
-npm install @zenstackhq/orm
+npm install @zenstackhq/schema @zenstackhq/orm
 ```
 
 Then create a `zenstack` folder and a `schema.zmodel` file in it.


### PR DESCRIPTION
## Summary

- The manual setup instructions were missing `@zenstackhq/schema` from the `npm install` command, which is a required peer dependency of `@zenstackhq/orm`.

## Test plan

- [ ] Visual check of the updated install command in the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated manual installation instructions to specify that an additional schema package must be installed alongside the ORM package for proper setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->