### PR TITLE
fix(policy): join base table when loading before-update entities for @@delegate sub-models

### DIFF
--- a/packages/plugins/policy/src/policy-handler.ts
+++ b/packages/plugins/policy/src/policy-handler.ts
@@ -587,11 +587,42 @@ export class PolicyHandler<Schema extends SchemaDef> extends OperationNodeTransf
         const combinedFilter = where ? conjunction(this.dialect, [where.where, policyFilter]) : policyFilter;
         const selections = beforeUpdateAccessFields ?? QueryUtils.requireIdFields(this.client.$schema, model);
 
+        // Always qualify each column with its owning table. For delegate sub-models,
+        // fields inherited from the base live in the base table and must be joined in.
+        const baseModelsToJoin = new Set<string>();
+        const selectionNodes = selections.map((f) => {
+            const fieldDef = QueryUtils.getField(this.client.$schema, model, f);
+            const owningTable = fieldDef?.originModel ?? model;
+            if (fieldDef?.originModel) {
+                baseModelsToJoin.add(fieldDef.originModel);
+            }
+            return SelectionNode.create(ReferenceNode.create(ColumnNode.create(f), TableNode.create(owningTable)));
+        });
+
+        const idFields = QueryUtils.requireIdFields(this.client.$schema, model);
+        const joins: JoinNode[] = Array.from(baseModelsToJoin).map((baseModel) =>
+            JoinNode.createWithOn(
+                'LeftJoin',
+                TableNode.create(baseModel),
+                conjunction(
+                    this.dialect,
+                    idFields.map((idField) =>
+                        BinaryOperationNode.create(
+                            ReferenceNode.create(ColumnNode.create(idField), TableNode.create(model)),
+                            OperatorNode.create('='),
+                            ReferenceNode.create(ColumnNode.create(idField), TableNode.create(baseModel)),
+                        ),
+                    ),
+                ),
+            ),
+        );
+
         const query: SelectQueryNode = {
             kind: 'SelectQueryNode',
             from: FromNode.create([TableNode.create(model)]),
+            joins: joins.length > 0 ? joins : undefined,
             where: WhereNode.create(combinedFilter),
-            selections: selections.map((f) => SelectionNode.create(ColumnNode.create(f))),
+            selections: selectionNodes,
         };
         const result = await proceed(query);
         return { fields: beforeUpdateAccessFields, rows: result.rows };

--- a/tests/regression/test/issue-2595.test.ts
+++ b/tests/regression/test/issue-2595.test.ts
@@ -1,0 +1,50 @@
+import { createPolicyTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2595
+describe('Regression for issue #2595', () => {
+    const schema = `
+model Transaction {
+    id      String @id @default(cuid())
+    variant String
+    status  String @default("Draft")
+
+    @@delegate(variant)
+    @@allow('all', true)
+    @@deny('post-update', before().status == 'Finalized' && status == 'Draft')
+}
+
+model Invoice extends Transaction {
+    invoiceNumber String?
+}
+`;
+
+    it('update on delegate sub-model with before() policy on base field does not error', async () => {
+        const db = await createPolicyTestClient(schema);
+
+        const invoice = await db.invoice.create({ data: {} });
+
+        // Should succeed: status is Draft, so the post-update deny rule doesn't fire
+        const updated = await db.invoice.update({
+            where: { id: invoice.id },
+            data: { invoiceNumber: 'INV-001' },
+        });
+
+        expect(updated.invoiceNumber).toBe('INV-001');
+    });
+
+    it('update is denied when before().status is Finalized', async () => {
+        const db = await createPolicyTestClient(schema);
+
+        const invoice = await db.invoice.create({ data: { status: 'Finalized' } });
+
+        // Should be denied: before().status == 'Finalized' && status == 'Draft' would
+        // become true if update changes status back to Draft
+        await expect(
+            db.invoice.update({
+                where: { id: invoice.id },
+                data: { status: 'Draft' },
+            }),
+        ).toBeRejectedByPolicy();
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #2595.

`loadBeforeUpdateEntities` built a plain `SELECT <fields> FROM <SubModel>` query to snapshot entity state before an update (for `post-update` / `before()` policy evaluation). When the model is a `@@delegate` sub-model, fields referenced via `before()` may live on the base table — Postgres rejects with *"column does not exist"*.

- Qualify every selected column with its owning table (`originModel ?? model`) using a `ReferenceNode` instead of a bare `ColumnNode`
- LEFT JOIN any base tables that contribute inherited fields, joining on the shared id fields
- Mirrors the same `originModel` fix applied to cursor pagination in #2591

## Test plan

- [ ] New regression test `tests/regression/test/issue-2595.test.ts` covers the failing path: update on a `@@delegate` sub-model with a `@@deny('post-update', before().<base-field> …)` policy no longer errors
- [ ] Second test case verifies the deny rule fires correctly when `before().status == 'Finalized'`
- [ ] `pnpm --filter @zenstackhq/plugin-policy exec tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query handling for delegated and inherited fields when applying policies based on base model conditions.

* **Tests**
  * Added regression test for policy enforcement on delegate sub-model field updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->