### PR TITLE
fix(server): declare h3 as optional peer dependency (#2601)

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -170,6 +170,7 @@
         "express": "^5.0.0",
         "fastify": "^5.0.0",
         "fastify-plugin": "^5.0.0",
+        "h3": "^1.15.0",
         "hono": "^4.6.0",
         "next": "^15.0.0 || ^16.0.0",
         "nuxt": "^4.0.0",
@@ -189,6 +190,9 @@
             "optional": true
         },
         "elysia": {
+            "optional": true
+        },
+        "h3": {
             "optional": true
         },
         "hono": {


### PR DESCRIPTION
## Summary

Fixes #2601. In 3.6.x, `dist/nuxt.d.mts` inlined `H3Event` and its transitive type graph from the pinned devDependency `h3@1.15.5`, causing TS2345 for consumers on a newer `h3` (e.g. Nuxt 4 on `h3@1.15.9`).

Root cause: the `tsup` → `tsdown` migration changed dts emission. `rolldown-plugin-dts` bundles declarations and externalizes only what's declared in `dependencies` / `peerDependencies`. `h3` was only in `devDependencies`, so its types got inlined.

This PR adds `h3` as an optional `peerDependency` (matching how `nuxt`, `next`, `express`, `fastify`, `hono`, `elysia`, `@sveltejs/kit`, `fastify-plugin` are already declared), keeping the fix consistent with the rest of the adapter deps and requiring no build-config changes.

## Test plan

- [x] Rebuild `@zenstackhq/server`; confirm `dist/nuxt.d.mts` now emits `import { H3Event, EventHandlerRequest } from "h3"` instead of inlined interfaces (size dropped to ~0.88 kB).
- [ ] Verify in a Nuxt 4 consumer (`h3@1.15.9`) that passing the handler's event into functions typed with the real `H3Event` no longer produces TS2345.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for an optional dependency to enhance compatibility with different runtime environments and project configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->