### PR TITLE
fix(tanstack-query): support DbNull/JsonNull/AnyNull serialization over the wire

### DIFF
--- a/packages/clients/client-helpers/src/fetch.ts
+++ b/packages/clients/client-helpers/src/fetch.ts
@@ -1,4 +1,5 @@
 import { lowerCaseFirst } from '@zenstackhq/common-helpers';
+import { AnyNull, AnyNullClass, DbNull, DbNullClass, JsonNull, JsonNullClass } from '@zenstackhq/orm/common-types';
 import Decimal from 'decimal.js';
 import SuperJSON from 'superjson';
 import type { QueryError } from './types';
@@ -63,6 +64,33 @@ SuperJSON.registerCustom<Decimal, string>(
         deserialize: (v) => new Decimal(v),
     },
     'Decimal',
+);
+
+SuperJSON.registerCustom<DbNullClass, string>(
+    {
+        isApplicable: (v): v is DbNullClass => v instanceof DbNullClass,
+        serialize: () => 'DbNull',
+        deserialize: () => DbNull,
+    },
+    'DbNull',
+);
+
+SuperJSON.registerCustom<JsonNullClass, string>(
+    {
+        isApplicable: (v): v is JsonNullClass => v instanceof JsonNullClass,
+        serialize: () => 'JsonNull',
+        deserialize: () => JsonNull,
+    },
+    'JsonNull',
+);
+
+SuperJSON.registerCustom<AnyNullClass, string>(
+    {
+        isApplicable: (v): v is AnyNullClass => v instanceof AnyNullClass,
+        serialize: () => 'AnyNull',
+        deserialize: () => AnyNull,
+    },
+    'AnyNull',
 );
 
 /**

--- a/packages/clients/client-helpers/src/index.ts
+++ b/packages/clients/client-helpers/src/index.ts
@@ -1,3 +1,4 @@
+export { AnyNull, DbNull, JsonNull } from '@zenstackhq/orm/common-types';
 export * from './constants';
 export * from './invalidation';
 export * from './logging';

--- a/packages/clients/tanstack-query/src/react.ts
+++ b/packages/clients/tanstack-query/src/react.ts
@@ -19,7 +19,14 @@ import {
     type UseSuspenseQueryOptions,
     type UseSuspenseQueryResult,
 } from '@tanstack/react-query';
-import { createInvalidator, createOptimisticUpdater, DEFAULT_QUERY_ENDPOINT, type InferExtResult, type InferOptions, type InferSchema } from '@zenstackhq/client-helpers';
+import {
+    createInvalidator,
+    createOptimisticUpdater,
+    DEFAULT_QUERY_ENDPOINT,
+    type InferExtResult,
+    type InferOptions,
+    type InferSchema,
+} from '@zenstackhq/client-helpers';
 import { fetcher, makeUrl, marshal } from '@zenstackhq/client-helpers/fetch';
 import { lowerCaseFirst } from '@zenstackhq/common-helpers';
 import type {
@@ -69,8 +76,9 @@ import type {
     TrimSlicedOperations,
     WithOptimistic,
 } from './common/types.js';
-export type { FetchFn } from '@zenstackhq/client-helpers/fetch';
+export { AnyNull, DbNull, JsonNull } from '@zenstackhq/client-helpers';
 export type { InferExtResult, InferOptions, InferSchema } from '@zenstackhq/client-helpers';
+export type { FetchFn } from '@zenstackhq/client-helpers/fetch';
 export type { SchemaDef } from '@zenstackhq/schema';
 
 type ProcedureHookFn<
@@ -147,7 +155,10 @@ export type ModelMutationModelResult<
     Array extends boolean = false,
     Options extends QueryOptions<Schema> = QueryOptions<Schema>,
     ExtResult extends ExtResultBase<Schema> = {},
-> = Omit<ModelMutationResult<SimplifiedResult<Schema, Model, TArgs, Options, false, Array, ExtResult>, TArgs>, 'mutateAsync'> & {
+> = Omit<
+    ModelMutationResult<SimplifiedResult<Schema, Model, TArgs, Options, false, Array, ExtResult>, TArgs>,
+    'mutateAsync'
+> & {
     mutateAsync<T extends TArgs>(
         args: T,
         options?: ModelMutationOptions<SimplifiedResult<Schema, Model, T, Options, false, Array, ExtResult>, T>,
@@ -159,7 +170,12 @@ export type ClientHooks<
     Options extends QueryOptions<Schema> = QueryOptions<Schema>,
     ExtResult extends ExtResultBase<Schema> = {},
 > = {
-    [Model in GetSlicedModels<Schema, Options> as `${Uncapitalize<Model>}`]: ModelQueryHooks<Schema, Model, Options, ExtResult>;
+    [Model in GetSlicedModels<Schema, Options> as `${Uncapitalize<Model>}`]: ModelQueryHooks<
+        Schema,
+        Model,
+        Options,
+        ExtResult
+    >;
 } & ProcedureHooks<Schema, Options>;
 
 type ProcedureHookGroup<Schema extends SchemaDef, Options extends QueryOptions<Schema>> = {
@@ -265,13 +281,26 @@ export type ModelQueryHooks<
 
         useInfiniteFindMany<T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>, TPageParam = unknown>(
             args?: SelectSubset<T, FindManyArgs<Schema, Model, Options, {}, ExtResult>>,
-            options?: ModelInfiniteQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>,
-        ): ModelInfiniteQueryResult<InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>>;
+            options?: ModelInfiniteQueryOptions<
+                SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[],
+                TPageParam
+            >,
+        ): ModelInfiniteQueryResult<
+            InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>
+        >;
 
-        useSuspenseInfiniteFindMany<T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>, TPageParam = unknown>(
+        useSuspenseInfiniteFindMany<
+            T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>,
+            TPageParam = unknown,
+        >(
             args?: SelectSubset<T, FindManyArgs<Schema, Model, Options, {}, ExtResult>>,
-            options?: ModelSuspenseInfiniteQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>,
-        ): ModelSuspenseInfiniteQueryResult<InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>>;
+            options?: ModelSuspenseInfiniteQueryOptions<
+                SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[],
+                TPageParam
+            >,
+        ): ModelSuspenseInfiniteQueryResult<
+            InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>
+        >;
 
         useCreate<T extends CreateArgs<Schema, Model, Options, {}, ExtResult>>(
             options?: ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>, T>,
@@ -360,23 +389,20 @@ export type ModelQueryHooks<
  * @param schema The schema.
  * @param options Options for all queries originated from this hook.
  */
-export function useClientQueries<
-    SchemaOrClient extends SchemaDef | ClientContract<any, any, any, any, any>,
->(
+export function useClientQueries<SchemaOrClient extends SchemaDef | ClientContract<any, any, any, any, any>>(
     schema: InferSchema<SchemaOrClient>,
     options?: QueryContext,
-): ClientHooks<InferSchema<SchemaOrClient>, InferOptions<SchemaOrClient, InferSchema<SchemaOrClient>>, InferExtResult<SchemaOrClient> extends ExtResultBase<InferSchema<SchemaOrClient>> ? InferExtResult<SchemaOrClient> : {}> {
-    const result = Object.keys(schema.models).reduce(
-        (acc, model) => {
-            (acc as any)[lowerCaseFirst(model)] = useModelQueries(
-                schema as any,
-                model as any,
-                options,
-            );
-            return acc;
-        },
-        {} as any,
-    );
+): ClientHooks<
+    InferSchema<SchemaOrClient>,
+    InferOptions<SchemaOrClient, InferSchema<SchemaOrClient>>,
+    InferExtResult<SchemaOrClient> extends ExtResultBase<InferSchema<SchemaOrClient>>
+        ? InferExtResult<SchemaOrClient>
+        : {}
+> {
+    const result = Object.keys(schema.models).reduce((acc, model) => {
+        (acc as any)[lowerCaseFirst(model)] = useModelQueries(schema as any, model as any, options);
+        return acc;
+    }, {} as any);
 
     const procedures = (schema as any).procedures as Record<string, { mutation?: boolean }> | undefined;
     if (procedures) {
@@ -599,7 +625,13 @@ export function useInternalInfiniteQuery<TQueryFnData, TData, TPageParam = unkno
     args: unknown,
     options:
         | (Omit<
-              UseInfiniteQueryOptions<TQueryFnData, DefaultError, InfiniteData<TData, TPageParam>, QueryKey, TPageParam>,
+              UseInfiniteQueryOptions<
+                  TQueryFnData,
+                  DefaultError,
+                  InfiniteData<TData, TPageParam>,
+                  QueryKey,
+                  TPageParam
+              >,
               'queryKey' | 'initialPageParam'
           > &
               QueryContext)
@@ -627,7 +659,14 @@ export function useInternalSuspenseInfiniteQuery<TQueryFnData, TData, TPageParam
     operation: string,
     args: unknown,
     options: Omit<
-        UseSuspenseInfiniteQueryOptions<TQueryFnData, DefaultError, InfiniteData<TData, TPageParam>, QueryKey, TPageParam> & QueryContext,
+        UseSuspenseInfiniteQueryOptions<
+            TQueryFnData,
+            DefaultError,
+            InfiniteData<TData, TPageParam>,
+            QueryKey,
+            TPageParam
+        > &
+            QueryContext,
         'queryKey' | 'initialPageParam'
     >,
 ) {

--- a/packages/clients/tanstack-query/src/svelte/index.svelte.ts
+++ b/packages/clients/tanstack-query/src/svelte/index.svelte.ts
@@ -73,8 +73,9 @@ import type {
     TrimSlicedOperations,
     WithOptimistic,
 } from '../common/types.js';
-export type { FetchFn } from '@zenstackhq/client-helpers/fetch';
+export { AnyNull, DbNull, JsonNull } from '@zenstackhq/client-helpers';
 export type { InferExtResult, InferOptions, InferSchema } from '@zenstackhq/client-helpers';
+export type { FetchFn } from '@zenstackhq/client-helpers/fetch';
 export type { SchemaDef } from '@zenstackhq/schema';
 
 type ProcedureHookFn<

--- a/packages/clients/tanstack-query/src/vue.ts
+++ b/packages/clients/tanstack-query/src/vue.ts
@@ -71,8 +71,9 @@ import type {
     TrimSlicedOperations,
     WithOptimistic,
 } from './common/types.js';
-export type { FetchFn } from '@zenstackhq/client-helpers/fetch';
+export { AnyNull, DbNull, JsonNull } from '@zenstackhq/client-helpers';
 export type { InferExtResult, InferOptions, InferSchema } from '@zenstackhq/client-helpers';
+export type { FetchFn } from '@zenstackhq/client-helpers/fetch';
 export type { SchemaDef } from '@zenstackhq/schema';
 
 export const VueQueryContextKey = 'zenstack-vue-query-context';
@@ -156,7 +157,12 @@ export type ClientHooks<
     Options extends QueryOptions<Schema> = QueryOptions<Schema>,
     ExtResult extends ExtResultBase<Schema> = {},
 > = {
-    [Model in GetSlicedModels<Schema, Options> as `${Uncapitalize<Model>}`]: ModelQueryHooks<Schema, Model, Options, ExtResult>;
+    [Model in GetSlicedModels<Schema, Options> as `${Uncapitalize<Model>}`]: ModelQueryHooks<
+        Schema,
+        Model,
+        Options,
+        ExtResult
+    >;
 } & ProcedureHooks<Schema, Options>;
 
 type ProcedureHookGroup<Schema extends SchemaDef, Options extends QueryOptions<Schema>> = {
@@ -226,12 +232,16 @@ export type ModelQueryHooks<
     {
         useFindUnique<T extends FindUniqueArgs<Schema, Model, Options, {}, ExtResult>>(
             args: MaybeRefOrGetter<SelectSubset<T, FindUniqueArgs<Schema, Model, Options, {}, ExtResult>>>,
-            options?: MaybeRefOrGetter<ModelQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult> | null>>,
+            options?: MaybeRefOrGetter<
+                ModelQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult> | null>
+            >,
         ): ModelQueryResult<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult> | null>;
 
         useFindFirst<T extends FindFirstArgs<Schema, Model, Options, {}, ExtResult>>(
             args?: MaybeRefOrGetter<SelectSubset<T, FindFirstArgs<Schema, Model, Options, {}, ExtResult>>>,
-            options?: MaybeRefOrGetter<ModelQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult> | null>>,
+            options?: MaybeRefOrGetter<
+                ModelQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult> | null>
+            >,
         ): ModelQueryResult<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult> | null>;
 
         useExists<T extends ExistsArgs<Schema, Model, Options>>(
@@ -241,16 +251,24 @@ export type ModelQueryHooks<
 
         useFindMany<T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>>(
             args?: MaybeRefOrGetter<SelectSubset<T, FindManyArgs<Schema, Model, Options, {}, ExtResult>>>,
-            options?: MaybeRefOrGetter<ModelQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>>,
+            options?: MaybeRefOrGetter<
+                ModelQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>
+            >,
         ): ModelQueryResult<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[]>;
 
         useInfiniteFindMany<T extends FindManyArgs<Schema, Model, Options, {}, ExtResult>, TPageParam = unknown>(
             args?: MaybeRefOrGetter<SelectSubset<T, FindManyArgs<Schema, Model, Options, {}, ExtResult>>>,
-            options?: MaybeRefOrGetter<ModelInfiniteQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>>,
-        ): ModelInfiniteQueryResult<InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>>;
+            options?: MaybeRefOrGetter<
+                ModelInfiniteQueryOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>
+            >,
+        ): ModelInfiniteQueryResult<
+            InfiniteData<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], TPageParam>
+        >;
 
         useCreate<T extends CreateArgs<Schema, Model, Options, {}, ExtResult>>(
-            options?: MaybeRefOrGetter<ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>, T>>,
+            options?: MaybeRefOrGetter<
+                ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>, T>
+            >,
         ): ModelMutationModelResult<Schema, Model, T, false, Options, ExtResult>;
 
         useCreateMany<T extends CreateManyArgs<Schema, Model>>(
@@ -258,11 +276,15 @@ export type ModelQueryHooks<
         ): ModelMutationResult<BatchResult, T>;
 
         useCreateManyAndReturn<T extends CreateManyAndReturnArgs<Schema, Model, Options, {}, ExtResult>>(
-            options?: MaybeRefOrGetter<ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], T>>,
+            options?: MaybeRefOrGetter<
+                ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], T>
+            >,
         ): ModelMutationModelResult<Schema, Model, T, true, Options, ExtResult>;
 
         useUpdate<T extends UpdateArgs<Schema, Model, Options, {}, ExtResult>>(
-            options?: MaybeRefOrGetter<ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>, T>>,
+            options?: MaybeRefOrGetter<
+                ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>, T>
+            >,
         ): ModelMutationModelResult<Schema, Model, T, false, Options, ExtResult>;
 
         useUpdateMany<T extends UpdateManyArgs<Schema, Model, Options>>(
@@ -270,15 +292,21 @@ export type ModelQueryHooks<
         ): ModelMutationResult<BatchResult, T>;
 
         useUpdateManyAndReturn<T extends UpdateManyAndReturnArgs<Schema, Model, Options, {}, ExtResult>>(
-            options?: MaybeRefOrGetter<ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], T>>,
+            options?: MaybeRefOrGetter<
+                ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>[], T>
+            >,
         ): ModelMutationModelResult<Schema, Model, T, true, Options, ExtResult>;
 
         useUpsert<T extends UpsertArgs<Schema, Model, Options, {}, ExtResult>>(
-            options?: MaybeRefOrGetter<ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>, T>>,
+            options?: MaybeRefOrGetter<
+                ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>, T>
+            >,
         ): ModelMutationModelResult<Schema, Model, T, false, Options, ExtResult>;
 
         useDelete<T extends DeleteArgs<Schema, Model, Options, {}, ExtResult>>(
-            options?: MaybeRefOrGetter<ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>, T>>,
+            options?: MaybeRefOrGetter<
+                ModelMutationOptions<SimplifiedPlainResult<Schema, Model, T, Options, ExtResult>, T>
+            >,
         ): ModelMutationModelResult<Schema, Model, T, false, Options, ExtResult>;
 
         useDeleteMany<T extends DeleteManyArgs<Schema, Model, Options>>(
@@ -318,12 +346,16 @@ export type ModelQueryHooks<
  * const client = useClientQueries<DbType>(schema)
  * ```
  */
-export function useClientQueries<
-    SchemaOrClient extends SchemaDef | ClientContract<any, any, any, any, any>,
->(
+export function useClientQueries<SchemaOrClient extends SchemaDef | ClientContract<any, any, any, any, any>>(
     schema: InferSchema<SchemaOrClient>,
     options?: MaybeRefOrGetter<QueryContext>,
-): ClientHooks<InferSchema<SchemaOrClient>, InferOptions<SchemaOrClient, InferSchema<SchemaOrClient>>, InferExtResult<SchemaOrClient> extends ExtResultBase<InferSchema<SchemaOrClient>> ? InferExtResult<SchemaOrClient> : {}> {
+): ClientHooks<
+    InferSchema<SchemaOrClient>,
+    InferOptions<SchemaOrClient, InferSchema<SchemaOrClient>>,
+    InferExtResult<SchemaOrClient> extends ExtResultBase<InferSchema<SchemaOrClient>>
+        ? InferExtResult<SchemaOrClient>
+        : {}
+> {
     const merge = (rootOpt: MaybeRefOrGetter<unknown> | undefined, opt: MaybeRefOrGetter<unknown> | undefined): any => {
         return computed(() => {
             const rootVal = toValue(rootOpt) ?? {};
@@ -332,17 +364,10 @@ export function useClientQueries<
         });
     };
 
-    const result = Object.keys(schema.models).reduce(
-        (acc, model) => {
-            (acc as any)[lowerCaseFirst(model)] = useModelQueries(
-                schema as any,
-                model as any,
-                options,
-            );
-            return acc;
-        },
-        {} as any,
-    );
+    const result = Object.keys(schema.models).reduce((acc, model) => {
+        (acc as any)[lowerCaseFirst(model)] = useModelQueries(schema as any, model as any, options);
+        return acc;
+    }, {} as any);
 
     const procedures = (schema as any).procedures as Record<string, { mutation?: boolean }> | undefined;
     if (procedures) {
@@ -392,7 +417,11 @@ export function useModelQueries<
     Model extends GetModels<Schema>,
     Options extends QueryOptions<Schema>,
     ExtResult extends ExtResultBase<Schema> = {},
->(schema: Schema, model: Model, rootOptions?: MaybeRefOrGetter<QueryContext>): ModelQueryHooks<Schema, Model, Options, ExtResult> {
+>(
+    schema: Schema,
+    model: Model,
+    rootOptions?: MaybeRefOrGetter<QueryContext>,
+): ModelQueryHooks<Schema, Model, Options, ExtResult> {
     const modelDef = Object.values(schema.models).find((m) => m.name.toLowerCase() === model.toLowerCase());
     if (!modelDef) {
         throw new Error(`Model "${model}" not found in schema`);
@@ -521,7 +550,13 @@ export function useInternalInfiniteQuery<TQueryFnData, TData, TPageParam = unkno
     options: MaybeRefOrGetter<
         | (Omit<
               UnwrapRef<
-                  UseInfiniteQueryOptions<TQueryFnData, DefaultError, InfiniteData<TData, TPageParam>, QueryKey, TPageParam>
+                  UseInfiniteQueryOptions<
+                      TQueryFnData,
+                      DefaultError,
+                      InfiniteData<TData, TPageParam>,
+                      QueryKey,
+                      TPageParam
+                  >
               >,
               'queryKey' | 'initialPageParam'
           > &

--- a/packages/clients/tanstack-query/test/react-query.test.tsx
+++ b/packages/clients/tanstack-query/test/react-query.test.tsx
@@ -4,11 +4,12 @@
 
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { deserialize, serialize } from '@zenstackhq/client-helpers/fetch';
 import nock from 'nock';
 import React from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { getQueryKey } from '../src/common/query-key';
-import { QuerySettingsProvider, useClientQueries } from '../src/react';
+import { AnyNull, DbNull, JsonNull, QuerySettingsProvider, useClientQueries } from '../src/react';
 import { schema } from './schemas/basic/schema-lite';
 
 const BASE_URL = 'http://localhost';
@@ -1782,6 +1783,144 @@ describe('React Query Test', () => {
             expect(cacheData[0].$optimistic).toBe(true);
             expect(cacheData[0].id).toBeTruthy();
             expect(cacheData[0].email).toBe('foo');
+        });
+    });
+
+    describe('JSON null value serialization', () => {
+        function createWrapper() {
+            const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <QueryClientProvider client={queryClient}>
+                    <QuerySettingsProvider value={{ endpoint: `${BASE_URL}/api/model` }}>
+                        {children}
+                    </QuerySettingsProvider>
+                </QueryClientProvider>
+            );
+            return { queryClient, wrapper };
+        }
+
+        it('encodes DbNull in query filter and includes serialization metadata in URL', async () => {
+            const { wrapper } = createWrapper();
+            let capturedUri = '';
+
+            nock(BASE_URL)
+                .get(/.*/)
+                .reply(200, function (uri) {
+                    capturedUri = uri;
+                    return { data: [] };
+                });
+
+            const { result } = renderHook(
+                () => useClientQueries(schema).user.useFindMany({ where: { name: DbNull } } as any),
+                { wrapper },
+            );
+
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+            const url = new URL(capturedUri, BASE_URL);
+            expect(url.searchParams.has('meta')).toBe(true);
+
+            const q = JSON.parse(decodeURIComponent(url.searchParams.get('q')!));
+            const meta = JSON.parse(decodeURIComponent(url.searchParams.get('meta')!));
+            const reconstructed = deserialize(q, meta.serialization) as any;
+            expect(reconstructed.where.name.__brand).toBe('DbNull');
+        });
+
+        it('encodes JsonNull in query filter and includes serialization metadata in URL', async () => {
+            const { wrapper } = createWrapper();
+            let capturedUri = '';
+
+            nock(BASE_URL)
+                .get(/.*/)
+                .reply(200, function (uri) {
+                    capturedUri = uri;
+                    return { data: [] };
+                });
+
+            const { result } = renderHook(
+                () => useClientQueries(schema).user.useFindMany({ where: { name: JsonNull } } as any),
+                { wrapper },
+            );
+
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+            const url = new URL(capturedUri, BASE_URL);
+            expect(url.searchParams.has('meta')).toBe(true);
+
+            const q = JSON.parse(decodeURIComponent(url.searchParams.get('q')!));
+            const meta = JSON.parse(decodeURIComponent(url.searchParams.get('meta')!));
+            const reconstructed = deserialize(q, meta.serialization) as any;
+            expect(reconstructed.where.name.__brand).toBe('JsonNull');
+        });
+
+        it('encodes AnyNull in query filter and includes serialization metadata in URL', async () => {
+            const { wrapper } = createWrapper();
+            let capturedUri = '';
+
+            nock(BASE_URL)
+                .get(/.*/)
+                .reply(200, function (uri) {
+                    capturedUri = uri;
+                    return { data: [] };
+                });
+
+            const { result } = renderHook(
+                () => useClientQueries(schema).user.useFindMany({ where: { name: AnyNull } } as any),
+                { wrapper },
+            );
+
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+            const url = new URL(capturedUri, BASE_URL);
+            expect(url.searchParams.has('meta')).toBe(true);
+
+            const q = JSON.parse(decodeURIComponent(url.searchParams.get('q')!));
+            const meta = JSON.parse(decodeURIComponent(url.searchParams.get('meta')!));
+            const reconstructed = deserialize(q, meta.serialization) as any;
+            expect(reconstructed.where.name.__brand).toBe('AnyNull');
+        });
+
+        it('encodes DbNull in mutation body with serialization metadata', async () => {
+            const { wrapper } = createWrapper();
+            let capturedBody: any;
+
+            nock(BASE_URL)
+                .post(/.*/)
+                .reply(200, function (_uri, body) {
+                    capturedBody = body;
+                    return { data: { id: '1', name: null } };
+                });
+
+            const { result } = renderHook(() => useClientQueries(schema).user.useCreate(), { wrapper });
+
+            const dbNull = { __brand: 'DbNull' } as any;
+            act(() => result.current.mutate({ data: { email: 'test@example.com', name: dbNull } } as any));
+
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+            expect(capturedBody.meta?.serialization).toBeDefined();
+            const reconstructed = deserialize({ data: capturedBody.data }, capturedBody.meta.serialization) as any;
+            expect(reconstructed.data.name.__brand).toBe('DbNull');
+        });
+
+        it('deserializes null sentinels in server response back to branded instances', async () => {
+            const { wrapper } = createWrapper();
+
+            const dbNull = { __brand: 'DbNull' } as any;
+            const responseData = { id: '1', email: 'test@example.com', name: dbNull };
+            const { data: serializedData, meta: serializedMeta } = serialize(responseData);
+
+            nock(BASE_URL)
+                .get(/.*/)
+                .reply(200, { data: serializedData, meta: { serialization: serializedMeta } });
+
+            const { result } = renderHook(() => useClientQueries(schema).user.useFindUnique({ where: { id: '1' } }), {
+                wrapper,
+            });
+
+            await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+            expect((result.current.data as any).name.__brand).toBe('DbNull');
         });
     });
 });

--- a/packages/clients/tanstack-query/test/react-query.test.tsx
+++ b/packages/clients/tanstack-query/test/react-query.test.tsx
@@ -1893,8 +1893,7 @@ describe('React Query Test', () => {
 
             const { result } = renderHook(() => useClientQueries(schema).user.useCreate(), { wrapper });
 
-            const dbNull = { __brand: 'DbNull' } as any;
-            act(() => result.current.mutate({ data: { email: 'test@example.com', name: dbNull } } as any));
+            act(() => result.current.mutate({ data: { email: 'test@example.com', name: DbNull } } as any));
 
             await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -1906,8 +1905,7 @@ describe('React Query Test', () => {
         it('deserializes null sentinels in server response back to branded instances', async () => {
             const { wrapper } = createWrapper();
 
-            const dbNull = { __brand: 'DbNull' } as any;
-            const responseData = { id: '1', email: 'test@example.com', name: dbNull };
+            const responseData = { id: '1', email: 'test@example.com', name: DbNull };
             const { data: serializedData, meta: serializedMeta } = serialize(responseData);
 
             nock(BASE_URL)

--- a/packages/orm/package.json
+++ b/packages/orm/package.json
@@ -95,6 +95,16 @@
                 "default": "./dist/helpers.cjs"
             }
         },
+        "./common-types": {
+            "import": {
+                "types": "./dist/common-types.d.mts",
+                "default": "./dist/common-types.mjs"
+            },
+            "require": {
+                "types": "./dist/common-types.d.cts",
+                "default": "./dist/common-types.cjs"
+            }
+        },
         "./package.json": {
             "import": "./package.json",
             "require": "./package.json"

--- a/packages/orm/tsdown.config.ts
+++ b/packages/orm/tsdown.config.ts
@@ -5,6 +5,7 @@ export default createConfig({
         index: 'src/index.ts',
         schema: 'src/schema.ts',
         helpers: 'src/helpers.ts',
+        'common-types': 'src/common-types.ts',
         'dialects/sqlite': 'src/dialects/sqlite.ts',
         'dialects/postgres': 'src/dialects/postgres.ts',
         'dialects/mysql': 'src/dialects/mysql.ts',

--- a/packages/server/src/api/utils.ts
+++ b/packages/server/src/api/utils.ts
@@ -1,3 +1,4 @@
+import { AnyNull, AnyNullClass, DbNull, DbNullClass, JsonNull, JsonNullClass } from '@zenstackhq/orm/common-types';
 import { Decimal } from 'decimal.js';
 import SuperJSON from 'superjson';
 import { match } from 'ts-pattern';
@@ -37,6 +38,33 @@ export function registerCustomSerializers() {
             deserialize: (v) => new Decimal(v),
         },
         'Decimal',
+    );
+
+    SuperJSON.registerCustom<DbNullClass, string>(
+        {
+            isApplicable: (v): v is DbNullClass => v instanceof DbNullClass,
+            serialize: () => 'DbNull',
+            deserialize: () => DbNull,
+        },
+        'DbNull',
+    );
+
+    SuperJSON.registerCustom<JsonNullClass, string>(
+        {
+            isApplicable: (v): v is JsonNullClass => v instanceof JsonNullClass,
+            serialize: () => 'JsonNull',
+            deserialize: () => JsonNull,
+        },
+        'JsonNull',
+    );
+
+    SuperJSON.registerCustom<AnyNullClass, string>(
+        {
+            isApplicable: (v): v is AnyNullClass => v instanceof AnyNullClass,
+            serialize: () => 'AnyNull',
+            deserialize: () => AnyNull,
+        },
+        'AnyNull',
     );
 
     // `Buffer` is not available in edge runtime


### PR DESCRIPTION
## Summary

- Registers SuperJSON custom serializers for `DbNull`, `JsonNull`, and `AnyNull` in `@zenstackhq/client-helpers` fetch layer, so these sentinels survive HTTP round-trips when passed as query filters or mutation input from tanstack-query hooks
- Registers the same serializers in the server package's `registerCustomSerializers()` so the server can correctly deserialize them back to ORM sentinel instances
- Re-exports `DbNull`, `JsonNull`, `AnyNull` from all tanstack-query framework entry points (`react`, `vue`, `svelte`) for convenient user access

## Test plan

- [ ] New tests in `packages/clients/tanstack-query/test/react-query.test.tsx` covering all three sentinels in query filters (URL includes SuperJSON metadata) and mutation bodies, plus response deserialization
- [ ] Run `pnpm test` in `packages/clients/tanstack-query` — all 52 tests pass
- [ ] Run `pnpm test` in `packages/clients/client-helpers`

Fixes #2278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publicly expose null-sentinel types (DbNull, JsonNull, AnyNull) across clients and framework integrations.
  * Ensure these null sentinels are preserved through network serialization/deserialization so queries, mutations, and responses round-trip correctly.

* **Tests**
  * Added tests validating serialization/deserialization of null sentinels in queries, mutations, and server responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->