### PR TITLE
fix(orm): resolve delegate-inherited fields in cursor pagination

### DIFF
--- a/packages/orm/src/client/crud/dialects/base-dialect.ts
+++ b/packages/orm/src/client/crud/dialects/base-dialect.ts
@@ -252,12 +252,17 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
                 const [field, order] = orderByItems[j]!;
                 const _order = negateOrderBy ? (order === 'asc' ? 'desc' : 'asc') : order;
                 const op = j === i ? (_order === 'asc' ? '>=' : '<=') : '=';
+                // Fields inherited from a delegate base live on the base table, which is
+                // joined with its model name as alias. See buildSelectModel/buildDelegateJoin.
+                const fieldDef = requireField(this.schema, model, field);
+                const outerAlias = fieldDef.originModel ?? modelAlias;
+                const subSelectAlias = fieldDef.originModel ?? subQueryAlias;
                 andFilters.push(
                     this.eb(
-                        this.eb.ref(`${modelAlias}.${field}`),
+                        this.eb.ref(`${outerAlias}.${field}`),
                         op,
                         this.buildSelectModel(model, subQueryAlias)
-                            .select(`${subQueryAlias}.${field}`)
+                            .select(`${subSelectAlias}.${field}`)
                             .where(cursorFilter),
                     ),
                 );

--- a/tests/regression/test/issue-2588.test.ts
+++ b/tests/regression/test/issue-2588.test.ts
@@ -1,0 +1,74 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2588
+describe('Regression for issue 2588', () => {
+    const schema = `
+model Asset {
+    id        String   @id @default(uuid())
+    createdAt DateTime @default(now())
+    assetType String
+    @@delegate(assetType)
+}
+
+model Notification extends Asset {
+    title String
+}
+`;
+
+    async function setup() {
+        const db = await createTestClient(schema);
+        const a = await db.notification.create({ data: { title: 'A' } });
+        await new Promise((r) => setTimeout(r, 2));
+        const b = await db.notification.create({ data: { title: 'B' } });
+        await new Promise((r) => setTimeout(r, 2));
+        const c = await db.notification.create({ data: { title: 'C' } });
+        return { db, a, b, c };
+    }
+
+    it('cursor + orderBy on delegate parent field does not error', async () => {
+        const { db, b } = await setup();
+
+        const result = await db.notification.findMany({
+            cursor: { id: b.id },
+            orderBy: { createdAt: 'asc' },
+        });
+
+        expect(result.map((n: any) => n.title)).toEqual(['B', 'C']);
+    });
+
+    it('cursor + skip + orderBy on delegate parent field works', async () => {
+        const { db, a } = await setup();
+
+        const result = await db.notification.findMany({
+            cursor: { id: a.id },
+            skip: 1,
+            orderBy: { createdAt: 'asc' },
+            take: 25,
+        });
+
+        expect(result.map((n: any) => n.title)).toEqual(['B', 'C']);
+    });
+
+    it('cursor + multiple orderBy mixing child and delegate fields', async () => {
+        const { db, a } = await setup();
+
+        const result = await db.notification.findMany({
+            cursor: { id: a.id },
+            orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+        });
+
+        expect(result.map((n: any) => n.title)).toEqual(['A', 'B', 'C']);
+    });
+
+    it('cursor + orderBy on child field still works', async () => {
+        const { db, b } = await setup();
+
+        const result = await db.notification.findMany({
+            cursor: { id: b.id },
+            orderBy: { title: 'asc' },
+        });
+
+        expect(result.map((n: any) => n.title)).toEqual(['B', 'C']);
+    });
+});

--- a/tests/regression/test/issue-2588.test.ts
+++ b/tests/regression/test/issue-2588.test.ts
@@ -18,11 +18,15 @@ model Notification extends Asset {
 
     async function setup() {
         const db = await createTestClient(schema);
-        const a = await db.notification.create({ data: { title: 'A' } });
-        await new Promise((r) => setTimeout(r, 2));
-        const b = await db.notification.create({ data: { title: 'B' } });
-        await new Promise((r) => setTimeout(r, 2));
-        const c = await db.notification.create({ data: { title: 'C' } });
+        const a = await db.notification.create({
+            data: { title: 'A', createdAt: new Date('2025-01-01T00:00:00Z') },
+        });
+        const b = await db.notification.create({
+            data: { title: 'B', createdAt: new Date('2025-01-02T00:00:00Z') },
+        });
+        const c = await db.notification.create({
+            data: { title: 'C', createdAt: new Date('2025-01-03T00:00:00Z') },
+        });
         return { db, a, b, c };
     }
 


### PR DESCRIPTION
## Summary

Closes #2588.

`buildCursorFilter` hardcoded the child model alias for both the outer reference and the sub-select projection, so `findMany({ cursor, orderBy: { <delegate-parent-field>: ... } })` errored with `column "Child.field" does not exist`. The fix mirrors the `originModel`-aware field resolution already used by `buildFilter` and `buildOrderBy` — when a field has `originModel`, reference the parent table alias (which `buildSelectModel` already joins using the parent's model name).

## Test plan

- [x] Added `tests/regression/test/issue-2588.test.ts` covering delegate-parent cursor, cursor+skip, mixed child/delegate orderBy, and child-only baseline.
- [x] Existing cursor tests in `tests/e2e/orm/client-api/find.test.ts` pass (18/18).
- [x] Existing delegate tests pass (23/23).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cursor-based pagination to correctly reference fields inherited from parent/delegated models, ensuring accurate ordering and stable paginated query results.

* **Tests**
  * Added a regression test suite that verifies cursor pagination and sorting when ordering by inherited/delegated fields across related models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->