### PR TITLE
fix: detect policy plugin by stable id

### DIFF
--- a/packages/orm/src/client/crud/operations/base.ts
+++ b/packages/orm/src/client/crud/operations/base.ts
@@ -221,7 +221,7 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
 
     // TODO: this is not clean, needs a better solution
     protected get hasPolicyEnabled() {
-        return this.options.plugins?.some((plugin) => plugin.constructor.name === 'PolicyPlugin');
+        return this.options.plugins?.some((plugin) => plugin.id === 'policy') ?? false;
     }
 
     protected requireModel(model: string) {

--- a/tests/regression/test/policy-plugin-detection.test.ts
+++ b/tests/regression/test/policy-plugin-detection.test.ts
@@ -1,0 +1,29 @@
+import { PolicyPlugin } from '@zenstackhq/plugin-policy';
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+describe('PolicyPlugin detection', () => {
+    it('uses plugin id when constructor names are bundled or minified', async () => {
+        const MinifiedPolicyPlugin = class a extends PolicyPlugin {};
+        const plugin = new MinifiedPolicyPlugin();
+
+        expect(plugin.id).toBe('policy');
+        expect(plugin.constructor.name).toBe('a');
+
+        const db = await createTestClient(
+            `
+model User {
+    id String @id
+    name String
+
+    @@allow('all', true)
+}
+            `,
+            { plugins: [plugin] },
+        );
+
+        await db.user.create({ data: { id: 'u1', name: 'User 1' } });
+
+        await expect(db.user.delete({ where: { id: 'u1' } })).resolves.toEqual({ id: 'u1', name: 'User 1' });
+    });
+});


### PR DESCRIPTION
### Summary
Fixes #2662 

This updates ZenStack ORM policy plugin detection so it no longer relies on `constructor.name`, which can be changed or removed by production bundling/minification.

Policy mode is now detected through the stable runtime plugin id (`policy`). This keeps ORM mutation behavior consistent when `PolicyPlugin` is active, including policy-safe delete behavior that avoids `DELETE ... RETURNING *` followed by failed post-delete read-back.

This problem can break deletes in Next.js/Turbopack production bundles with:

`result is not allowed to be read back`

### Validation
pnpm --filter @zenstackhq/orm build
TEST_DB_PROVIDER=sqlite pnpm --dir tests/regression exec vitest run test/policy-plugin-detection.test.ts

PostgreSQL validation was attempted but blocked by local default credential auth:
`password authentication failed for user "postgres"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy enforcement detection to work reliably across different code optimization levels.

* **Tests**
  * Added regression test suite for policy enforcement functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zenstackhq/zenstack/pull/2663)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->