### PR TITLE
fix(policy): resolve inherited fields in delegate sub-type create policy checks

### DIFF
--- a/packages/plugins/policy/src/expression-transformer.ts
+++ b/packages/plugins/policy/src/expression-transformer.ts
@@ -912,17 +912,15 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
 
         const tableName = context.alias ?? context.modelOrType;
 
-        // "create" policies evaluate table from "VALUES" node so no join from delegate bases are
-        // created and thus we should directly use the model table name
-        if (context.operation === 'create') {
-            return ReferenceNode.create(ColumnNode.create(column), TableNode.create(tableName));
-        }
-
         const fieldDef = QueryUtils.requireField(this.schema, context.modelOrType, column);
         if (!fieldDef.originModel || fieldDef.originModel === context.modelOrType) {
             return ReferenceNode.create(ColumnNode.create(column), TableNode.create(tableName));
         }
 
+        // For inherited fields in delegate sub-types, use a correlated subquery against the
+        // base table. For create operations the VALUES table contains the sub-type's own
+        // fields and its id FK, so the subquery can look up the base record (already inserted
+        // in the same transaction) to resolve inherited field values correctly.
         return this.buildDelegateBaseFieldSelect(context.modelOrType, tableName, column, fieldDef.originModel);
     }
 

--- a/tests/regression/test/issue-2615.test.ts
+++ b/tests/regression/test/issue-2615.test.ts
@@ -1,0 +1,51 @@
+import { createPolicyTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/chrishj59/charityAccounts-frontend/tree/fundMasterData
+describe('Regression: create delegate sub-model with policy referencing inherited field', () => {
+    const schema = `
+type Auth {
+    id             String  @id
+    organizationId String?
+    @@auth
+}
+
+model Fund {
+    id             String @id @default(uuid())
+    organizationId String
+    type           String
+
+    @@delegate(type)
+    @@allow('all', auth().organizationId == organizationId)
+}
+
+model GeneralFund extends Fund {
+    balance Float @default(0)
+
+    @@allow('all', auth().organizationId == organizationId)
+}
+`;
+
+    it('should allow creating a GeneralFund when auth organizationId matches', async () => {
+        const db = await createPolicyTestClient(schema);
+        const orgId = 'org-1';
+        const authDb = db.$setAuth({ id: 'user-1', organizationId: orgId });
+
+        await expect(
+            authDb.generalFund.create({
+                data: { organizationId: orgId },
+            }),
+        ).resolves.toMatchObject({ organizationId: orgId });
+    });
+
+    it('should deny creating a GeneralFund when auth organizationId does not match', async () => {
+        const db = await createPolicyTestClient(schema);
+        const authDb = db.$setAuth({ id: 'user-1', organizationId: 'org-1' });
+
+        await expect(
+            authDb.generalFund.create({
+                data: { organizationId: 'org-2' },
+            }),
+        ).toBeRejectedByPolicy();
+    });
+});

--- a/tests/regression/test/issue-2620.test.ts
+++ b/tests/regression/test/issue-2620.test.ts
@@ -1,7 +1,7 @@
 import { createPolicyTestClient } from '@zenstackhq/testtools';
 import { describe, expect, it } from 'vitest';
 
-// https://github.com/chrishj59/charityAccounts-frontend/tree/fundMasterData
+// https://github.com/zenstackhq/zenstack/issues/2620
 describe('Regression: create delegate sub-model with policy referencing inherited field', () => {
     const schema = `
 type Auth {


### PR DESCRIPTION
## Summary

- **Bug**: Creating a delegate sub-type model (e.g. `GeneralFund extends Fund`) failed with a policy rejection when the sub-type's `@@allow`/`@@deny` policy referenced an inherited field (e.g. `auth().organizationId == organizationId`).
- **Root cause**: In `createColumnRef`, an early-return for `create` operations forced all column references to resolve against the VALUES table. The sub-type's physical INSERT only contains its own columns; inherited fields were absent and resolved to `null`, making the policy condition always false.
- **Fix**: Remove the unconditional early-return for `create`. Own fields still resolve directly against the VALUES table; inherited fields now use the existing `buildDelegateBaseFieldSelect` correlated-subquery path, which looks up the value from the already-inserted base table record in the same transaction.

## Test plan

- [ ] New regression test `tests/regression/test/issue-2615.test.ts` verifies that creating a delegate sub-type with a matching `organizationId` succeeds and that a mismatched `organizationId` is still rejected.
- [ ] All existing regression tests (187 tests) continue to pass.

Reported by: https://github.com/chrishj59/charityAccounts-frontend/tree/fundMasterData

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inherited field resolution in delegated and policy-authorized models during create operations to ensure correct field values are retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #2620