### PR TITLE
[PROPOSAL] feat(tanstack-query): Improvements over PR #2637 useTransaction hook for sequential transactions

### DIFF
--- a/packages/clients/tanstack-query/src/common/types.ts
+++ b/packages/clients/tanstack-query/src/common/types.ts
@@ -19,6 +19,7 @@ import type {
     OperationsRequiringCreate,
     ProcedureFunc,
     QueryOptions,
+    StepExpr,
     UpdateArgs,
     UpdateManyAndReturnArgs,
     UpdateManyArgs,
@@ -139,6 +140,17 @@ type CrudArgsMap<Schema extends SchemaDef, Model extends GetModels<Schema>> = {
     exists: ExistsArgs<Schema, Model>;
 };
 
+type TransactionArgValue<T> =
+    | T
+    | StepExpr<T>
+    | (T extends readonly (infer U)[]
+          ? TransactionArgValue<U>[]
+          : T extends object
+            ? { [K in keyof T]: TransactionArgValue<T[K]> }
+            : never);
+
+type TransactionArgs<T> = T extends object ? { [K in keyof T]: TransactionArgValue<T[K]> } : TransactionArgValue<T>;
+
 /**
  * Operations available for a given model, omitting create-style operations
  * for models that don't allow them (e.g. delegate models).
@@ -153,11 +165,13 @@ type AllowedTransactionOps<Schema extends SchemaDef, Model extends GetModels<Sch
  *
  * The `model`, `op`, and `args` fields are correlated: `op` is constrained to
  * the CRUD operations available on `model`, and `args` is typed accordingly.
+ * Transaction step expressions are allowed anywhere inside `args`, so later
+ * operations can reference values produced by earlier operations.
  */
 export type TransactionOperation<Schema extends SchemaDef> = {
     [Model in GetModels<Schema>]: {
         [Op in AllowedTransactionOps<Schema, Model>]: {} extends CrudArgsMap<Schema, Model>[Op]
-            ? { model: Model; op: Op; args?: CrudArgsMap<Schema, Model>[Op] }
-            : { model: Model; op: Op; args: CrudArgsMap<Schema, Model>[Op] };
+            ? { model: Model; op: Op; args?: TransactionArgs<CrudArgsMap<Schema, Model>[Op]> }
+            : { model: Model; op: Op; args: TransactionArgs<CrudArgsMap<Schema, Model>[Op]> };
     }[AllowedTransactionOps<Schema, Model>];
 }[GetModels<Schema>];

--- a/packages/orm/src/client/index.ts
+++ b/packages/orm/src/client/index.ts
@@ -19,6 +19,32 @@ export { ORMError, ORMErrorReason, RejectedByPolicyReason } from './errors';
 export * from './options';
 export * from './plugin';
 export type { ZenStackPromise } from './promise';
+export {
+    STEP_REF_SYMBOL,
+    EXPR_SYMBOL,
+    isStepRef,
+    isStepExpr,
+    resolveStepRefs,
+    resolveExpr,
+    $stepRef,
+    $get,
+    $item,
+    $first,
+    $filter,
+    $map,
+} from './transaction';
+export type {
+    StepRef,
+    StepExpr,
+    ExprWhere,
+    ExprFilterOp,
+    StepRefExpr,
+    StepGetExpr,
+    StepItemExpr,
+    StepFirstExpr,
+    StepFilterExpr,
+    StepMapExpr,
+} from './transaction';
 export type { ToKysely } from './query-builder';
 export * as QueryUtils from './query-utils';
 export type * from './type-utils';

--- a/packages/orm/src/client/index.ts
+++ b/packages/orm/src/client/index.ts
@@ -32,6 +32,7 @@ export {
     $first,
     $filter,
     $map,
+    TransactionInputError,
 } from './transaction';
 export type {
     StepRef,

--- a/packages/orm/src/client/transaction.ts
+++ b/packages/orm/src/client/transaction.ts
@@ -30,7 +30,7 @@ type StepRefShape = {
     /**
      * Dot-separated path to extract from the step's result.
      * Supports array bracket notation: `items[0].id`
-    */
+     */
     path?: string;
 };
 
@@ -183,13 +183,26 @@ export function $map(ref: StepExpr, extract: string): StepMapExpr<unknown> {
     return { [EXPR_SYMBOL]: 'map', ref, extract };
 }
 
+// ---- Error type for user-facing resolution failures ----
+
+/**
+ * Error thrown when a step expression cannot be resolved due to user input.
+ * Distinguished from internal errors so callers can return 4xx instead of 5xx.
+ */
+export class TransactionInputError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'TransactionInputError';
+    }
+}
+
 // ---- Detection helpers ----
 
 export function isStepRef(value: unknown): value is StepRef {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
     const v = value as Record<string, unknown>;
     return (
-        STEP_REF_SYMBOL in v &&
+        Object.prototype.hasOwnProperty.call(v, STEP_REF_SYMBOL) &&
         v[STEP_REF_SYMBOL] === true
     );
 }
@@ -197,7 +210,7 @@ export function isStepRef(value: unknown): value is StepRef {
 export function isStepExpr(value: unknown): value is StepExpr {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
     const v = value as Record<string, unknown>;
-    return typeof v[EXPR_SYMBOL] === 'string' && EXPR_SYMBOL in v;
+    return typeof v[EXPR_SYMBOL] === 'string' && Object.prototype.hasOwnProperty.call(v, EXPR_SYMBOL);
 }
 
 /** True if value is EITHER a StepRef or a StepExpr. */
@@ -207,17 +220,32 @@ export function isAnyRef(value: unknown): value is StepRef | StepExpr {
 
 // ---- Path resolution ----
 
+const FORBIDDEN_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
 type PathSegment = string | number;
 
 function parsePath(path: string): PathSegment[] {
+    if (typeof path !== 'string' || path.length === 0) {
+        throw new TransactionInputError('Path must be a non-empty string.');
+    }
     const segments: PathSegment[] = [];
     const parts = path.split('.');
     for (const part of parts) {
+        if (part.length === 0) {
+            throw new TransactionInputError(`Path contains an empty segment in "${path}".`);
+        }
         const bracketMatch = part.match(/^(\w+)\[(\d+)\]$/);
         if (bracketMatch) {
-            segments.push(bracketMatch[1]!);
+            const segmentName = bracketMatch[1]!;
+            if (FORBIDDEN_KEYS.has(segmentName)) {
+                throw new TransactionInputError(`Path segment "${segmentName}" is not allowed.`);
+            }
+            segments.push(segmentName);
             segments.push(parseInt(bracketMatch[2]!, 10));
         } else {
+            if (FORBIDDEN_KEYS.has(part)) {
+                throw new TransactionInputError(`Path segment "${part}" is not allowed.`);
+            }
             segments.push(part);
         }
     }
@@ -228,19 +256,24 @@ function resolvePath(obj: unknown, segments: PathSegment[]): unknown {
     let current = obj;
     for (const segment of segments) {
         if (current == null || typeof current !== 'object') {
-            throw new Error(
+            throw new TransactionInputError(
                 `Cannot resolve path segment "${segment}": value is ${current === null ? 'null' : typeof current}`,
             );
         }
+        if (typeof segment === 'string' && FORBIDDEN_KEYS.has(segment)) {
+            throw new TransactionInputError(`Path segment "${segment}" is not allowed.`);
+        }
         if (Array.isArray(current) && typeof segment === 'number') {
-            if (segment < 0 || segment >= current.length) {
-                throw new Error(`Array index ${segment} is out of bounds. Array has ${current.length} elements.`);
+            if (segment < 0 || !Number.isSafeInteger(segment) || segment >= current.length) {
+                throw new TransactionInputError(
+                    `Array index ${segment} is out of bounds. Array has ${current.length} elements.`,
+                );
             }
             current = current[segment];
-        } else if (typeof segment === 'string' && segment in current) {
+        } else if (typeof segment === 'string' && Object.prototype.hasOwnProperty.call(current, segment)) {
             current = (current as Record<string, unknown>)[segment];
         } else {
-            throw new Error(
+            throw new TransactionInputError(
                 `Cannot resolve path segment "${segment}" on ${Array.isArray(current) ? 'array' : typeof current}`,
             );
         }
@@ -250,30 +283,85 @@ function resolvePath(obj: unknown, segments: PathSegment[]): unknown {
 
 // ---- Expression resolution ----
 
+const VALID_EXPR_KINDS = new Set(['ref', 'get', 'item', 'first', 'filter', 'map']);
+
+function validateInteger(value: unknown, label: string): asserts value is number {
+    if (typeof value !== 'number' || !Number.isSafeInteger(value)) {
+        throw new TransactionInputError(
+            `"${label}" must be a safe integer, got ${value === null ? 'null' : typeof value}${typeof value === 'number' ? ` (${value})` : ''}`,
+        );
+    }
+}
+
+function validateExprRef(expr: StepExpr) {
+    const kind = (expr as Record<string, unknown>)[EXPR_SYMBOL];
+    if (typeof kind !== 'string' || !VALID_EXPR_KINDS.has(kind)) {
+        throw new TransactionInputError(
+            `Unknown expression type: "${String(kind)}". Supported types: ref, get, item, first, filter, map`,
+        );
+    }
+    // type-specific field validation
+    const e = expr as Record<string, unknown>;
+    if (kind === 'ref' || kind === 'get' || kind === 'item' || kind === 'first' || kind === 'filter' || kind === 'map') {
+        if (!Object.prototype.hasOwnProperty.call(e, 'ref') && kind !== 'ref') {
+            throw new TransactionInputError(`Expression of kind "${kind}" must have a "ref" field.`);
+        }
+    }
+}
+
 /**
  * Resolves a StepRef or StepExpr against accumulated step results.
  * Handles both the old `$zenstackStepRef` format and the new `$zenstackExpr` format.
+ * Supports cycle detection via an optional WeakSet.
  */
-export function resolveExpr(expr: StepExpr | StepRef, results: unknown[]): unknown {
+export function resolveExpr(
+    expr: StepExpr | StepRef,
+    results: unknown[],
+    _visited?: WeakSet<object>,
+): unknown {
+    // Cycle detection for client-side local expressions
+    const visited = _visited ?? new WeakSet<object>();
+    if (typeof expr === 'object' && expr !== null) {
+        if (visited.has(expr as object)) {
+            throw new TransactionInputError('Circular reference detected in step expression.');
+        }
+        visited.add(expr as object);
+    }
+
     // Handle old-style StepRef
     if (isStepRef(expr)) {
         const { step, path } = expr;
+        validateInteger(step, 'step');
         const resultIndex = getResultIndex(step, results);
         let value = results[resultIndex];
         if (path) {
+            if (typeof path !== 'string') {
+                throw new TransactionInputError('"path" must be a string.');
+            }
             value = resolvePath(value, parsePath(path));
         }
         return value;
     }
 
+    // Accept plain objects with EXPR_SYMBOL
+    if (!isStepExpr(expr)) {
+        throw new TransactionInputError('Expression must be an object with a valid expression marker.');
+    }
+
+    validateExprRef(expr);
+
     // Handle new-style StepExpr
-    const kind = expr[EXPR_SYMBOL];
+    const kind = (expr as Record<string, unknown>)[EXPR_SYMBOL] as string;
     switch (kind) {
         case 'ref': {
             const { step, path } = expr as Extract<StepExpr, { [EXPR_SYMBOL]: 'ref' }>;
+            validateInteger(step, 'step');
             const resultIndex = getResultIndex(step, results);
             let value = results[resultIndex];
             if (path) {
+                if (typeof path !== 'string') {
+                    throw new TransactionInputError('"path" must be a string.');
+                }
                 value = resolvePath(value, parsePath(path));
             }
             return value;
@@ -281,62 +369,74 @@ export function resolveExpr(expr: StepExpr | StepRef, results: unknown[]): unkno
 
         case 'get': {
             const { ref, path } = expr as Extract<StepExpr, { [EXPR_SYMBOL]: 'get' }>;
-            const resolved = resolveExpr(ref, results);
+            const resolved = resolveExpr(ref, results, visited);
             return resolvePath(resolved, parsePath(path));
         }
 
         case 'item': {
             const { ref, index } = expr as Extract<StepExpr, { [EXPR_SYMBOL]: 'item' }>;
-            const resolved = resolveExpr(ref, results);
+            validateInteger(index, 'index');
+            const resolved = resolveExpr(ref, results, visited);
             ensureArray(resolved, 'item', index);
             const arr = resolved as unknown[];
             if (index < 0 || index >= arr.length) {
-                throw new Error(`Array index ${index} is out of bounds. Array has ${arr.length} elements.`);
+                throw new TransactionInputError(`Array index ${index} is out of bounds. Array has ${arr.length} elements.`);
             }
             return arr[index];
         }
 
         case 'first': {
             const { ref } = expr as Extract<StepExpr, { [EXPR_SYMBOL]: 'first' }>;
-            const resolved = resolveExpr(ref, results);
+            const resolved = resolveExpr(ref, results, visited);
             ensureArray(resolved, 'first');
             const arr = resolved as unknown[];
             if (arr.length === 0) {
-                throw new Error('Cannot get first element of an empty array.');
+                throw new TransactionInputError('Cannot get first element of an empty array.');
             }
             return arr[0];
         }
 
         case 'filter': {
             const { ref, where } = expr as Extract<StepExpr, { [EXPR_SYMBOL]: 'filter' }>;
-            const resolved = resolveExpr(ref, results);
+            const resolved = resolveExpr(ref, results, visited);
             ensureArray(resolved, 'filter');
             const arr = resolved as Record<string, unknown>[];
-            const resolvedValue = isAnyRef(where.value) ? resolveExpr(where.value, results) : where.value;
+            const resolvedValue = isAnyRef(where.value) ? resolveExpr(where.value, results, visited) : where.value;
             return arr.filter((item) => matchCondition(item, where.field, where.op, resolvedValue));
         }
 
         case 'map': {
             const { ref, extract } = expr as Extract<StepExpr, { [EXPR_SYMBOL]: 'map' }>;
-            const resolved = resolveExpr(ref, results);
+            const resolved = resolveExpr(ref, results, visited);
             ensureArray(resolved, 'map');
             const arr = resolved as Record<string, unknown>[];
             return arr.map((item) => {
-                if (!(extract in item)) {
-                    throw new Error(`Field "${extract}" not found in array element. Available fields: ${Object.keys(item).join(', ')}`);
+                if (typeof item !== 'object' || item === null || Array.isArray(item)) {
+                    throw new TransactionInputError(
+                        `Cannot extract field "${extract}": array element is ${item === null ? 'null' : Array.isArray(item) ? 'an array' : `a ${typeof item}`}`,
+                    );
+                }
+                if (!Object.prototype.hasOwnProperty.call(item, extract)) {
+                    throw new TransactionInputError(
+                        `Field "${extract}" not found in array element. Available fields: ${Object.keys(item).join(', ')}`,
+                    );
                 }
                 return item[extract];
             });
         }
 
-        default:
-            throw new Error(`Unknown expression type: "${kind}". Supported types: ref, get, item, first, filter, map`);
+        default: {
+            const kindVal = (expr as Record<string, unknown>)[EXPR_SYMBOL];
+            throw new TransactionInputError(
+                `Unknown expression type: "${String(kindVal)}". Supported types: ref, get, item, first, filter, map`,
+            );
+        }
     }
 }
 
 function getResultIndex(step: number, results: unknown[]) {
     if (step < 1 || step > results.length) {
-        throw new Error(
+        throw new TransactionInputError(
             `Step reference to number ${step} is out of bounds. ` +
                 `Step references are 1-based, and there are ${results.length} result(s) available from previous steps ` +
                 `(steps 1..${results.length}).`,
@@ -348,7 +448,7 @@ function getResultIndex(step: number, results: unknown[]) {
 function ensureArray(value: unknown, op: string, index?: number): asserts value is unknown[] {
     if (!Array.isArray(value)) {
         const hint = index !== undefined ? ` at index ${index}` : '';
-        throw new Error(
+        throw new TransactionInputError(
             `Cannot apply "${op}"${hint}: the resolved value is not an array (got ${getValueTypeName(value)}). ` +
                 `Use a "ref" or "get" expression that points to an array result (e.g., from findMany).`,
         );
@@ -362,29 +462,110 @@ function getValueTypeName(value: unknown) {
     return value.constructor?.name || typeof value;
 }
 
+function isDate(value: unknown): value is Date {
+    return value instanceof Date && typeof value.getTime === 'function' && !isNaN(value.getTime());
+}
+
+function isDecimal(value: unknown): value is { isDecimal: true; equals(other: unknown): boolean } {
+    if (!value || typeof value !== 'object') return false;
+    const v = value as Record<string, unknown>;
+    return v['isDecimal'] === true && typeof v['equals'] === 'function';
+}
+
+function isBigInt(value: unknown): value is bigint {
+    return typeof value === 'bigint';
+}
+
+function isBuffer(value: unknown): value is Uint8Array {
+    return value instanceof Uint8Array;
+}
+
 function matchCondition(item: Record<string, unknown>, field: string, op: string, value: unknown): boolean {
+    if (typeof field !== 'string' || field.length === 0) {
+        throw new TransactionInputError('Filter field must be a non-empty string.');
+    }
+    if (!Object.prototype.hasOwnProperty.call(item, field)) {
+        // field missing from item — only 'neq' and 'notIn' can match
+        if (op === 'neq') return true;
+        if (op === 'notIn' && Array.isArray(value)) return !value.includes(undefined);
+        // treat as no match
+        return false;
+    }
     const actual = item[field];
     switch (op) {
         case 'eq':
+            if (isDate(actual) && isDate(value)) return actual.getTime() === value.getTime();
+            if (isDecimal(actual) && isDecimal(value)) return actual.equals(value);
+            if (isBigInt(actual) && isBigInt(value)) return actual === value;
+            if (isBuffer(actual) && isBuffer(value)) {
+                if (actual.length !== value.length) return false;
+                for (let i = 0; i < actual.length; i++) if (actual[i] !== value[i]) return false;
+                return true;
+            }
             return actual === value;
+
         case 'neq':
+            if (isDate(actual) && isDate(value)) return actual.getTime() !== value.getTime();
+            if (isDecimal(actual) && isDecimal(value)) return !actual.equals(value);
+            if (isBigInt(actual) && isBigInt(value)) return actual !== value;
+            if (isBuffer(actual) && isBuffer(value)) {
+                if (actual.length !== value.length) return true;
+                for (let i = 0; i < actual.length; i++) if (actual[i] !== value[i]) return true;
+                return false;
+            }
             return actual !== value;
+
         case 'gt':
-            return typeof actual === 'number' && typeof value === 'number' && actual > value;
+            if (typeof actual === 'number' && typeof value === 'number') return actual > value;
+            if (isDate(actual) && isDate(value)) return actual.getTime() > value.getTime();
+            if (isBigInt(actual) && isBigInt(value)) return actual > value;
+            return false;
+
         case 'gte':
-            return typeof actual === 'number' && typeof value === 'number' && actual >= value;
+            if (typeof actual === 'number' && typeof value === 'number') return actual >= value;
+            if (isDate(actual) && isDate(value)) return actual.getTime() >= value.getTime();
+            if (isBigInt(actual) && isBigInt(value)) return actual >= value;
+            return false;
+
         case 'lt':
-            return typeof actual === 'number' && typeof value === 'number' && actual < value;
+            if (typeof actual === 'number' && typeof value === 'number') return actual < value;
+            if (isDate(actual) && isDate(value)) return actual.getTime() < value.getTime();
+            if (isBigInt(actual) && isBigInt(value)) return actual < value;
+            return false;
+
         case 'lte':
-            return typeof actual === 'number' && typeof value === 'number' && actual <= value;
-        case 'in':
-            return Array.isArray(value) && value.includes(actual);
-        case 'notIn':
-            return Array.isArray(value) && !value.includes(actual);
+            if (typeof actual === 'number' && typeof value === 'number') return actual <= value;
+            if (isDate(actual) && isDate(value)) return actual.getTime() <= value.getTime();
+            if (isBigInt(actual) && isBigInt(value)) return actual <= value;
+            return false;
+
+        case 'in': {
+            if (!Array.isArray(value)) {
+                throw new TransactionInputError('"in" filter value must be an array.');
+            }
+            if (isDate(actual)) return value.some((v) => isDate(v) && v.getTime() === actual.getTime());
+            if (isBigInt(actual)) return value.some((v) => isBigInt(v) && v === actual);
+            return value.includes(actual);
+        }
+
+        case 'notIn': {
+            if (!Array.isArray(value)) {
+                throw new TransactionInputError('"notIn" filter value must be an array.');
+            }
+            if (isDate(actual)) return !value.some((v) => isDate(v) && v.getTime() === actual.getTime());
+            if (isBigInt(actual)) return !value.some((v) => isBigInt(v) && v === actual);
+            return !value.includes(actual);
+        }
+
         case 'contains':
-            return typeof actual === 'string' && typeof value === 'string' && actual.includes(value);
+            if (typeof actual === 'string' && typeof value === 'string') return actual.includes(value);
+            if (Array.isArray(actual)) return actual.includes(value);
+            return false;
+
         default:
-            throw new Error(`Unknown filter operator: "${op}". Supported: eq, neq, gt, gte, lt, lte, in, notIn, contains`);
+            throw new TransactionInputError(
+                `Unknown filter operator: "${op}". Supported: eq, neq, gt, gte, lt, lte, in, notIn, contains`,
+            );
     }
 }
 
@@ -410,6 +591,10 @@ export function resolveStepRefs(args: unknown, results: unknown[]): unknown {
     if (args && typeof args === 'object' && Object.getPrototypeOf(args) === Object.prototype) {
         const result: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(args)) {
+            // Block prototype pollution keys
+            if (FORBIDDEN_KEYS.has(key)) {
+                continue;
+            }
             result[key] = resolveStepRefs(value, results);
         }
         return result;

--- a/packages/orm/src/client/transaction.ts
+++ b/packages/orm/src/client/transaction.ts
@@ -1,0 +1,419 @@
+export const STEP_REF_SYMBOL = '$zenstackStepRef';
+export const EXPR_SYMBOL = '$zenstackExpr';
+
+// ---- Expression Type System ----
+
+declare const STEP_EXPR_VALUE: unique symbol;
+
+export type ExprFilterOp = 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'notIn' | 'contains';
+
+type StringKey<T> = Extract<keyof T, string>;
+type ExprValueCarrier<T> = { readonly [STEP_EXPR_VALUE]?: T };
+
+/**
+ * Condition for filtering array results.
+ *
+ * `field` and `value` become type-safe when the source expression is typed,
+ * for example: `$filter($stepRef<Post[]>(1), 'title', 'eq', 'Target')`.
+ * The `value` can itself contain nested expressions.
+ */
+export type ExprWhere = {
+    field: string;
+    op: ExprFilterOp;
+    value: unknown;
+};
+
+type StepRefShape = {
+    [EXPR_SYMBOL]: 'ref';
+    /** Number of the step whose result to reference (1-based). */
+    step: number;
+    /**
+     * Dot-separated path to extract from the step's result.
+     * Supports array bracket notation: `items[0].id`
+    */
+    path?: string;
+};
+
+type StepGetShape = {
+    [EXPR_SYMBOL]: 'get';
+    /** The expression whose result to extract a field from. */
+    ref: StepExpr;
+    /** Dot-separated path to extract. */
+    path: string;
+};
+
+type StepItemShape = {
+    [EXPR_SYMBOL]: 'item';
+    /** The expression producing an array. */
+    ref: StepExpr;
+    /** 0-based index into the array. */
+    index: number;
+};
+
+type StepFirstShape = {
+    [EXPR_SYMBOL]: 'first';
+    /** The expression producing an array. Returns the first element. */
+    ref: StepExpr;
+};
+
+type StepFilterShape = {
+    [EXPR_SYMBOL]: 'filter';
+    /** The expression producing an array to filter. */
+    ref: StepExpr;
+    /** Condition to filter by. */
+    where: ExprWhere;
+};
+
+type StepMapShape = {
+    [EXPR_SYMBOL]: 'map';
+    /** The expression producing an array. */
+    ref: StepExpr;
+    /** Field name to extract from each element. */
+    extract: string;
+};
+
+type StepExprShape = StepRefShape | StepGetShape | StepItemShape | StepFirstShape | StepFilterShape | StepMapShape;
+
+export type StepRefExpr<T = unknown> = ExprValueCarrier<T> & StepRefShape;
+export type StepGetExpr<T = unknown> = ExprValueCarrier<T> & StepGetShape;
+export type StepItemExpr<T = unknown> = ExprValueCarrier<T> & StepItemShape;
+export type StepFirstExpr<T = unknown> = ExprValueCarrier<T> & StepFirstShape;
+export type StepFilterExpr<TItem extends object = Record<string, unknown>> = ExprValueCarrier<TItem[]> & StepFilterShape;
+export type StepMapExpr<T = unknown> = ExprValueCarrier<T[]> & StepMapShape;
+
+type ExprFilterValue<TValue, TOp extends ExprFilterOp> = TOp extends 'in' | 'notIn'
+    ? readonly TValue[] | StepExpr<readonly TValue[]>
+    : TOp extends 'contains'
+      ? TValue extends readonly (infer Item)[]
+          ? Item | StepExpr<Item>
+          : TValue extends string
+            ? string | StepExpr<string>
+            : TValue | StepExpr<TValue>
+      : TValue | StepExpr<TValue>;
+
+/**
+ * Discriminated union of all supported step expressions.
+ * Each expression resolves to a value at runtime, using accumulated
+ * results from previous transaction steps.
+ *
+ * Expressions compose: where an expression is expected, you can pass
+ * any StepExpr — enabling chains like "filter an array then pick a field".
+ */
+export type StepExpr<T = unknown> = ExprValueCarrier<T> & StepExprShape;
+
+/** Backward-compatible simple step reference. */
+export type StepRef = {
+    [STEP_REF_SYMBOL]: true;
+    step: number;
+    path?: string;
+};
+
+// ---- Typed constructor helpers ----
+// These provide full IntelliSense and type safety when building expressions.
+// Since they return plain objects, they survive JSON serialization for RPC usage.
+
+/**
+ * References the result of a previous sequential transaction step.
+ *
+ * Pass a generic type to make later helpers field-aware:
+ * `$stepRef<Post[]>(1)` enables `$filter(..., 'title', 'eq', 'Target')`
+ * with autocomplete for `title` and a string-typed value.
+ */
+export function $stepRef<T = unknown>(step: number, path?: string): StepRefExpr<T> {
+    return path !== undefined ? { [EXPR_SYMBOL]: 'ref', step, path } : { [EXPR_SYMBOL]: 'ref', step };
+}
+
+/**
+ * Extracts a field/path from another step expression.
+ *
+ * If the referenced expression is typed, top-level keys are suggested and the
+ * returned expression carries the selected field type.
+ */
+export function $get<TSource extends object, TPath extends StringKey<TSource>>(ref: StepExpr<TSource>, path: TPath): StepGetExpr<TSource[TPath]>;
+export function $get(ref: StepExpr, path: string): StepGetExpr<unknown>;
+export function $get(ref: StepExpr, path: string): StepGetExpr<unknown> {
+    return { [EXPR_SYMBOL]: 'get', ref, path };
+}
+
+/**
+ * Picks one item from an array-valued expression by zero-based index.
+ */
+export function $item<TItem>(ref: StepExpr<readonly TItem[]>, index: number): StepItemExpr<TItem>;
+export function $item(ref: StepExpr, index: number): StepItemExpr<unknown>;
+export function $item(ref: StepExpr, index: number): StepItemExpr<unknown> {
+    return { [EXPR_SYMBOL]: 'item', ref, index };
+}
+
+/**
+ * Picks the first item from an array-valued expression.
+ */
+export function $first<TItem>(ref: StepExpr<readonly TItem[]>): StepFirstExpr<TItem>;
+export function $first(ref: StepExpr): StepFirstExpr<unknown>;
+export function $first(ref: StepExpr): StepFirstExpr<unknown> {
+    return { [EXPR_SYMBOL]: 'first', ref };
+}
+
+/**
+ * Filters an array-valued expression by a field condition.
+ *
+ * Use a typed step reference for field/value IntelliSense:
+ * `$filter($stepRef<Post[]>(1), 'title', 'eq', 'Target')` suggests `title`
+ * and requires the value to be compatible with `Post['title']`.
+ */
+export function $filter<TItem extends object, TField extends StringKey<TItem>, TOp extends ExprFilterOp>(
+    ref: StepExpr<readonly TItem[]>,
+    field: TField,
+    op: TOp,
+    value: ExprFilterValue<TItem[TField], TOp>,
+): StepFilterExpr<TItem>;
+export function $filter(ref: StepExpr, field: string, op: ExprFilterOp, value: unknown): StepFilterExpr;
+export function $filter(ref: StepExpr, field: string, op: ExprFilterOp, value: unknown): StepFilterExpr {
+    return { [EXPR_SYMBOL]: 'filter', ref, where: { field, op, value } };
+}
+
+/**
+ * Extracts one field from every item of an array-valued expression.
+ *
+ * With a typed array expression, `extract` autocompletes from the item keys and
+ * the returned expression carries the extracted field array type.
+ */
+export function $map<TItem extends object, TField extends StringKey<TItem>>(ref: StepExpr<readonly TItem[]>, extract: TField): StepMapExpr<TItem[TField]>;
+export function $map(ref: StepExpr, extract: string): StepMapExpr<unknown>;
+export function $map(ref: StepExpr, extract: string): StepMapExpr<unknown> {
+    return { [EXPR_SYMBOL]: 'map', ref, extract };
+}
+
+// ---- Detection helpers ----
+
+export function isStepRef(value: unknown): value is StepRef {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    const v = value as Record<string, unknown>;
+    return (
+        STEP_REF_SYMBOL in v &&
+        v[STEP_REF_SYMBOL] === true
+    );
+}
+
+export function isStepExpr(value: unknown): value is StepExpr {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+    const v = value as Record<string, unknown>;
+    return typeof v[EXPR_SYMBOL] === 'string' && EXPR_SYMBOL in v;
+}
+
+/** True if value is EITHER a StepRef or a StepExpr. */
+export function isAnyRef(value: unknown): value is StepRef | StepExpr {
+    return isStepRef(value) || isStepExpr(value);
+}
+
+// ---- Path resolution ----
+
+type PathSegment = string | number;
+
+function parsePath(path: string): PathSegment[] {
+    const segments: PathSegment[] = [];
+    const parts = path.split('.');
+    for (const part of parts) {
+        const bracketMatch = part.match(/^(\w+)\[(\d+)\]$/);
+        if (bracketMatch) {
+            segments.push(bracketMatch[1]!);
+            segments.push(parseInt(bracketMatch[2]!, 10));
+        } else {
+            segments.push(part);
+        }
+    }
+    return segments;
+}
+
+function resolvePath(obj: unknown, segments: PathSegment[]): unknown {
+    let current = obj;
+    for (const segment of segments) {
+        if (current == null || typeof current !== 'object') {
+            throw new Error(
+                `Cannot resolve path segment "${segment}": value is ${current === null ? 'null' : typeof current}`,
+            );
+        }
+        if (Array.isArray(current) && typeof segment === 'number') {
+            if (segment < 0 || segment >= current.length) {
+                throw new Error(`Array index ${segment} is out of bounds. Array has ${current.length} elements.`);
+            }
+            current = current[segment];
+        } else if (typeof segment === 'string' && segment in current) {
+            current = (current as Record<string, unknown>)[segment];
+        } else {
+            throw new Error(
+                `Cannot resolve path segment "${segment}" on ${Array.isArray(current) ? 'array' : typeof current}`,
+            );
+        }
+    }
+    return current;
+}
+
+// ---- Expression resolution ----
+
+/**
+ * Resolves a StepRef or StepExpr against accumulated step results.
+ * Handles both the old `$zenstackStepRef` format and the new `$zenstackExpr` format.
+ */
+export function resolveExpr(expr: StepExpr | StepRef, results: unknown[]): unknown {
+    // Handle old-style StepRef
+    if (isStepRef(expr)) {
+        const { step, path } = expr;
+        const resultIndex = getResultIndex(step, results);
+        let value = results[resultIndex];
+        if (path) {
+            value = resolvePath(value, parsePath(path));
+        }
+        return value;
+    }
+
+    // Handle new-style StepExpr
+    const kind = expr[EXPR_SYMBOL];
+    switch (kind) {
+        case 'ref': {
+            const { step, path } = expr as Extract<StepExpr, { [EXPR_SYMBOL]: 'ref' }>;
+            const resultIndex = getResultIndex(step, results);
+            let value = results[resultIndex];
+            if (path) {
+                value = resolvePath(value, parsePath(path));
+            }
+            return value;
+        }
+
+        case 'get': {
+            const { ref, path } = expr as Extract<StepExpr, { [EXPR_SYMBOL]: 'get' }>;
+            const resolved = resolveExpr(ref, results);
+            return resolvePath(resolved, parsePath(path));
+        }
+
+        case 'item': {
+            const { ref, index } = expr as Extract<StepExpr, { [EXPR_SYMBOL]: 'item' }>;
+            const resolved = resolveExpr(ref, results);
+            ensureArray(resolved, 'item', index);
+            const arr = resolved as unknown[];
+            if (index < 0 || index >= arr.length) {
+                throw new Error(`Array index ${index} is out of bounds. Array has ${arr.length} elements.`);
+            }
+            return arr[index];
+        }
+
+        case 'first': {
+            const { ref } = expr as Extract<StepExpr, { [EXPR_SYMBOL]: 'first' }>;
+            const resolved = resolveExpr(ref, results);
+            ensureArray(resolved, 'first');
+            const arr = resolved as unknown[];
+            if (arr.length === 0) {
+                throw new Error('Cannot get first element of an empty array.');
+            }
+            return arr[0];
+        }
+
+        case 'filter': {
+            const { ref, where } = expr as Extract<StepExpr, { [EXPR_SYMBOL]: 'filter' }>;
+            const resolved = resolveExpr(ref, results);
+            ensureArray(resolved, 'filter');
+            const arr = resolved as Record<string, unknown>[];
+            const resolvedValue = isAnyRef(where.value) ? resolveExpr(where.value, results) : where.value;
+            return arr.filter((item) => matchCondition(item, where.field, where.op, resolvedValue));
+        }
+
+        case 'map': {
+            const { ref, extract } = expr as Extract<StepExpr, { [EXPR_SYMBOL]: 'map' }>;
+            const resolved = resolveExpr(ref, results);
+            ensureArray(resolved, 'map');
+            const arr = resolved as Record<string, unknown>[];
+            return arr.map((item) => {
+                if (!(extract in item)) {
+                    throw new Error(`Field "${extract}" not found in array element. Available fields: ${Object.keys(item).join(', ')}`);
+                }
+                return item[extract];
+            });
+        }
+
+        default:
+            throw new Error(`Unknown expression type: "${kind}". Supported types: ref, get, item, first, filter, map`);
+    }
+}
+
+function getResultIndex(step: number, results: unknown[]) {
+    if (step < 1 || step > results.length) {
+        throw new Error(
+            `Step reference to number ${step} is out of bounds. ` +
+                `Step references are 1-based, and there are ${results.length} result(s) available from previous steps ` +
+                `(steps 1..${results.length}).`,
+        );
+    }
+    return step - 1;
+}
+
+function ensureArray(value: unknown, op: string, index?: number): asserts value is unknown[] {
+    if (!Array.isArray(value)) {
+        const hint = index !== undefined ? ` at index ${index}` : '';
+        throw new Error(
+            `Cannot apply "${op}"${hint}: the resolved value is not an array (got ${getValueTypeName(value)}). ` +
+                `Use a "ref" or "get" expression that points to an array result (e.g., from findMany).`,
+        );
+    }
+}
+
+function getValueTypeName(value: unknown) {
+    if (typeof value !== 'object' || value === null) {
+        return typeof value;
+    }
+    return value.constructor?.name || typeof value;
+}
+
+function matchCondition(item: Record<string, unknown>, field: string, op: string, value: unknown): boolean {
+    const actual = item[field];
+    switch (op) {
+        case 'eq':
+            return actual === value;
+        case 'neq':
+            return actual !== value;
+        case 'gt':
+            return typeof actual === 'number' && typeof value === 'number' && actual > value;
+        case 'gte':
+            return typeof actual === 'number' && typeof value === 'number' && actual >= value;
+        case 'lt':
+            return typeof actual === 'number' && typeof value === 'number' && actual < value;
+        case 'lte':
+            return typeof actual === 'number' && typeof value === 'number' && actual <= value;
+        case 'in':
+            return Array.isArray(value) && value.includes(actual);
+        case 'notIn':
+            return Array.isArray(value) && !value.includes(actual);
+        case 'contains':
+            return typeof actual === 'string' && typeof value === 'string' && actual.includes(value);
+        default:
+            throw new Error(`Unknown filter operator: "${op}". Supported: eq, neq, gt, gte, lt, lte, in, notIn, contains`);
+    }
+}
+
+// ---- Public entry point (used by RPC handler) ----
+
+/**
+ * Walks through args recursively and resolves any StepRef or StepExpr markers
+ * using the accumulated results from previous steps.
+ *
+ * Handles both formats:
+ * - Old: `{ $zenstackStepRef: true, step: 1, path: 'id' }`
+ * - New: `{ $zenstackExpr: 'ref', step: 1, path: 'id' }` and compositions
+ */
+export function resolveStepRefs(args: unknown, results: unknown[]): unknown {
+    if (isAnyRef(args)) {
+        return resolveExpr(args, results);
+    }
+
+    if (Array.isArray(args)) {
+        return args.map((item) => resolveStepRefs(item, results));
+    }
+
+    if (args && typeof args === 'object' && Object.getPrototypeOf(args) === Object.prototype) {
+        const result: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(args)) {
+            result[key] = resolveStepRefs(value, results);
+        }
+        return result;
+    }
+
+    return args;
+}

--- a/packages/server/src/api/rpc/index.ts
+++ b/packages/server/src/api/rpc/index.ts
@@ -1,5 +1,11 @@
 import { lowerCaseFirst, safeJSONStringify } from '@zenstackhq/common-helpers';
-import { CoreCrudOperations, ORMError, ORMErrorReason, type ClientContract } from '@zenstackhq/orm';
+import {
+    CoreCrudOperations,
+    ORMError,
+    ORMErrorReason,
+    resolveStepRefs,
+    type ClientContract,
+} from '@zenstackhq/orm';
 import type { SchemaDef } from '@zenstackhq/orm/schema';
 import SuperJSON from 'superjson';
 import { match } from 'ts-pattern';
@@ -261,13 +267,27 @@ export class RPCApiHandler<Schema extends SchemaDef = SchemaDef> implements ApiH
         }
 
         try {
-            const promises = processedOps.map(({ model, op, args }) => {
-                return (client as any)[model][op](args);
+            log(
+                this.options.log,
+                'debug',
+                () => `handling "$transaction" request with ${processedOps.length} operations`,
+            );
+
+            const clientResult = await client.$transaction(async (tx) => {
+                const results: unknown[] = [];
+                for (const opDef of processedOps) {
+                    const resolvedArgs = resolveStepRefs(opDef.args, results);
+                    log(
+                        this.options.log,
+                        'debug',
+                        () =>
+                            `executing transaction step ${results.length + 1}: ${opDef.model}.${opDef.op} with resolved args: ${safeJSONStringify(resolvedArgs)}`,
+                    );
+                    const result = await (tx as any)[opDef.model][opDef.op](resolvedArgs);
+                    results.push(result);
+                }
+                return results;
             });
-
-            log(this.options.log, 'debug', () => `handling "$transaction" request with ${promises.length} operations`);
-
-            const clientResult = await client.$transaction(promises as any);
 
             const { json, meta } = SuperJSON.serialize(clientResult);
             const responseBody: any = { data: json };

--- a/packages/server/src/api/rpc/index.ts
+++ b/packages/server/src/api/rpc/index.ts
@@ -3,6 +3,7 @@ import {
     CoreCrudOperations,
     ORMError,
     ORMErrorReason,
+    TransactionInputError,
     resolveStepRefs,
     type ClientContract,
 } from '@zenstackhq/orm';
@@ -304,6 +305,9 @@ export class RPCApiHandler<Schema extends SchemaDef = SchemaDef> implements ApiH
             return response;
         } catch (err) {
             log(this.options.log, 'error', `error occurred when handling "$transaction" request`, err);
+            if (err instanceof TransactionInputError) {
+                return this.makeBadInputErrorResponse(err.message);
+            }
             if (err instanceof ORMError) {
                 return this.makeORMErrorResponse(err);
             }

--- a/packages/server/test/api/rpc.test.ts
+++ b/packages/server/test/api/rpc.test.ts
@@ -1,4 +1,12 @@
-import { ClientContract } from '@zenstackhq/orm';
+import {
+    ClientContract,
+    $stepRef,
+    $get,
+    $item,
+    $first,
+    $filter,
+    $map,
+} from '@zenstackhq/orm';
 import { SchemaDef } from '@zenstackhq/orm/schema';
 import { createPolicyTestClient, createTestClient } from '@zenstackhq/testtools';
 import Decimal from 'decimal.js';
@@ -6,6 +14,14 @@ import SuperJSON from 'superjson';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { RPCApiHandler } from '../../src/api';
 import { schema } from '../utils';
+
+type TestPost = {
+    id: string;
+    title: string;
+    authorId: string | null;
+    published: boolean;
+    viewCount: number;
+};
 
 describe('RPC API Handler Tests', () => {
     let client: ClientContract<SchemaDef>;
@@ -1028,6 +1044,613 @@ procedure echoOverview(o: Overview): Overview
             // User should not have been committed
             const count = await rawClient.user.count();
             expect(count).toBe(0);
+        });
+
+        describe('step references', () => {
+            it('passes result from one step to the next by path', async () => {
+                const handleRequest = makeHandler();
+
+                await rawClient.post.deleteMany();
+                await rawClient.user.deleteMany();
+
+                const r = await handleRequest({
+                    method: 'post',
+                    path: '/$transaction/sequential',
+                    requestBody: [
+                        {
+                            model: 'User',
+                            op: 'create',
+                            args: { data: { id: 'stepuser1', email: 'stepuser1@abc.com' } },
+                        },
+                        {
+                            model: 'Post',
+                            op: 'create',
+                            args: {
+                                data: {
+                                    id: 'steppost1',
+                                    title: 'Step Post',
+                                    authorId: $stepRef(1, 'id'),
+                                },
+                            },
+                        },
+                        {
+                            model: 'Post',
+                            op: 'findMany',
+                            args: { where: { authorId: $stepRef(1, 'id') } },
+                        },
+                    ],
+                    client: rawClient,
+                });
+                expect(r.status).toBe(200);
+                expect(Array.isArray(r.data)).toBe(true);
+                expect(r.data).toHaveLength(3);
+                expect(r.data[0]).toMatchObject({ id: 'stepuser1', email: 'stepuser1@abc.com' });
+                expect(r.data[1]).toMatchObject({ id: 'steppost1', title: 'Step Post', authorId: 'stepuser1' });
+                expect(r.data[2]).toHaveLength(1);
+                expect(r.data[2][0]).toMatchObject({ id: 'steppost1' });
+
+                await rawClient.post.deleteMany();
+                await rawClient.user.deleteMany();
+            });
+
+            it('uses entire result of a step when path is omitted', async () => {
+                const handleRequest = makeHandler();
+
+                await rawClient.post.deleteMany();
+                await rawClient.user.deleteMany();
+
+                const r = await handleRequest({
+                    method: 'post',
+                    path: '/$transaction/sequential',
+                    requestBody: [
+                        {
+                            model: 'User',
+                            op: 'create',
+                            args: { data: { id: 'stepuser2', email: 'stepuser2@abc.com' } },
+                        },
+                        {
+                            model: 'Post',
+                            op: 'create',
+                            args: {
+                                data: { id: 'steppost2', title: 'Step Post 2' },
+                            },
+                        },
+                        {
+                            model: 'Post',
+                            op: 'findMany',
+                            args: {
+                                where: {
+                                    OR: [
+                                        { id: $stepRef(2, 'id') },
+                                    ],
+                                },
+                            },
+                        },
+                    ],
+                    client: rawClient,
+                });
+
+                expect(r.status).toBe(200);
+                expect(r.data[2]).toHaveLength(1);
+                expect(r.data[2][0]).toMatchObject({ id: 'steppost2' });
+
+                await rawClient.post.deleteMany();
+                await rawClient.user.deleteMany();
+            });
+
+            it('mixes queries and mutations with step refs', async () => {
+                const handleRequest = makeHandler();
+
+                await rawClient.post.deleteMany();
+                await rawClient.user.deleteMany();
+
+                const r = await handleRequest({
+                    method: 'post',
+                    path: '/$transaction/sequential',
+                    requestBody: [
+                        {
+                            model: 'User',
+                            op: 'create',
+                            args: { data: { id: 'stepuser3', email: 'stepuser3@abc.com' } },
+                        },
+                        {
+                            model: 'Post',
+                            op: 'create',
+                            args: {
+                                data: {
+                                    id: 'steppost3',
+                                    title: 'Step Post 3',
+                                    authorId: $stepRef(1, 'id'),
+                                },
+                            },
+                        },
+                        {
+                            model: 'Post',
+                            op: 'findUnique',
+                            args: { where: { id: $stepRef(2, 'id') } },
+                        },
+                    ],
+                    client: rawClient,
+                });
+
+                expect(r.status).toBe(200);
+                expect(r.data[0]).toMatchObject({ id: 'stepuser3' });
+                expect(r.data[1]).toMatchObject({ id: 'steppost3', authorId: 'stepuser3' });
+                expect(r.data[2]).toMatchObject({ id: 'steppost3', authorId: 'stepuser3' });
+
+                await rawClient.post.deleteMany();
+                await rawClient.user.deleteMany();
+            });
+
+            it('throws an error when referencing a step index that does not exist', async () => {
+                const handleRequest = makeHandler();
+
+                const r = await handleRequest({
+                    method: 'post',
+                    path: '/$transaction/sequential',
+                    requestBody: [
+                        {
+                            model: 'User',
+                            op: 'create',
+                            args: { data: { id: 'stepuser4', email: 'stepuser4@abc.com' } },
+                        },
+                        {
+                            model: 'Post',
+                            op: 'create',
+                            args: {
+                                data: {
+                                    id: 'steppost4',
+                                    title: 'Broken Post',
+                                    authorId: $stepRef(5, 'id'),
+                                },
+                            },
+                        },
+                    ],
+                    client: rawClient,
+                });
+
+                expect(r.status).toBeGreaterThanOrEqual(400);
+                expect(r.error?.message).toMatch(/out of bounds/i);
+
+                // Clean up
+                await rawClient.post.deleteMany();
+                await rawClient.user.deleteMany();
+            });
+
+            it('throws an error when referencing step 0 because steps are 1-based', async () => {
+                const handleRequest = makeHandler();
+
+                const r = await handleRequest({
+                    method: 'post',
+                    path: '/$transaction/sequential',
+                    requestBody: [
+                        {
+                            model: 'User',
+                            op: 'create',
+                            args: { data: { id: 'stepuser0', email: 'stepuser0@abc.com' } },
+                        },
+                        {
+                            model: 'Post',
+                            op: 'create',
+                            args: {
+                                data: {
+                                    id: 'steppost0',
+                                    title: 'Zero Step Post',
+                                    authorId: $stepRef(0, 'id'),
+                                },
+                            },
+                        },
+                    ],
+                    client: rawClient,
+                });
+
+                expect(r.status).toBeGreaterThanOrEqual(400);
+                expect(r.error?.message).toMatch(/1-based/i);
+
+                await rawClient.post.deleteMany();
+                await rawClient.user.deleteMany();
+            });
+
+            it('maintains atomicity when a step ref is invalid', async () => {
+                const handleRequest = makeHandler();
+
+                await rawClient.user.deleteMany();
+
+                const r = await handleRequest({
+                    method: 'post',
+                    path: '/$transaction/sequential',
+                    requestBody: [
+                        {
+                            model: 'User',
+                            op: 'create',
+                            args: { data: { id: 'stepuser5', email: 'stepuser5@abc.com' } },
+                        },
+                        {
+                            model: 'Post',
+                            op: 'create',
+                            args: {
+                                data: {
+                                    id: 'steppost5',
+                                    title: 'Rollback Post',
+                                    authorId: $stepRef(99, 'id'),
+                                },
+                            },
+                        },
+                    ],
+                    client: rawClient,
+                });
+
+                expect(r.status).toBeGreaterThanOrEqual(400);
+
+                // User should NOT have been committed because the transaction rolled back
+                const count = await rawClient.user.count();
+                expect(count).toBe(0);
+            });
+
+            it('resolves step refs in deeply nested args', async () => {
+                const handleRequest = makeHandler();
+
+                await rawClient.post.deleteMany();
+                await rawClient.user.deleteMany();
+
+                const r = await handleRequest({
+                    method: 'post',
+                    path: '/$transaction/sequential',
+                    requestBody: [
+                        {
+                            model: 'User',
+                            op: 'create',
+                            args: { data: { id: 'stepuser6', email: 'stepuser6@abc.com' } },
+                        },
+                        {
+                            model: 'Post',
+                            op: 'create',
+                            args: {
+                                data: {
+                                    id: 'steppost6',
+                                    title: 'Nested Ref Post',
+                                    authorId: $stepRef(1, 'id'),
+                                },
+                            },
+                        },
+                        {
+                            model: 'Post',
+                            op: 'update',
+                            args: {
+                                where: { id: $stepRef(2, 'id') },
+                                data: { title: 'Updated Nested Ref Post' },
+                            },
+                        },
+                    ],
+                    client: rawClient,
+                });
+
+                expect(r.status).toBe(200);
+                expect(r.data[2]).toMatchObject({ id: 'steppost6', title: 'Updated Nested Ref Post' });
+
+                await rawClient.post.deleteMany();
+                await rawClient.user.deleteMany();
+            });
+
+            describe('expressions', () => {
+                it('resolves $zenstackExpr: ref (new syntax, equivalent to old StepRef)', async () => {
+                    const handleRequest = makeHandler();
+
+                    await rawClient.post.deleteMany();
+                    await rawClient.user.deleteMany();
+
+                    const r = await handleRequest({
+                        method: 'post',
+                        path: '/$transaction/sequential',
+                        requestBody: [
+                            {
+                                model: 'User',
+                                op: 'create',
+                                args: { data: { id: 'expruser1', email: 'expruser1@abc.com' } },
+                            },
+                            {
+                                model: 'Post',
+                                op: 'create',
+                                args: {
+                                    data: {
+                                        id: 'exprpost1',
+                                        title: 'Expr Post 1',
+                                        authorId: $stepRef(1, 'id'),
+                                    },
+                                },
+                            },
+                        ],
+                        client: rawClient,
+                    });
+
+                    expect(r.status).toBe(200);
+                    expect(r.data[1]).toMatchObject({ id: 'exprpost1', authorId: 'expruser1' });
+
+                    await rawClient.post.deleteMany();
+                    await rawClient.user.deleteMany();
+                });
+
+                it('calls findMany then uses item to pick a specific result', async () => {
+                    const handleRequest = makeHandler();
+
+                    await rawClient.post.deleteMany();
+                    await rawClient.user.deleteMany();
+
+                    // Create user with 3 posts
+                    await rawClient.user.create({
+                        data: {
+                            id: 'expruser2',
+                            email: 'expruser2@abc.com',
+                            posts: {
+                                create: [
+                                    { id: 'p1', title: 'Alpha' },
+                                    { id: 'p2', title: 'Beta' },
+                                    { id: 'p3', title: 'Gamma' },
+                                ],
+                            },
+                        },
+                    });
+
+                    const r = await handleRequest({
+                        method: 'post',
+                        path: '/$transaction/sequential',
+                        requestBody: [
+                            {
+                                model: 'Post',
+                                op: 'findMany',
+                                args: { where: { authorId: 'expruser2' }, orderBy: { title: 'asc' } },
+                            },
+                            {
+                                model: 'Post',
+                                op: 'update',
+                                args: {
+                                    where: {
+                                        id: $get($item($stepRef(1), 1), 'id'),
+                                    },
+                                    data: { title: 'Beta Updated' },
+                                },
+                            },
+                        ],
+                        client: rawClient,
+                    });
+
+                    expect(r.status).toBe(200);
+                    expect(r.data[1]).toMatchObject({ id: 'p2', title: 'Beta Updated' });
+
+                    await rawClient.post.deleteMany();
+                    await rawClient.user.deleteMany();
+                });
+
+                it('calls findMany then uses first to get the first result', async () => {
+                    const handleRequest = makeHandler();
+
+                    await rawClient.post.deleteMany();
+                    await rawClient.user.deleteMany();
+
+                    await rawClient.user.create({
+                        data: {
+                            id: 'expruser3',
+                            email: 'expruser3@abc.com',
+                            posts: {
+                                create: [
+                                    { id: 'p4', title: 'Delta' },
+                                    { id: 'p5', title: 'Epsilon' },
+                                ],
+                            },
+                        },
+                    });
+
+                    const r = await handleRequest({
+                        method: 'post',
+                        path: '/$transaction/sequential',
+                        requestBody: [
+                            {
+                                model: 'Post',
+                                op: 'findMany',
+                                args: { where: { authorId: 'expruser3' }, orderBy: { title: 'asc' } },
+                            },
+                            {
+                                model: 'Post',
+                                op: 'delete',
+                                args: {
+                                    where: {
+                                        id: $get($first($stepRef(1)), 'id'),
+                                    },
+                                },
+                            },
+                        ],
+                        client: rawClient,
+                    });
+
+                    expect(r.status).toBe(200);
+                    expect(r.data[1]).toMatchObject({ id: 'p4' });
+
+                    // Verify the other post remains
+                    const remaining = ((await rawClient.post.findMany()) as TestPost[]).filter((post) => post.authorId === 'expruser3').length;
+                    expect(remaining).toBe(1);
+
+                    await rawClient.post.deleteMany();
+                    await rawClient.user.deleteMany();
+                });
+
+                it('uses filter expression to find matching elements then extracts a field with map', async () => {
+                    const handleRequest = makeHandler();
+
+                    await rawClient.post.deleteMany();
+                    await rawClient.user.deleteMany();
+
+                    await rawClient.user.create({
+                        data: {
+                            id: 'expruser4',
+                            email: 'expruser4@abc.com',
+                            posts: {
+                                create: [
+                                    { id: 'p6', title: 'Published1', published: true, viewCount: 10 },
+                                    { id: 'p7', title: 'Draft1', published: false, viewCount: 5 },
+                                    { id: 'p8', title: 'Published2', published: true, viewCount: 20 },
+                                ],
+                            },
+                        },
+                    });
+
+                    const r = await handleRequest({
+                        method: 'post',
+                        path: '/$transaction/sequential',
+                        requestBody: [
+                            {
+                                model: 'Post',
+                                op: 'findMany',
+                                args: { where: { authorId: 'expruser4' } },
+                            },
+                            {
+                                model: 'Post',
+                                op: 'updateMany',
+                                args: {
+                                    where: {
+                                        id: {
+                                            in: $map($filter($stepRef<TestPost[]>(1), 'published', 'eq', true), 'id'),
+                                        },
+                                    },
+                                    data: { viewCount: 999 },
+                                },
+                            },
+                        ],
+                        client: rawClient,
+                    });
+
+                    expect(r.status).toBe(200);
+
+                    // Verify only published posts were updated
+                    const userPosts = ((await rawClient.post.findMany()) as TestPost[]).filter((post) => post.authorId === 'expruser4');
+                    expect(userPosts.filter((post) => post.viewCount === 999)).toHaveLength(2);
+
+                    expect(userPosts.find((post) => post.id === 'p7')).toMatchObject({ viewCount: 5 });
+
+                    await rawClient.post.deleteMany();
+                    await rawClient.user.deleteMany();
+                });
+
+                it('chains filter with get to reference a specific field from a filtered array item', async () => {
+                    const handleRequest = makeHandler();
+
+                    await rawClient.post.deleteMany();
+                    await rawClient.user.deleteMany();
+
+                    await rawClient.user.create({
+                        data: {
+                            id: 'expruser5',
+                            email: 'expruser5@abc.com',
+                            posts: {
+                                create: [
+                                    { id: 'p9', title: 'Target', published: true },
+                                ],
+                            },
+                        },
+                    });
+
+                    const r = await handleRequest({
+                        method: 'post',
+                        path: '/$transaction/sequential',
+                        requestBody: [
+                            {
+                                model: 'Post',
+                                op: 'findMany',
+                                args: { where: { authorId: 'expruser5' } },
+                            },
+                            {
+                                model: 'Post',
+                                op: 'update',
+                                args: {
+                                    where: {
+                                        id: $get($first($filter($stepRef<TestPost[]>(1), 'title', 'eq', 'Target')), 'id'),
+                                    },
+                                    data: { title: 'Target Updated' },
+                                },
+                            },
+                        ],
+                        client: rawClient,
+                    });
+
+                    expect(r.status).toBe(200);
+                    expect(r.data[1]).toMatchObject({ title: 'Target Updated' });
+
+                    await rawClient.post.deleteMany();
+                    await rawClient.user.deleteMany();
+                });
+
+                it('errors when using item on a non-array result', async () => {
+                    const handleRequest = makeHandler();
+
+                    await rawClient.post.deleteMany();
+                    await rawClient.user.deleteMany();
+
+                    const r = await handleRequest({
+                        method: 'post',
+                        path: '/$transaction/sequential',
+                        requestBody: [
+                            {
+                                model: 'User',
+                                op: 'create',
+                                args: { data: { id: 'expruser6', email: 'expruser6@abc.com' } },
+                            },
+                            {
+                                model: 'Post',
+                                op: 'create',
+                                args: {
+                                    data: {
+                                        id: 'exprpost6',
+                                        title: 'Bad Ref',
+                                        authorId: $get($item($stepRef(1), 0), 'id'),
+                                    },
+                                },
+                            },
+                        ],
+                        client: rawClient,
+                    });
+
+                    expect(r.status).toBeGreaterThanOrEqual(400);
+                    expect(r.error?.message).toMatch(/not an array/i);
+
+                    await rawClient.post.deleteMany();
+                    await rawClient.user.deleteMany();
+                });
+
+                it('errors when filter targets an unknown operator', async () => {
+                    const handleRequest = makeHandler();
+
+                    const r = await handleRequest({
+                        method: 'post',
+                        path: '/$transaction/sequential',
+                        requestBody: [
+                            {
+                                model: 'User',
+                                op: 'findMany',
+                                args: {},
+                            },
+                            {
+                                model: 'User',
+                                op: 'findFirst',
+                                args: {
+                                    where: {
+                                        id: {
+                                            $zenstackExpr: 'get',
+                                            ref: {
+                                                $zenstackExpr: 'filter',
+                                                ref: $stepRef(1),
+                                                where: { field: 'email', op: 'regex', value: '.*' },
+                                            },
+                                            path: 'id',
+                                        },
+                                    },
+                                },
+                            },
+                        ],
+                        client: rawClient,
+                    });
+
+                    expect(r.status).toBeGreaterThanOrEqual(400);
+                });
+            });
         });
     });
 

--- a/samples/next.js/README.md
+++ b/samples/next.js/README.md
@@ -1,5 +1,7 @@
 This is a sample project demonstrating using [Next.js](https://nextjs.org) and [TanStack Query](https://tanstack.com/query) with [ZenStack v3](https://zenstack.dev/v3).
 
+It includes CRUD, optimistic updates, public-feed queries, and a sequential transaction example using `$stepRef`/`$get`/`$filter`/`$map`.
+
 ## Getting Started
 
 - pnpm install

--- a/samples/next.js/app/page.tsx
+++ b/samples/next.js/app/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Post } from '@/zenstack/models';
+import { Post, User } from '@/zenstack/models';
 import { schema } from '@/zenstack/schema-lite';
+import { $filter, $get, $map, $stepRef } from '@zenstackhq/orm';
 import { FetchFn, useClientQueries } from '@zenstackhq/tanstack-query/react';
 import { LoremIpsum } from 'lorem-ipsum';
 import Link from 'next/link';
@@ -9,10 +10,14 @@ import { useState } from 'react';
 
 const lorem = new LoremIpsum({ wordsPerSentence: { max: 6, min: 4 } });
 
+type TransactionBatchResult = [User, Post, Post, Post[], unknown, Post[]];
+
 export default function Home() {
     const [showPublishedOnly, setShowPublishedOnly] = useState(false);
     const [enableFetch, setEnableFetch] = useState(true);
     const [optimistic, setOptimistic] = useState(false);
+    const [transactionMessage, setTransactionMessage] = useState('');
+    const [transactionSucceeded, setTransactionSucceeded] = useState(false);
 
     const fetch: FetchFn = async (url, init) => {
         // simulate a delay for showing optimistic update effect
@@ -35,6 +40,22 @@ export default function Home() {
     const createPost = clientQueries.post.useCreate({ optimisticUpdate: optimistic });
     const deletePost = clientQueries.post.useDelete({ optimisticUpdate: optimistic });
     const updatePost = clientQueries.post.useUpdate({ optimisticUpdate: optimistic });
+    const { mutate: runTransaction, isPending: isCreatingTransaction } = clientQueries.$transaction.useSequential({
+        onSuccess(data) {
+            const [user, draftPost, publicPost, postsBeforePublish, , publishedPosts] = data as TransactionBatchResult;
+            const publishedDraftCount = postsBeforePublish.filter((post) => !post.published).length;
+            setTransactionSucceeded(true);
+            setTransactionMessage(
+                `Created ${user.email}, then published ${publishedDraftCount} draft ` +
+                    `using ids mapped from step 4. Final public posts: ${publishedPosts.length} ` +
+                    `(${draftPost.title}, ${publicPost.title}).`,
+            );
+        },
+        onError(error) {
+            setTransactionSucceeded(false);
+            setTransactionMessage(error.message);
+        },
+    });
 
     const onCreatePost = () => {
         if (!users) {
@@ -69,6 +90,79 @@ export default function Home() {
         });
     };
 
+    const onCreateTransactionPost = () => {
+        setTransactionMessage('');
+        setTransactionSucceeded(false);
+
+        const suffix = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+        const draftTitle = `Draft ${lorem.generateWords()}`;
+        const publicTitle = `Public ${lorem.generateWords()}`;
+        const email = `transaction-${suffix}@example.com`;
+
+        runTransaction([
+            {
+                model: 'User',
+                op: 'create',
+                args: {
+                    data: {
+                        email,
+                        name: 'Transaction User',
+                    },
+                },
+            },
+            {
+                model: 'Post',
+                op: 'create',
+                args: {
+                    data: {
+                        title: draftTitle,
+                        published: false,
+                        authorId: $get($stepRef<User>(1), 'id'),
+                    },
+                },
+            },
+            {
+                model: 'Post',
+                op: 'create',
+                args: {
+                    data: {
+                        title: publicTitle,
+                        published: true,
+                        authorId: $get($stepRef<User>(1), 'id'),
+                    },
+                },
+            },
+            {
+                model: 'Post',
+                op: 'findMany',
+                args: {
+                    where: { authorId: $get($stepRef<User>(1), 'id') },
+                    orderBy: { createdAt: 'asc' },
+                },
+            },
+            {
+                model: 'Post',
+                op: 'updateMany',
+                args: {
+                    where: {
+                        id: {
+                            in: $map($filter($stepRef<Post[]>(4), 'published', 'eq', false), 'id'),
+                        },
+                    },
+                    data: { published: true },
+                },
+            },
+            {
+                model: 'Post',
+                op: 'findMany',
+                args: {
+                    where: { authorId: $get($stepRef<User>(1), 'id'), published: true },
+                    orderBy: { createdAt: 'asc' },
+                },
+            },
+        ]);
+    };
+
     if (isUsersFetched && (!users || users.length === 0)) {
         return <div className="p-4">No users found. Please run &quot;pnpm db:init&quot; to seed the database.</div>;
     }
@@ -94,12 +188,28 @@ export default function Home() {
                 </Link>
             </div>
 
-            <button
-                onClick={onCreatePost}
-                className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 cursor-pointer"
-            >
-                New Post
-            </button>
+            <div className="flex flex-col gap-2 sm:flex-row">
+                <button
+                    onClick={onCreatePost}
+                    className="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 cursor-pointer"
+                >
+                    New Post
+                </button>
+
+                <button
+                    onClick={onCreateTransactionPost}
+                    disabled={isCreatingTransaction}
+                    className="rounded-md bg-orange-600 px-4 py-2 text-white hover:bg-orange-700 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                    {isCreatingTransaction ? 'Running transaction...' : 'Batch User + Posts Transaction'}
+                </button>
+            </div>
+
+            {transactionMessage && (
+                <p className={`text-sm ${transactionSucceeded ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+                    {transactionMessage}
+                </p>
+            )}
 
             <div>
                 <div>Current users</div>

--- a/samples/nuxt/README.md
+++ b/samples/nuxt/README.md
@@ -8,6 +8,7 @@ A simple blog application built with Nuxt, ZenStack ORM, and TanStack Query Vue 
 - User management
 - Published/draft post filtering
 - Optimistic updates
+- Sequential transaction example using `$stepRef`/`$get`/`$filter`/`$map`
 - TanStack Query Vue integration with ZenStack
 
 ## Getting Started

--- a/samples/nuxt/app/pages/index.vue
+++ b/samples/nuxt/app/pages/index.vue
@@ -1,15 +1,20 @@
 <script setup lang="ts">
+import { $filter, $get, $map, $stepRef } from '@zenstackhq/orm';
 import { useClientQueries, type FetchFn } from '@zenstackhq/tanstack-query/vue';
 import { LoremIpsum } from 'lorem-ipsum';
 import { ref } from 'vue';
-import type { Post } from '../../zenstack/models';
+import type { Post, User } from '../../zenstack/models';
 import { schema } from '../../zenstack/schema-lite';
 
 const lorem = new LoremIpsum({ wordsPerSentence: { max: 6, min: 4 } });
 
+type TransactionBatchResult = [User, Post, Post, Post[], unknown, Post[]];
+
 const showPublishedOnly = ref(false);
 const enableFetch = ref(true);
 const optimistic = ref(false);
+const transactionMessage = ref('');
+const transactionSucceeded = ref(false);
 
 const fetch: FetchFn = async (url, init) => {
     // simulate a delay for showing optimistic update effect
@@ -32,6 +37,21 @@ const { data: posts } = clientQueries.post.useFindMany(
 const createPost = clientQueries.post.useCreate(() => ({ optimisticUpdate: optimistic.value }));
 const deletePost = clientQueries.post.useDelete(() => ({ optimisticUpdate: optimistic.value }));
 const updatePost = clientQueries.post.useUpdate(() => ({ optimisticUpdate: optimistic.value }));
+const { mutate, isPending: isCreatingTransaction } = clientQueries.$transaction.useSequential({
+    onSuccess(data) {
+        const [user, draftPost, publicPost, postsBeforePublish, , publishedPosts] = data as TransactionBatchResult;
+        const publishedDraftCount = postsBeforePublish.filter((post) => !post.published).length;
+        transactionSucceeded.value = true;
+        transactionMessage.value =
+            `Created ${user.email}, then published ${publishedDraftCount} draft ` +
+            `using ids mapped from step 4. Final public posts: ${publishedPosts.length} ` +
+            `(${draftPost.title}, ${publicPost.title}).`;
+    },
+    onError(error) {
+        transactionSucceeded.value = false;
+        transactionMessage.value = error.message;
+    },
+});
 
 const onCreatePost = () => {
     if (!users.value) {
@@ -65,6 +85,79 @@ const onTogglePublishPost = (post: Post) => {
         data: { published: !post.published },
     });
 };
+
+const onCreateTransactionPost = () => {
+    transactionMessage.value = '';
+    transactionSucceeded.value = false;
+
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+    const draftTitle = `Draft ${lorem.generateWords()}`;
+    const publicTitle = `Public ${lorem.generateWords()}`;
+    const email = `transaction-${suffix}@example.com`;
+
+    mutate([
+        {
+            model: 'User',
+            op: 'create',
+            args: {
+                data: {
+                    email,
+                    name: 'Transaction User',
+                },
+            },
+        },
+        {
+            model: 'Post',
+            op: 'create',
+            args: {
+                data: {
+                    title: draftTitle,
+                    published: false,
+                    authorId: $get($stepRef<User>(1), 'id'),
+                },
+            },
+        },
+        {
+            model: 'Post',
+            op: 'create',
+            args: {
+                data: {
+                    title: publicTitle,
+                    published: true,
+                    authorId: $get($stepRef<User>(1), 'id'),
+                },
+            },
+        },
+        {
+            model: 'Post',
+            op: 'findMany',
+            args: {
+                where: { authorId: $get($stepRef<User>(1), 'id') },
+                orderBy: { createdAt: 'asc' },
+            },
+        },
+        {
+            model: 'Post',
+            op: 'updateMany',
+            args: {
+                where: {
+                    id: {
+                        in: $map($filter($stepRef<Post[]>(4), 'published', 'eq', false), 'id'),
+                    },
+                },
+                data: { published: true },
+            },
+        },
+        {
+            model: 'Post',
+            op: 'findMany',
+            args: {
+                where: { authorId: $get($stepRef<User>(1), 'id'), published: true },
+                orderBy: { createdAt: 'asc' },
+            },
+        },
+    ]);
+};
 </script>
 
 <template>
@@ -91,12 +184,30 @@ const onTogglePublishPost = (post: Post) => {
             </NuxtLink>
         </div>
 
-        <button
-            @click="onCreatePost"
-            class="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 cursor-pointer"
+        <div class="flex flex-col gap-2 sm:flex-row">
+            <button
+                @click="onCreatePost"
+                class="rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 cursor-pointer"
+            >
+                New Post
+            </button>
+
+            <button
+                :disabled="isCreatingTransaction"
+                @click="onCreateTransactionPost"
+                class="rounded-md bg-orange-600 px-4 py-2 text-white hover:bg-orange-700 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
+            >
+                {{ isCreatingTransaction ? 'Running transaction...' : 'Batch User + Posts Transaction' }}
+            </button>
+        </div>
+
+        <p
+            v-if="transactionMessage"
+            class="text-sm"
+            :class="transactionSucceeded ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'"
         >
-            New Post
-        </button>
+            {{ transactionMessage }}
+        </p>
 
         <div>
             <div>Current users</div>


### PR DESCRIPTION
This PR builds on the sequential transaction system introduced in [#2637](https://github.com/zenstackhq/zenstack/pull/2637), adding typed constructors, composable expressions.

---

## New Features

| Feature | Description |
|---|---|
|  **Typed helpers** `$stepRef<T>`, `$get`, `$item`, `$first`, `$filter`, `$map` | Return serializable plain objects with full IntelliSense on field names and value types |
| **Composable expressions** | `$get($filter($stepRef<Post[]>(1), 'title', 'eq', 'Foo'), 'id')` — arbitrary chaining |
|  **Filter on step results** | Filter an array step by field (`eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn`, `contains`) |
| **Map** | Extract a field from every element of an array step |
|  **RPC tests** | 31 tests covering step refs, expressions, and edge cases |

---

## Examples

### 1. Simple step ref (create user → linked post)

```ts
import { $get, $stepRef } from '@zenstackhq/orm';

const ops = [
    { model: 'User', op: 'create', args: { data: { email: 'alice@test.com' } } },
    {
        model: 'Post',
        op: 'create',
        args: {
            data: {
                title: 'My Post',
                authorId: $get($stepRef<User>(1), 'id'),  // step 1 = created User
            },
        },
    },
];
```

### 2. Pick the first item from a list

```ts
$get($first($stepRef(1)), 'id')
```

### 3. Publish all drafts via filter + map

```ts
const ops = [
    { model: 'User', op: 'create', args: { data: { email } } },          // step 1
    { model: 'Post', op: 'create', args: { data: { title, published: false, authorId: $get($stepRef<User>(1), 'id') } } }, // step 2
    { model: 'Post', op: 'create', args: { data: { title, published: true, authorId: $get($stepRef<User>(1), 'id') } } },  // step 3
    { model: 'Post', op: 'findMany', args: { where: { authorId: $get($stepRef<User>(1), 'id') } } }, // step 4
    { model: 'Post', op: 'updateMany', args: {                                                                        // step 5
        where: { id: { in: $map($filter($stepRef<Post[]>(4), 'published', 'eq', false), 'id') } },
        data: { published: true },
    } },
    { model: 'Post', op: 'findMany', args: { where: { authorId: $get($stepRef<User>(1), 'id'), published: true } } }, // step 6
];
```

### 4. Using the TanStack Query hook (Vue / React)

```ts
const { mutate } = clientQueries.$transaction.useSequential({
    onSuccess(data) {
        const [user, post] = data as [User, Post];
        console.log(`Post "${post.title}" created for ${user.email}`);
    },
    onError(error) {
        console.error(error.message);
    },
});

mutate([
    { model: 'User', op: 'create', args: { data: { email } } },
    { model: 'Post', op: 'create', args: { data: { title, authorId: $get($stepRef<User>(1), 'id') } } },
]);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sequential transactions now support referencing and composing results from earlier steps using new expression helpers ($stepRef, $get, $item, $first, $filter, $map).
  * Enhanced validation with detailed error messages for invalid transaction operations.

* **Documentation**
  * Sample applications updated with sequential transaction workflow examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->