### PR TITLE
fix(orm): handle cyclic JSON typedef references in zod factory (#2654)

### DIFF
--- a/packages/orm/src/client/zod/factory.ts
+++ b/packages/orm/src/client/zod/factory.ts
@@ -384,7 +384,11 @@ export class ZodSchemaFactory<
         const schema = z.looseObject(
             Object.fromEntries(
                 Object.entries(typeDef.fields).map(([field, def]) => {
-                    let fieldSchema = this.makeScalarSchema(def.type);
+                    // Wrap nested typedef references in z.lazy() so cyclic or self-referencing
+                    // typedefs don't recurse infinitely while building schemas.
+                    let fieldSchema: ZodType = isTypeDef(this.schema, def.type)
+                        ? z.lazy(() => this.makeTypeDefSchema(def.type))
+                        : this.makeScalarSchema(def.type);
                     if (def.array) {
                         fieldSchema = fieldSchema.array();
                     }

--- a/tests/regression/test/issue-2654.test.ts
+++ b/tests/regression/test/issue-2654.test.ts
@@ -1,0 +1,72 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2654
+describe('Regression for issue 2654', () => {
+    it('handles cyclic references between JSON typedefs', async () => {
+        const schema = `
+type A {
+    name String
+    b    B
+}
+
+type B {
+    a A[]
+    x String
+}
+
+model User {
+    id String @id @default(cuid())
+    a  A      @json
+}
+`;
+
+        const db = await createTestClient(schema, { provider: 'postgresql' });
+
+        const data = {
+            id: 'u1',
+            a: { name: 'abc', b: { x: '123', a: [] } },
+        };
+        await expect(db.user.create({ data })).resolves.toMatchObject(data);
+
+        const nested = {
+            id: 'u2',
+            a: {
+                name: 'root',
+                b: {
+                    x: 'b1',
+                    a: [{ name: 'inner', b: { x: 'b2', a: [] } }],
+                },
+            },
+        };
+        await expect(db.user.create({ data: nested })).resolves.toMatchObject(nested);
+    });
+
+    it('handles self-referencing JSON typedef', async () => {
+        const schema = `
+type Tree {
+    name     String
+    children Tree[]?
+}
+
+model Node {
+    id   String @id @default(cuid())
+    tree Tree   @json
+}
+`;
+
+        const db = await createTestClient(schema, { provider: 'postgresql' });
+
+        const data = {
+            id: 'n1',
+            tree: {
+                name: 'root',
+                children: [
+                    { name: 'child1', children: [] },
+                    { name: 'child2', children: [{ name: 'grandchild', children: [] }] },
+                ],
+            },
+        };
+        await expect(db.node.create({ data })).resolves.toMatchObject(data);
+    });
+});


### PR DESCRIPTION
## Summary
- `makeTypeDefSchema` previously recursed forever when JSON typedefs referenced each other (or themselves), throwing `RangeError: Maximum call stack size exceeded`. The `@cache()` decorator only populates the cache *after* the method returns, so the recursive call still saw an empty cache.
- Wrap nested typedef references in `z.lazy(() => …)` so the inner lookup defers to validation time, by which point the outer build has finished and cached its result. Same pattern already used by `makeJsonValueSchema`.
- Added regression test [`tests/regression/test/issue-2654.test.ts`](tests/regression/test/issue-2654.test.ts) covering cyclic (`A` ↔ `B`) and self-referencing (`Tree { children Tree[]? }`) typedefs.

Fixes #2654

## Test plan
- [x] `tests/regression/test/issue-2654.test.ts` passes
- [x] `tests/regression/test/issue-{493,558,586}.test.ts` (existing JSON typedef coverage) still pass
- [x] `tests/e2e/orm/client-api/typed-json-fields.test.ts` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved infinite recursion errors that occurred during schema generation when working with cyclic or self-referential JSON typedefs, enabling applications to properly create, persist, and retrieve complex nested data structures with circular references.

* **Tests**
  * Added comprehensive regression tests verifying the correct behavior and persistence of cyclic and self-referential JSON typedef operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->