### PR TITLE
fix(better-auth): keep schema-generator import lazy in CJS output

### DIFF
--- a/packages/auth-adapters/better-auth/src/adapter.ts
+++ b/packages/auth-adapters/better-auth/src/adapter.ts
@@ -187,7 +187,9 @@ export const zenstackAdapter = <Schema extends SchemaDef>(db: ClientContract<Sch
                 options: config,
 
                 createSchema: async ({ file, tables }) => {
-                    const generateSchema = (await import('./schema-generator')).generateSchema;
+                    // Self-import via package subpath (not a relative './schema-generator') so the
+                    // bundler treats it as external and keeps it lazy in the CJS output — see tsdown.config.ts.
+                    const generateSchema = (await import('@zenstackhq/better-auth/schema-generator')).generateSchema;
                     return generateSchema(file, tables, config, options);
                 },
             };

--- a/packages/auth-adapters/better-auth/tsconfig.json
+++ b/packages/auth-adapters/better-auth/tsconfig.json
@@ -3,7 +3,10 @@
     "compilerOptions": {
         "rootDir": ".",
         "noPropertyAccessFromIndexSignature": false,
-        "types": ["node"]
+        "types": ["node"],
+        "paths": {
+            "@zenstackhq/better-auth/schema-generator": ["./src/schema-generator.ts"]
+        }
     },
     "include": ["src/**/*"]
 }

--- a/packages/auth-adapters/better-auth/tsdown.config.ts
+++ b/packages/auth-adapters/better-auth/tsdown.config.ts
@@ -1,3 +1,18 @@
 import { createConfig } from '@zenstackhq/tsdown-config';
 
-export default createConfig({ entry: { index: 'src/index.ts', 'schema-generator': 'src/schema-generator.ts' } });
+// `index` and `schema-generator` are built as two separate tsdown invocations so that
+// the lazy `await import('@zenstackhq/better-auth/schema-generator')` in the adapter
+// stays lazy in the CJS output. When both entries live in a single build, Rolldown
+// treats them as siblings and injects a top-level `require('./schema-generator.cjs')`
+// into `index.cjs`, which eagerly pulls in `@zenstackhq/language` (Langium) at adapter
+// load time. Splitting the builds hides that relationship; `neverBundle` then keeps
+// the dynamic import as a package-name reference that Node resolves at first call.
+export default [
+    createConfig({
+        entry: { index: 'src/index.ts' },
+        deps: { neverBundle: ['@zenstackhq/better-auth/schema-generator'] },
+    }),
+    createConfig({
+        entry: { 'schema-generator': 'src/schema-generator.ts' },
+    }),
+];


### PR DESCRIPTION
## Summary

- Fixes #2646 — `ERR_PACKAGE_PATH_NOT_EXPORTED` for `langium/package.json` on CJS apps (e.g. NestJS) when constructing the better-auth adapter.
- Root cause: the bundled `index.cjs` had a top-level `require("./schema-generator.cjs")` that eagerly pulled `@zenstackhq/language` (Langium) at adapter load time. Langium's `package.json` lacks an `exports` main, so resolution from CJS failed.
- The dynamic `await import('./schema-generator')` inside `createSchema` was supposed to keep that branch lazy, but Rolldown was hoisting a sibling-chunk register into the file top because both entries were built in a single tsdown invocation.

## Fix

- Split `tsdown.config.ts` into two separate tsdown invocations (one per entry) so Rolldown no longer treats them as siblings and stops injecting the eager top-level require.
- Switched the dynamic import to a package self-subpath (`@zenstackhq/better-auth/schema-generator`) and added it to `deps.neverBundle` so Rolldown leaves it as an external reference resolved by Node at first call.
- Added comments in both files explaining why this setup is required.

After the change, `dist/index.cjs` no longer has any top-level reference to `schema-generator`; only the lazy `await import("@zenstackhq/better-auth/schema-generator")` inside `createSchema` remains. Langium is therefore only loaded when schema generation is actually invoked (e.g. during `@better-auth/cli generate`), not on adapter construction.

## Test plan

- [x] `pnpm test` in `packages/auth-adapters/better-auth` passes (6/6, including `cli-generate.test.ts` which exercises the dynamic import path)
- [x] Verified `dist/index.cjs` has no top-level `require("./schema-generator.cjs")` after build
- [x] Verified `dist/index.mjs` still uses lazy `await import(...)` only inside `createSchema`
- [ ] Manual repro from #2646 (NestJS + better-auth CJS startup) confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Better-Auth adapter now loads its schema generator from a dedicated package entry, preserving lazy/dynamic loading so adapter startup remains lightweight.
  * Build and TypeScript configs updated to support the modular entry, improving packaging and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->