### PR TITLE
fix(orm): resolve implicit m2m join table schema for non-public PostgreSQL schemas

### DIFF
--- a/packages/orm/src/client/executor/name-mapper.ts
+++ b/packages/orm/src/client/executor/name-mapper.ts
@@ -36,6 +36,7 @@ import {
     extractModelName,
     getEnum,
     getField,
+    getManyToManyRelation,
     getModel,
     getModelFields,
     isEnum,
@@ -54,6 +55,8 @@ export class QueryNameMapper extends OperationNodeTransformer {
     private readonly modelToTableMap = new Map<string, string>();
     private readonly fieldToColumnMap = new Map<string, string>();
     private readonly enumTypeMap = new Map<string, string>();
+    // Maps implicit many-to-many join table names to their PostgreSQL schema
+    private readonly joinTableSchemaMap = new Map<string, string>();
     private readonly scopes: Scope[] = [];
     private readonly dialect: BaseCrudDialect<SchemaDef>;
 
@@ -78,6 +81,23 @@ export class QueryNameMapper extends OperationNodeTransformer {
             const mappedName = this.getMappedName(enumDef);
             if (mappedName) {
                 this.enumTypeMap.set(enumName, mappedName);
+            }
+        }
+
+        // Build a map from implicit many-to-many join table names to their PostgreSQL schema.
+        // Join tables live in the schema of the alphabetically-first model in the relation
+        // (matching Prisma's convention for both naming and placement).
+        if (client.$schema.provider.type === 'postgresql') {
+            for (const modelName of Object.keys(client.$schema.models)) {
+                for (const fieldDef of getModelFields(this.schema, modelName, { relations: true })) {
+                    const m2m = getManyToManyRelation(this.schema, modelName, fieldDef.name);
+                    if (m2m && !this.joinTableSchemaMap.has(m2m.joinTable)) {
+                        // Use the schema of whichever model comes first alphabetically —
+                        // that is where Prisma creates the join table.
+                        const owningModel = [modelName, m2m.otherModel].sort()[0]!;
+                        this.joinTableSchemaMap.set(m2m.joinTable, this.getTableSchema(owningModel) ?? 'public');
+                    }
+                }
             }
         }
     }
@@ -548,8 +568,13 @@ export class QueryNameMapper extends OperationNodeTransformer {
         if (this.schema.provider.type !== 'postgresql') {
             return undefined;
         }
+        // Implicit many-to-many join tables (e.g. _AToB) are not represented as models.
+        // Their schema is pre-computed in the constructor from the models they join.
+        if (!this.schema.models[model]) {
+            return this.joinTableSchemaMap.get(model) ?? 'public';
+        }
         let schema = this.schema.provider.defaultSchema ?? 'public';
-        const schemaAttr = this.schema.models[model]?.attributes?.find((attr) => attr.name === '@@schema');
+        const schemaAttr = this.schema.models[model].attributes?.find((attr) => attr.name === '@@schema');
         if (schemaAttr) {
             const mapArg = schemaAttr.args?.find((arg) => arg.name === 'map');
             if (mapArg && mapArg.value.kind === 'literal') {

--- a/tests/regression/test/issue-2603.test.ts
+++ b/tests/regression/test/issue-2603.test.ts
@@ -1,0 +1,129 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2603
+// Implicit many-to-many join tables live in the same schema as their models.
+// The ORM must derive that schema from the models involved rather than
+// defaulting to 'public', which would generate SQL referencing a non-existent relation.
+describe('Regression for issue 2603', () => {
+    it('implicit m2m with defaultSchema set to non-public schema', async () => {
+        const db = await createTestClient(
+            `
+datasource db {
+    provider = 'postgresql'
+    schemas = ['public', 'mySchema']
+    defaultSchema = 'mySchema'
+    url = '$DB_URL'
+}
+
+model Post {
+    id   Int    @id @default(autoincrement())
+    tags Tag[]
+}
+
+model Tag {
+    id    Int    @id @default(autoincrement())
+    name  String
+    posts Post[]
+}
+`,
+            {
+                provider: 'postgresql',
+                usePrismaPush: true,
+            },
+        );
+
+        const post = await db.post.create({
+            data: {
+                tags: {
+                    create: [{ name: 'foo' }, { name: 'bar' }],
+                },
+            },
+            include: { tags: true },
+        });
+
+        expect(post.tags).toHaveLength(2);
+        expect(post.tags.map((t: any) => t.name).sort()).toEqual(['bar', 'foo']);
+
+        const fetched = await db.post.findFirst({ include: { tags: true } });
+        expect(fetched?.tags).toHaveLength(2);
+    });
+
+    it('implicit m2m with explicit @@schema on models', async () => {
+        const db = await createTestClient(
+            `
+datasource db {
+    provider = 'postgresql'
+    schemas = ['public', 'mySchema']
+    url = '$DB_URL'
+}
+
+model Post {
+    id   Int    @id @default(autoincrement())
+    tags Tag[]
+    @@schema('mySchema')
+}
+
+model Tag {
+    id    Int    @id @default(autoincrement())
+    name  String
+    posts Post[]
+    @@schema('mySchema')
+}
+`,
+            {
+                provider: 'postgresql',
+                usePrismaPush: true,
+            },
+        );
+
+        const post = await db.post.create({
+            data: {
+                tags: {
+                    create: [{ name: 'alpha' }, { name: 'beta' }],
+                },
+            },
+            include: { tags: true },
+        });
+
+        expect(post.tags).toHaveLength(2);
+        expect(post.tags.map((t: any) => t.name).sort()).toEqual(['alpha', 'beta']);
+    });
+
+    it('implicit m2m with models in different custom schemas', async () => {
+        // Prisma places the join table in the schema of the alphabetically-first model
+        // (_PostToTag goes to schema1 because 'Post' < 'Tag').
+        const db = await createTestClient(
+            `
+datasource db {
+    provider = 'postgresql'
+    schemas = ['schema1', 'schema2', 'public']
+    url = '$DB_URL'
+}
+
+model Post {
+    id   Int    @id @default(autoincrement())
+    tags Tag[]
+    @@schema('schema1')
+}
+
+model Tag {
+    id    Int    @id @default(autoincrement())
+    name  String
+    posts Post[]
+    @@schema('schema2')
+}
+`,
+            {
+                provider: 'postgresql',
+                usePrismaPush: true,
+            },
+        );
+
+        const post = await db.post.create({
+            data: { tags: { create: [{ name: 'foo' }] } },
+            include: { tags: true },
+        });
+        expect(post.tags.map((t: any) => t.name)).toEqual(['foo']);
+    });
+});


### PR DESCRIPTION
## Summary

- Fixes #2603
- Implicit many-to-many join tables (e.g. `_PostToTag`) were always queried under the `public` schema in PostgreSQL multi-schema setups, causing a "relation does not exist" error
- The ORM now pre-computes each join table's schema at startup by looking at the alphabetically-first model in the relation — matching the convention Prisma uses when creating the join table

## Changes

- [packages/orm/src/client/executor/name-mapper.ts](packages/orm/src/client/executor/name-mapper.ts) — build `joinTableSchemaMap` in the constructor; use it in `getTableSchema` when the model is not found in `schema.models`
- [tests/regression/test/issue-2603.test.ts](tests/regression/test/issue-2603.test.ts) — regression tests covering: default schema, explicit `@@schema`, and models in different schemas

## Test plan

- [ ] `implicit m2m with defaultSchema set to non-public schema` — creates/fetches posts with tags in `mySchema`
- [ ] `implicit m2m with explicit @@schema on models` — both models pinned to `mySchema`
- [ ] `implicit m2m with models in different custom schemas` — join table lands in `schema1` (alphabetically first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of PostgreSQL implicit many-to-many relationships when databases use custom schemas. Join tables now correctly determine their location based on related models, even when different models declare different custom schemas or use a non-default schema. Nested create operations and include queries now work properly in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->