### PR TITLE
test(fetch-client): restore globalThis.fetch in afterEach

### DIFF
--- a/packages/clients/fetch-client/test/fetch-client.test.ts
+++ b/packages/clients/fetch-client/test/fetch-client.test.ts
@@ -18,6 +18,7 @@ function makeSerializedResponseText(data: unknown) {
 
 describe('createClient', () => {
     let mockFetch: ReturnType<typeof vi.fn>;
+    const originalFetch = globalThis.fetch;
 
     beforeEach(() => {
         mockFetch = vi.fn();
@@ -25,6 +26,7 @@ describe('createClient', () => {
     });
 
     afterEach(() => {
+        globalThis.fetch = originalFetch;
         vi.resetAllMocks();
     });
 


### PR DESCRIPTION
## Summary
- Save the original `globalThis.fetch` at describe scope and restore it in `afterEach` so the mocked fetch does not leak into other test files.

## Test plan
- [x] `pnpm vitest run test/fetch-client.test.ts` in `packages/clients/fetch-client` passes (47/47).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup to properly preserve and restore the original fetch implementation between test runs, enhancing test reliability and preventing potential test interference.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zenstackhq/zenstack/pull/2668)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->