### PR TITLE
feat: phone validation

### DIFF
--- a/packages/cli/test/db/pull.test.ts
+++ b/packages/cli/test/db/pull.test.ts
@@ -621,6 +621,7 @@ enum Status {
                 `model User {
     id       Int     @id @default(autoincrement())
     email    String  @unique @email
+    phone    String  @phone
     name     String  @length(min: 2, max: 100)
     website  String? @url
     code     String? @regex('^[A-Z]+$')

--- a/packages/language/res/stdlib.zmodel
+++ b/packages/language/res/stdlib.zmodel
@@ -552,6 +552,11 @@ attribute @datetime(_ message: String?) @@@targetField([StringField]) @@@validat
 attribute @url(_ message: String?) @@@targetField([StringField]) @@@validation
 
 /**
+ * Validates a string field value is a valid E.164 phone number.
+ */
+attribute @phone(_ message: String?) @@@targetField([StringField]) @@@validation
+
+/**
  * Trims whitespaces from the start and end of the string.
  */
 attribute @trim() @@@targetField([StringField]) @@@validation
@@ -620,6 +625,12 @@ function isDateTime(field: String): Boolean {
  * Validates a string field value is a valid url.
  */
 function isUrl(field: String): Boolean {
+} @@@expressionContext([ValidationRule])
+
+/**
+ * Validates a string field value is a valid E.164 phone number.
+ */
+function isPhone(field: String): Boolean {
 } @@@expressionContext([ValidationRule])
 
 //////////////////////////////////////////////

--- a/packages/zod/src/utils.ts
+++ b/packages/zod/src/utils.ts
@@ -72,6 +72,9 @@ export function addStringValidation(
             case '@email':
                 result = result.email();
                 break;
+            case '@phone':
+                result = result.e164();
+                break;
             case '@datetime':
                 result = result.datetime();
                 break;
@@ -533,12 +536,19 @@ function evalCall(data: any, expr: CallExpression) {
         }
         case 'isEmail':
         case 'isUrl':
+        case 'isPhone':
         case 'isDateTime': {
             if (fieldArg === undefined || fieldArg === null || fieldArg === ABSENT) {
                 return false;
             }
             invariant(typeof fieldArg === 'string', `"${f}" first argument must be a string`);
-            const fn = f === 'isEmail' ? ('email' as const) : f === 'isUrl' ? ('url' as const) : ('datetime' as const);
+            const fn = f === 'isEmail'
+                ? ('email' as const)
+                : f === 'isUrl'
+                    ? ('url' as const)
+                    : f === 'isPhone'
+                        ? ('e164' as const)
+                        : ('datetime' as const);
             return z.string()[fn]().safeParse(fieldArg).success;
         }
         // list functions

--- a/packages/zod/test/factory.test.ts
+++ b/packages/zod/test/factory.test.ts
@@ -263,7 +263,7 @@ describe('SchemaFactory - makeModelSchema', () => {
 
         it('rejects invalid phone number for @phone field', () => {
             const userSchema = factory.makeModelSchema('User');
-            const result = userSchema.safeParse({ ...validUser, website: 'not-a-phone' });
+            const result = userSchema.safeParse({ ...validUser, phone: 'not-a-phone' });
             expect(result.success).toBe(false);
         });
 

--- a/packages/zod/test/factory.test.ts
+++ b/packages/zod/test/factory.test.ts
@@ -590,6 +590,7 @@ describe('SchemaFactory - makeTypeSchema', () => {
             const validUser = {
                 id: 'u1',
                 email: 'a@b.com',
+                phone: '+15555555555',
                 username: 'alice',
                 website: null,
                 code: 'USR01',

--- a/packages/zod/test/factory.test.ts
+++ b/packages/zod/test/factory.test.ts
@@ -11,6 +11,7 @@ const factory = createSchemaFactory(schema);
 const validUser = {
     id: 'user123',
     email: 'test@example.com',
+    phone: '+15555555555',
     username: 'johndoe',
     website: null,
     code: 'USR001',
@@ -44,6 +45,7 @@ describe('SchemaFactory - makeModelSchema', () => {
             // required string fields
             expectTypeOf<User['id']>().toEqualTypeOf<string>();
             expectTypeOf<User['email']>().toEqualTypeOf<string>();
+            expectTypeOf<User['phone']>().toEqualTypeOf<string>();
             expectTypeOf<User['username']>().toEqualTypeOf<string>();
             expectTypeOf<User['code']>().toEqualTypeOf<string>();
             // optional string field (nullable + optional)
@@ -256,6 +258,18 @@ describe('SchemaFactory - makeModelSchema', () => {
         it('accepts null for optional @url field', () => {
             const userSchema = factory.makeModelSchema('User');
             const result = userSchema.safeParse({ ...validUser, website: null });
+            expect(result.success).toBe(true);
+        });
+
+        it('rejects invalid phone number for @phone field', () => {
+            const userSchema = factory.makeModelSchema('User');
+            const result = userSchema.safeParse({ ...validUser, website: 'not-a-phone' });
+            expect(result.success).toBe(false);
+        });
+
+        it('accepts valid phone number for @phone field', () => {
+            const userSchema = factory.makeModelSchema('User');
+            const result = userSchema.safeParse({ ...validUser, phone: '+15555555555' });
             expect(result.success).toBe(true);
         });
 
@@ -934,7 +948,9 @@ describe('SchemaFactory - makeModelSchema with options', () => {
             expectTypeOf<Result>().toHaveProperty('id');
             expectTypeOf<Result['id']>().toEqualTypeOf<string>();
             expectTypeOf<Result>().toHaveProperty('email');
+            expectTypeOf<Result>().toHaveProperty('phone');
             expectTypeOf<Result['email']>().toEqualTypeOf<string>();
+            expectTypeOf<Result['phone']>().toEqualTypeOf<string>();
         });
 
         it('omit: {} (empty) keeps all scalar fields', () => {
@@ -954,6 +970,7 @@ describe('SchemaFactory - makeModelSchema with options', () => {
             expectTypeOf<Result>().not.toHaveProperty('username');
             expectTypeOf<Result>().not.toHaveProperty('avatar');
             expectTypeOf<Result>().toHaveProperty('email');
+            expectTypeOf<Result>().toHaveProperty('phone');
         });
     });
 
@@ -985,6 +1002,7 @@ describe('SchemaFactory - makeModelSchema with options', () => {
             type Result = z.infer<typeof _schema>;
             expectTypeOf<Result['id']>().toEqualTypeOf<string>();
             expectTypeOf<Result['email']>().toEqualTypeOf<string>();
+            expectTypeOf<Result['phone']>().toEqualTypeOf<string>();
             expectTypeOf<Result['username']>().toEqualTypeOf<string>();
         });
 
@@ -1039,6 +1057,7 @@ describe('SchemaFactory - makeModelSchema with options', () => {
             type Result = z.infer<typeof _schema>;
             expectTypeOf<Result>().not.toHaveProperty('username');
             expectTypeOf<Result>().toHaveProperty('email');
+            expectTypeOf<Result>().toHaveProperty('phone');
             expectTypeOf<Result>().toHaveProperty('posts');
         });
     });
@@ -1069,6 +1088,7 @@ describe('SchemaFactory - makeModelSchema with options', () => {
             expectTypeOf<Result['email']>().toEqualTypeOf<string>();
             expectTypeOf<Result>().not.toHaveProperty('username');
             expectTypeOf<Result>().not.toHaveProperty('posts');
+            expectTypeOf<Result>().not.toHaveProperty('phone');
         });
 
         it('select with a relation field (true) includes the relation', () => {
@@ -1084,6 +1104,7 @@ describe('SchemaFactory - makeModelSchema with options', () => {
             expectTypeOf<Result>().toHaveProperty('id');
             expectTypeOf<Result>().toHaveProperty('posts');
             expectTypeOf<Result>().not.toHaveProperty('email');
+            expectTypeOf<Result>().not.toHaveProperty('phone');
         });
 
         it('select with nested options on a relation', () => {
@@ -1214,6 +1235,7 @@ describe('SchemaFactory - makeModelSchema with options', () => {
                 type Result = z.infer<typeof _schema>;
                 expectTypeOf<Result['id']>().toEqualTypeOf<string | undefined>();
                 expectTypeOf<Result['email']>().toEqualTypeOf<string | undefined>();
+                expectTypeOf<Result['phone']>().toEqualTypeOf<string | undefined>();
                 expectTypeOf<Result['username']>().toEqualTypeOf<string | undefined>();
                 expectTypeOf<Result['active']>().toEqualTypeOf<boolean | undefined>();
                 expectTypeOf<Result['age']>().toEqualTypeOf<number | undefined>();
@@ -1342,6 +1364,7 @@ describe('SchemaFactory - makeModelSchema with options', () => {
                 const _schema = factory.makeModelSchema('User', { optionality: 'all' });
                 type Result = z.infer<typeof _schema>;
                 expectTypeOf<Result['email']>().toEqualTypeOf<string | undefined>();
+                expectTypeOf<Result['phone']>().toEqualTypeOf<string | undefined>();
                 expectTypeOf<Result['username']>().toEqualTypeOf<string | undefined>();
                 expectTypeOf<Result['age']>().toEqualTypeOf<number | undefined>();
                 // already-optional nullable field
@@ -1356,6 +1379,7 @@ describe('SchemaFactory - makeModelSchema with options', () => {
                 type Result = z.infer<typeof _schema>;
                 expectTypeOf<Result>().not.toHaveProperty('username');
                 expectTypeOf<Result['email']>().toEqualTypeOf<string | undefined>();
+                expectTypeOf<Result['phone']>().toEqualTypeOf<string | undefined>();
             });
 
             it('infers selected fields as optional when optionality is all', () => {

--- a/packages/zod/test/schema/schema.ts
+++ b/packages/zod/test/schema/schema.ts
@@ -26,6 +26,11 @@ export class SchemaType implements SchemaDef {
                     type: "String",
                     attributes: [{ name: "@email" }, { name: "@meta", args: [{ name: "name", value: ExpressionUtils.literal("description") }, { name: "value", value: ExpressionUtils.literal("The user's email address") }] }] as readonly AttributeApplication[]
                 },
+                phone: {
+                    name: "phone",
+                    type: "String",
+                    attributes: [{ name: "@phone" }] as readonly AttributeApplication[]
+                },
                 username: {
                     name: "username",
                     type: "String",

--- a/packages/zod/test/schema/schema.zmodel
+++ b/packages/zod/test/schema/schema.zmodel
@@ -23,6 +23,7 @@ type Address {
 model User {
     id        String    @id @default(cuid())
     email     String    @email @meta("description", "The user's email address")
+    phone     String    @phone
     username  String    @length(3, 50)
     website   String?   @url
     code      String    @startsWith("USR")

--- a/tests/e2e/orm/validation/custom-validation.test.ts
+++ b/tests/e2e/orm/validation/custom-validation.test.ts
@@ -113,6 +113,7 @@ describe('Custom validation tests', () => {
                     str3: 'ab@c.com',
                     str4: 'http://a.b.c',
                     str5: new Date().toISOString(),
+                    str6: '+15555555555',
                     int1: 2,
                     list1: [1, 2, 4, 5],
                     list2: [],

--- a/tests/e2e/orm/validation/custom-validation.test.ts
+++ b/tests/e2e/orm/validation/custom-validation.test.ts
@@ -12,6 +12,7 @@ describe('Custom validation tests', () => {
             str3 String?
             str4 String?
             str5 String?
+            str6 String?
             int1 Int?
             list1 Int[]
             list2 Int[]
@@ -31,6 +32,8 @@ describe('Custom validation tests', () => {
             @@validate(str4 == null || isUrl(str4), 'invalid str4')
 
             @@validate(str5 == null || isDateTime(str5), 'invalid str5')
+
+            @@validate(str6 == null || isPhone(str6), 'invalid str6')
 
             @@validate(list1 == null || (has(list1, 1) && hasSome(list1, [2, 3]) && hasEvery(list1, [4, 5])), 'invalid list1')
 
@@ -76,6 +79,9 @@ describe('Custom validation tests', () => {
 
             // violates datetime
             await expect(_t({ str5: 'not-an-datetime' })).toBeRejectedByValidation(['invalid str5']);
+
+            // violates phone
+            await expect(_t({ str6: 'not-a-phone' })).toBeRejectedByValidation(['invalid str6']);
 
             // violates has
             await expect(_t({ list1: [2, 3, 4, 5] })).toBeRejectedByValidation(['invalid list1']);

--- a/tests/e2e/orm/validation/toplevel.test.ts
+++ b/tests/e2e/orm/validation/toplevel.test.ts
@@ -14,6 +14,7 @@ describe('Toplevel field validation tests', () => {
             str4 String? @url
             str5 String? @trim @lower
             str6 String? @upper
+            str7 String? @phone
         }
         `,
         );
@@ -83,6 +84,12 @@ describe('Toplevel field validation tests', () => {
             } else {
                 await expect(_t({ str6: 'aBc' })).resolves.toMatchObject({ count: 1 });
             }
+
+            // violates @phone
+            await expect(_t({ str7: 'not-a-phone' })).toBeRejectedByValidation(['Invalid E.164']);
+
+            // satisfies @phone
+            await expect(_t({ str7: '+15555555555' })).toResolveTruthy();
         }
     });
 


### PR DESCRIPTION
Adds a `@phone` attribute and `isPhone` function that validates E.164 phone numbers.

Closes #1897 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added E.164 phone-number validation for string fields: new field-level attribute and corresponding validation rule, with runtime enforcement added to schema validation.

* **Tests**
  * Updated unit, integration, and e2e tests to cover phone validation (valid and invalid cases) and to ensure validation attributes are preserved across schema operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zenstackhq/zenstack/pull/2672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->