### PR TITLE
fix: invalid prisma schema with format args

### DIFF
--- a/packages/cli/test/prisma-schema-gen.test.ts
+++ b/packages/cli/test/prisma-schema-gen.test.ts
@@ -29,6 +29,7 @@ model User {
 
         expect(prismaSchemaText.includes('cuid()')).toBe(true);
         expect(prismaSchemaText.includes('cuid(1)')).toBe(true);
+        expect(prismaSchemaText.includes('cuid(2)')).toBe(true);
         expect(prismaSchemaText.includes('cuid1_%s')).toBe(false);
         expect(prismaSchemaText.includes('cuid2_%s')).toBe(false);
 

--- a/packages/cli/test/prisma-schema-gen.test.ts
+++ b/packages/cli/test/prisma-schema-gen.test.ts
@@ -31,6 +31,7 @@ model User {
         expect(prismaSchemaText.includes('cuid(1)')).toBe(true);
         expect(prismaSchemaText.includes('cuid(2)')).toBe(true);
 
+        expect(prismaSchemaText.includes('uuid()')).toBe(true);
         expect(prismaSchemaText.includes('uuid(4)')).toBe(true);
         expect(prismaSchemaText.includes('uuid(7)')).toBe(true);
 

--- a/packages/cli/test/prisma-schema-gen.test.ts
+++ b/packages/cli/test/prisma-schema-gen.test.ts
@@ -29,15 +29,20 @@ model User {
 
         expect(prismaSchemaText.includes('cuid()')).toBe(true);
         expect(prismaSchemaText.includes('cuid(1)')).toBe(true);
-        expect(prismaSchemaText.includes('cuid(2)')).toBe(true);
+        expect(prismaSchemaText.includes('cuid1_%s')).toBe(false);
+        expect(prismaSchemaText.includes('cuid2_%s')).toBe(false);
 
         expect(prismaSchemaText.includes('uuid()')).toBe(true);
         expect(prismaSchemaText.includes('uuid(4)')).toBe(true);
         expect(prismaSchemaText.includes('uuid(7)')).toBe(true);
+        expect(prismaSchemaText.includes('uuid4_%s')).toBe(false);
+        expect(prismaSchemaText.includes('uuid7_%s')).toBe(false);
 
         expect(prismaSchemaText.match(/ulid\(\)/g)).toHaveLength(2);
+        expect(prismaSchemaText.includes('ulid_%s')).toBe(false);
 
         expect(prismaSchemaText.includes('nanoid()')).toBe(true);
         expect(prismaSchemaText.includes('nanoid(12)')).toBe(true);
+        expect(prismaSchemaText.includes('nanoid12_%s')).toBe(false);
     });
 });

--- a/packages/cli/test/prisma-schema-gen.test.ts
+++ b/packages/cli/test/prisma-schema-gen.test.ts
@@ -1,0 +1,42 @@
+import { loadSchema } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+import { PrismaSchemaGenerator } from '@zenstackhq/sdk';
+
+describe('Prisma schema generation tests', () => {
+    it('strips format args from id functions', async () => {
+        const model = await loadSchema(`
+model User {
+    id       Int    @id @default(autoincrement())
+
+    cuid     String @default(cuid())
+    cuid1    String @default(cuid(1, 'cuid1_%s'))
+    cuid2    String @default(cuid(2, 'cuid2_%s'))
+
+    uuid     String @default(uuid())
+    uuid4    String @default(uuid(4, 'uuid4_%s'))
+    uuid7    String @default(uuid(7, 'uuid7_%s'))
+
+    ulid     String @default(ulid())
+    ulid1    String @default(ulid('ulid_%s'))
+
+    nanoid   String @default(nanoid())
+    nanoid12 String @default(nanoid(12, 'nanoid12_%s'))
+}
+        `);
+
+        const generator = new PrismaSchemaGenerator(model);
+        const prismaSchemaText = await generator.generate();
+
+        expect(prismaSchemaText.includes('cuid()')).toBe(true);
+        expect(prismaSchemaText.includes('cuid(1)')).toBe(true);
+        expect(prismaSchemaText.includes('cuid(2)')).toBe(true);
+
+        expect(prismaSchemaText.includes('uuid(4)')).toBe(true);
+        expect(prismaSchemaText.includes('uuid(7)')).toBe(true);
+
+        expect(prismaSchemaText.match(/ulid\(\)/g)).toHaveLength(2);
+
+        expect(prismaSchemaText.includes('nanoid()')).toBe(true);
+        expect(prismaSchemaText.includes('nanoid(12)')).toBe(true);
+    });
+});

--- a/packages/sdk/src/prisma/prisma-schema-generator.ts
+++ b/packages/sdk/src/prisma/prisma-schema-generator.ts
@@ -67,6 +67,7 @@ const IDENTIFIER_NAME_MAX_LENGTH = 50 - DELEGATE_AUX_RELATION_PREFIX.length;
 
 // Datasource fields that only exist in ZModel but not in Prisma schema
 const NON_PRISMA_DATASOURCE_FIELDS = ['defaultSchema'];
+const ID_FUNCTIONS = ['uuid', 'ulid', 'cuid', 'nanoid'];
 
 /**
  * Generates Prisma schema file
@@ -383,7 +384,11 @@ export class PrismaSchemaGenerator {
     makeFunctionCall(node: InvocationExpr): PrismaFunctionCall {
         return new PrismaFunctionCall(
             node.function.ref!.name,
-            node.args.map((arg) => {
+
+            // strip format args from id functions
+            node.args.filter((_, i) => (
+                !(ID_FUNCTIONS.includes(node.function.ref!.name) && (node.function.ref!.name === 'ulid' && i === 0 || i === 1))
+            )).map((arg) => {
                 const val = match(arg.value)
                     .when(isStringLiteral, (v) => `"${v.value}"`)
                     .when(isLiteralExpr, (v) => v.value.toString())


### PR DESCRIPTION
Prisma errors when the ID format args are left as is. This PR strips them during Prisma schema generation.

<img width="742" height="446" alt="image" src="https://github.com/user-attachments/assets/f8e53988-f8b1-4df2-81a8-a7b93fdc72ac" />

https://discord.com/channels/1035538056146595961/1506671487745265796/1506671487745265796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying Prisma schema output for default ID generators (cuid, uuid, ulid, nanoid), including base and numeric-argument variants.

* **Improvements**
  * Prisma schema generation now emits ID default calls in normalized forms, omitting unnecessary format arguments so generated schemas match expected call patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zenstackhq/zenstack/pull/2677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->