### PR TITLE
fix(vscode): update language server module extension to .cjs after tsdown migration

### DIFF
--- a/packages/ide/vscode/src/extension/main.ts
+++ b/packages/ide/vscode/src/extension/main.ts
@@ -34,7 +34,7 @@ export function deactivate(): Thenable<void> | undefined {
 }
 
 function startLanguageClient(context: vscode.ExtensionContext): LanguageClient {
-    const serverModule = context.asAbsolutePath(path.join('dist', 'language-server.js'));
+    const serverModule = context.asAbsolutePath(path.join('dist', 'language-server.cjs'));
     // The debug options for the server
     // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging.
     // By setting `process.env.DEBUG_BREAK` to a truthy value, the language server will wait until a debugger is attached.


### PR DESCRIPTION
## Summary

- Updates the language server module path from `language-server.js` to `language-server.cjs` in the VSCode extension
- The tsdown build (migrated in #2580) outputs CommonJS files with `.cjs` extension instead of `.js`, causing the extension to fail loading the language server

## Test plan

- [ ] Build the VSCode extension and verify the language server starts correctly
- [ ] Verify ZModel syntax highlighting and language features work in VSCode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated language server module configuration for VS Code extension to use the latest build artifact format. This ensures the language server loads correctly in both normal and debug modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->