### PR TITLE
fix(better-auth): lazy-load schema-generator and expose as separate entry point

### DIFF
--- a/packages/auth-adapters/better-auth/package.json
+++ b/packages/auth-adapters/better-auth/package.json
@@ -39,6 +39,16 @@
                 "default": "./dist/index.cjs"
             }
         },
+        "./schema-generator": {
+            "import": {
+                "types": "./dist/schema-generator.d.mts",
+                "default": "./dist/schema-generator.mjs"
+            },
+            "require": {
+                "types": "./dist/schema-generator.d.cts",
+                "default": "./dist/schema-generator.cjs"
+            }
+        },
         "./package.json": {
             "import": "./package.json",
             "require": "./package.json"

--- a/packages/auth-adapters/better-auth/src/adapter.ts
+++ b/packages/auth-adapters/better-auth/src/adapter.ts
@@ -8,7 +8,6 @@ import {
     type AdapterFactoryCustomizeAdapterCreator,
     type AdapterFactoryOptions,
 } from 'better-auth/adapters';
-import { generateSchema } from './schema-generator';
 
 /**
  * Options for the ZenStack adapter factory.
@@ -209,6 +208,7 @@ export const zenstackAdapter = <Schema extends SchemaDef>(db: ClientContract<Sch
                 options: config,
 
                 createSchema: async ({ file, tables }) => {
+                    const generateSchema = (await import('./schema-generator')).generateSchema;
                     return generateSchema(file, tables, config, options);
                 },
             };

--- a/packages/auth-adapters/better-auth/tsdown.config.ts
+++ b/packages/auth-adapters/better-auth/tsdown.config.ts
@@ -1,3 +1,3 @@
 import { createConfig } from '@zenstackhq/tsdown-config';
 
-export default createConfig({ entry: { index: 'src/index.ts' } });
+export default createConfig({ entry: { index: 'src/index.ts', 'schema-generator': 'src/schema-generator.ts' } });


### PR DESCRIPTION
## Summary

- Converts the static `import { generateSchema }` in `adapter.ts` to a dynamic `import()` so the heavy ZModel schema-parsing code is only loaded when `createSchema` is actually invoked
- Adds `schema-generator` as a dedicated build entry in `tsdown.config.ts` so it can be bundled and tree-shaken independently
- Exposes `./schema-generator` as a new package export in `package.json` for consumers who want to use it directly

## Test plan

- [ ] Verify `better-auth` adapter still works end-to-end with `createSchema` flow
- [ ] Confirm the new `./schema-generator` export resolves correctly in both CJS and ESM environments
- [ ] Check that the adapter bundle size is reduced (schema-generator no longer eagerly loaded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed schema generator as a publicly available module with dedicated ESM and CommonJS entry points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #2610