### PR TITLE
fix better-auth array support

### DIFF
--- a/packages/auth-adapters/better-auth/src/adapter.ts
+++ b/packages/auth-adapters/better-auth/src/adapter.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthOptions } from '@better-auth/core';
-import type { DBAdapter, DBAdapterDebugLogOption, Where } from '@better-auth/core/db/adapter';
+import type { DBAdapter, Where } from '@better-auth/core/db/adapter';
 import { BetterAuthError } from '@better-auth/core/error';
 import type { ClientContract, ModelOperations, UpdateInput } from '@zenstackhq/orm';
 import type { GetModels, SchemaDef } from '@zenstackhq/orm/schema';
@@ -8,30 +8,9 @@ import {
     type AdapterFactoryCustomizeAdapterCreator,
     type AdapterFactoryOptions,
 } from 'better-auth/adapters';
+import { getSupportsArrays, type AdapterConfig } from './config';
 
-/**
- * Options for the ZenStack adapter factory.
- */
-export interface AdapterConfig {
-    /**
-     * Database provider
-     */
-    provider: 'sqlite' | 'postgresql';
-
-    /**
-     * Enable debug logs for the adapter
-     *
-     * @default false
-     */
-    debugLogs?: DBAdapterDebugLogOption | undefined;
-
-    /**
-     * Use plural table names
-     *
-     * @default false
-     */
-    usePlural?: boolean | undefined;
-}
+export type { AdapterConfig } from './config';
 
 /**
  * Create a Better-Auth adapter for ZenStack ORM.
@@ -220,6 +199,7 @@ export const zenstackAdapter = <Schema extends SchemaDef>(db: ClientContract<Sch
             adapterName: 'ZenStack Adapter',
             usePlural: config.usePlural ?? false,
             debugLogs: config.debugLogs ?? false,
+            supportsArrays: getSupportsArrays(config),
             transaction: (cb) =>
                 db.$transaction((tx) => {
                     const adapter = createAdapterFactory({

--- a/packages/auth-adapters/better-auth/src/config.ts
+++ b/packages/auth-adapters/better-auth/src/config.ts
@@ -1,0 +1,36 @@
+import type { DBAdapterDebugLogOption } from '@better-auth/core/db/adapter';
+
+/**
+ * Options for the ZenStack adapter factory.
+ */
+export interface AdapterConfig {
+    /**
+     * Database provider
+     */
+    provider: 'sqlite' | 'postgresql';
+
+    /**
+     * Enable debug logs for the adapter
+     *
+     * @default false
+     */
+    debugLogs?: DBAdapterDebugLogOption | undefined;
+
+    /**
+     * Use plural table names
+     *
+     * @default false
+     */
+    usePlural?: boolean | undefined;
+
+    /**
+     * Preserve Better Auth array fields as native database arrays.
+     *
+     * Defaults to true for PostgreSQL and false for SQLite.
+     */
+    supportsArrays?: boolean | undefined;
+}
+
+export function getSupportsArrays(config: AdapterConfig) {
+    return config.supportsArrays ?? config.provider === 'postgresql';
+}

--- a/packages/auth-adapters/better-auth/src/schema-generator.ts
+++ b/packages/auth-adapters/better-auth/src/schema-generator.ts
@@ -26,7 +26,7 @@ import type { DBAdapterSchemaCreation } from 'better-auth/adapters';
 import type { BetterAuthDBSchema, DBFieldAttribute, DBFieldType } from 'better-auth/db';
 import fs from 'node:fs';
 import { match } from 'ts-pattern';
-import type { AdapterConfig } from './adapter';
+import { getSupportsArrays, type AdapterConfig } from './config';
 
 export async function generateSchema(
     file: string | undefined,
@@ -95,6 +95,7 @@ async function updateSchema(
 
     let changed = false;
 
+    const supportsArrays = getSupportsArrays(config);
     for (const [name, table] of Object.entries(tables)) {
         const c = addOrUpdateModel(
             name,
@@ -102,6 +103,7 @@ async function updateSchema(
             zmodel,
             tables,
             toManyRelations,
+            supportsArrays,
             !!options.advanced?.database?.useNumberId,
         );
         changed = changed || c;
@@ -251,15 +253,15 @@ function initializeZmodel(config: AdapterConfig) {
     return zmodel;
 }
 
-function getMappedFieldType({ bigint, type }: DBFieldAttribute) {
+function getMappedFieldType({ bigint, type }: DBFieldAttribute, supportsArrays: boolean) {
     return match<DBFieldType, { type: string; array?: boolean }>(type)
         .with('string', () => ({ type: 'String' }))
         .with('number', () => (bigint ? { type: 'BigInt' } : { type: 'Int' }))
         .with('boolean', () => ({ type: 'Boolean' }))
         .with('date', () => ({ type: 'DateTime' }))
         .with('json', () => ({ type: 'Json' }))
-        .with('string[]', () => ({ type: 'String', array: true }))
-        .with('number[]', () => ({ type: 'Int', array: true }))
+        .with('string[]', () => (supportsArrays ? { type: 'String', array: true } : { type: 'Json' }))
+        .with('number[]', () => (supportsArrays ? { type: 'Int', array: true } : { type: 'Json' }))
         .when(
             (v) => Array.isArray(v) && v.every((e) => typeof e === 'string'),
             () => {
@@ -278,6 +280,7 @@ function addOrUpdateModel(
     zmodel: Model,
     tables: BetterAuthDBSchema,
     toManyRelations: Map<string, Set<string>>,
+    supportsArrays: boolean,
     numericId: boolean,
 ): boolean {
     let changed = false;
@@ -305,7 +308,7 @@ function addOrUpdateModel(
 
         if (!field.references) {
             // scalar field
-            const { array, type } = getMappedFieldType(field);
+            const { array, type } = getMappedFieldType(field, supportsArrays);
 
             const df: DataField = {
                 $type: 'DataField',

--- a/packages/auth-adapters/better-auth/test/adapter.test.ts
+++ b/packages/auth-adapters/better-auth/test/adapter.test.ts
@@ -1,0 +1,115 @@
+import type { BetterAuthOptions } from '@better-auth/core';
+import type { BetterAuthDBSchema } from 'better-auth/db';
+import fs from 'node:fs';
+import path from 'node:path';
+import tmp from 'tmp';
+import { describe, expect, it } from 'vitest';
+import { type AdapterConfig, zenstackAdapter } from '../src/adapter';
+import { generateSchema } from '../src/schema-generator';
+
+const oauthClientSchema = {
+    oauthClient: {
+        modelName: 'oauthClient',
+        fields: {
+            name: {
+                type: 'string',
+                required: true,
+            },
+            scopes: {
+                type: 'string[]',
+                required: true,
+            },
+            retryDelays: {
+                type: 'number[]',
+                required: false,
+            },
+        },
+    },
+} satisfies BetterAuthDBSchema;
+
+function makeAuthOptions() {
+    return {
+        plugins: [
+            {
+                id: 'oauth-provider',
+                schema: oauthClientSchema,
+            },
+        ],
+    } as unknown as BetterAuthOptions;
+}
+
+function makeDb(captured: { createData?: Record<string, unknown> }) {
+    return {
+        oauthClient: {
+            create: async ({ data }: { data: Record<string, unknown> }) => {
+                captured.createData = data;
+                return data;
+            },
+        },
+        $transaction: async <T>(cb: (tx: unknown) => Promise<T>) => cb(makeDb(captured)),
+    };
+}
+
+async function createOauthClient(config: AdapterConfig) {
+    const captured: { createData?: Record<string, unknown> } = {};
+    const adapter = zenstackAdapter(makeDb(captured) as any, config)(makeAuthOptions());
+
+    await adapter.create({
+        model: 'oauthClient',
+        data: {
+            id: 'client-1',
+            name: 'client',
+            scopes: ['openid', 'profile'],
+            retryDelays: [1, 2],
+        },
+        forceAllowId: true,
+    });
+
+    return captured.createData;
+}
+
+async function generateOauthClientSchema(config: AdapterConfig) {
+    const { name: workDir, removeCallback } = tmp.dirSync({ unsafeCleanup: true });
+    const schemaPath = path.join(workDir, 'schema.zmodel');
+
+    try {
+        const result = await generateSchema(schemaPath, oauthClientSchema, config, makeAuthOptions());
+        return result.code;
+    } finally {
+        if (fs.existsSync(workDir)) {
+            removeCallback();
+        }
+    }
+}
+
+describe('ZenStack Better Auth adapter', () => {
+    it('preserves native array inputs for PostgreSQL (#2615)', async () => {
+        const data = await createOauthClient({ provider: 'postgresql' });
+
+        expect(data?.scopes).toEqual(['openid', 'profile']);
+        expect(data?.retryDelays).toEqual([1, 2]);
+    });
+
+    it('serializes array inputs when native arrays are disabled (#2615)', async () => {
+        const data = await createOauthClient({ provider: 'postgresql', supportsArrays: false });
+
+        expect(data?.scopes).toBe(JSON.stringify(['openid', 'profile']));
+        expect(data?.retryDelays).toBe(JSON.stringify([1, 2]));
+    });
+
+    it('generates native array fields when the adapter supports arrays (#2615)', async () => {
+        const schema = await generateOauthClientSchema({ provider: 'postgresql' });
+
+        expect(schema).toMatch(/scopes\s+String\[\]/);
+        expect(schema).toMatch(/retryDelays\s+Int\[\]\?/);
+    });
+
+    it('generates JSON fields when the adapter does not support arrays (#2615)', async () => {
+        const schema = await generateOauthClientSchema({ provider: 'sqlite' });
+
+        expect(schema).toMatch(/scopes\s+Json/);
+        expect(schema).toMatch(/retryDelays\s+Json\?/);
+        expect(schema).not.toMatch(/scopes\s+String\[\]/);
+        expect(schema).not.toMatch(/retryDelays\s+Int\[\]/);
+    });
+});

--- a/packages/auth-adapters/better-auth/test/cli-generate.test.ts
+++ b/packages/auth-adapters/better-auth/test/cli-generate.test.ts
@@ -7,6 +7,7 @@ import tmp from 'tmp';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const packageRoot = path.join(__dirname, '..');
 
 /**
  * Helper function to generate schema using better-auth CLI
@@ -17,7 +18,7 @@ function generateSchema(configFile: string): string {
     const configPath = path.join(__dirname, configFile);
 
     execSync(`pnpm better-auth generate --config ${configPath} --output ${schemaPath} --yes`, {
-        cwd: __dirname,
+        cwd: packageRoot,
         stdio: 'pipe',
     });
 


### PR DESCRIPTION
## Summary

Fixes #2615.

This updates the ZenStack Better Auth adapter so Better Auth array fields are preserved for PostgreSQL-backed ZenStack schemas instead of being JSON-stringified before ZenStack validation. The adapter config now exposes `supportsArrays`, defaulting to native array support for PostgreSQL and disabled array support for SQLite.

Schema generation now uses the same capability decision as runtime: `string[]` and `number[]` become native `String[]` and `Int[]` when arrays are supported, and fall back to `Json` fields when they are not.

## Validation

- `pnpm --filter @zenstackhq/better-auth lint`
- `pnpm --filter @zenstackhq/better-auth build`
- `pnpm --filter @zenstackhq/better-auth test`
