### PR TITLE
ci: switch publish workflow to npm trusted publishing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,6 +11,7 @@ env:
 
 permissions:
     contents: write
+    id-token: write
 
 jobs:
     publish-and-release:
@@ -28,7 +29,7 @@ jobs:
             - name: Use Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 22.x
+                  node-version: 24.x
                   cache: 'pnpm'
                   registry-url: 'https://registry.npmjs.org'
 
@@ -55,7 +56,7 @@ jobs:
             - name: Publish packages
               run: pnpm run publish-all
               env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+                  NPM_CONFIG_PROVENANCE: 'true'
 
             - name: Generate changelog
               id: changelog


### PR DESCRIPTION
## Summary
- Switch the publish workflow to npm OIDC trusted publishing (drops `NPM_TOKEN`, adds `id-token: write` and `NPM_CONFIG_PROVENANCE`).
- Bump Node to 24.x so the bundled npm (11.x) supports trusted publishing without an extra `npm install -g npm@latest` step.

## Test plan
- [ ] Trusted publisher config exists on each `@zenstackhq/*` package (see `scripts/setup-trusted-publishers.sh`).
- [ ] Trigger the workflow on `main` and confirm publish + provenance succeeds without `NPM_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow security and reliability with updated build tooling and provenance generation for published packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zenstackhq/zenstack/pull/2680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->