### PR TITLE
fix(zod): `DateTime`, `Bytes`, and `Decimal` field inference for `z.input`

### DIFF
--- a/packages/zod/src/types.ts
+++ b/packages/zod/src/types.ts
@@ -17,8 +17,8 @@ import type {
     TypeDefFieldIsArray,
     TypeDefFieldIsOptional,
 } from '@zenstackhq/schema';
-import type Decimal from 'decimal.js';
 import type z from 'zod';
+import type { decimalSchema, bytesSchema } from './utils';
 
 /**
  * Scalar-only shape returned by the no-options `makeModelSchema` overload.
@@ -106,10 +106,10 @@ type FieldTypeZodMap = {
     Int: z.ZodNumber;
     BigInt: z.ZodBigInt;
     Float: z.ZodNumber;
-    Decimal: z.ZodType<Decimal>;
+    Decimal: typeof decimalSchema;
     Boolean: z.ZodBoolean;
     DateTime: z.ZodDate;
-    Bytes: z.ZodType<Uint8Array>;
+    Bytes: typeof bytesSchema;
     Json: JsonZodType;
 };
 

--- a/packages/zod/src/types.ts
+++ b/packages/zod/src/types.ts
@@ -17,8 +17,8 @@ import type {
     TypeDefFieldIsArray,
     TypeDefFieldIsOptional,
 } from '@zenstackhq/schema';
-import type z from 'zod';
 import type Decimal from 'decimal.js';
+import type z from 'zod';
 
 /**
  * Scalar-only shape returned by the no-options `makeModelSchema` overload.

--- a/packages/zod/src/types.ts
+++ b/packages/zod/src/types.ts
@@ -18,7 +18,7 @@ import type {
     TypeDefFieldIsOptional,
 } from '@zenstackhq/schema';
 import type z from 'zod';
-import type { decimalSchema, bytesSchema } from './utils';
+import type Decimal from 'decimal.js';
 
 /**
  * Scalar-only shape returned by the no-options `makeModelSchema` overload.
@@ -106,10 +106,10 @@ type FieldTypeZodMap = {
     Int: z.ZodNumber;
     BigInt: z.ZodBigInt;
     Float: z.ZodNumber;
-    Decimal: typeof decimalSchema;
+    Decimal: z.ZodType<Decimal, Decimal>;
     Boolean: z.ZodBoolean;
     DateTime: z.ZodDate;
-    Bytes: typeof bytesSchema;
+    Bytes: z.ZodType<Uint8Array, Uint8Array>;
     Json: JsonZodType;
 };
 

--- a/packages/zod/src/types.ts
+++ b/packages/zod/src/types.ts
@@ -108,7 +108,7 @@ type FieldTypeZodMap = {
     Float: z.ZodNumber;
     Decimal: z.ZodType<Decimal>;
     Boolean: z.ZodBoolean;
-    DateTime: z.ZodType<Date>;
+    DateTime: z.ZodDate;
     Bytes: z.ZodType<Uint8Array>;
     Json: JsonZodType;
 };

--- a/packages/zod/src/utils.ts
+++ b/packages/zod/src/utils.ts
@@ -12,9 +12,6 @@ import Decimal from 'decimal.js';
 import { z } from 'zod';
 import { SchemaFactoryError } from './error';
 
-export const decimalSchema = z.custom<Decimal>((val) => Decimal.isDecimal(val));
-export const bytesSchema = z.instanceof(Uint8Array) as z.ZodCustom<Uint8Array<ArrayBufferLike>, Uint8Array<ArrayBufferLike>>;
-
 function getArgValue<T extends string | number | boolean>(expr: Expression | undefined): T | undefined {
     if (!expr || !ExpressionUtils.isLiteral(expr)) {
         return undefined;

--- a/packages/zod/src/utils.ts
+++ b/packages/zod/src/utils.ts
@@ -13,7 +13,7 @@ import { z } from 'zod';
 import { SchemaFactoryError } from './error';
 
 export const decimalSchema = z.custom<Decimal>((val) => Decimal.isDecimal(val));
-export const bytesSchema = z.instanceof(Uint8Array);
+export const bytesSchema = z.instanceof(Uint8Array) as z.ZodCustom<Uint8Array<ArrayBufferLike>, Uint8Array<ArrayBufferLike>>;
 
 function getArgValue<T extends string | number | boolean>(expr: Expression | undefined): T | undefined {
     if (!expr || !ExpressionUtils.isLiteral(expr)) {

--- a/packages/zod/src/utils.ts
+++ b/packages/zod/src/utils.ts
@@ -12,6 +12,9 @@ import Decimal from 'decimal.js';
 import { z } from 'zod';
 import { SchemaFactoryError } from './error';
 
+export const decimalSchema = z.custom<Decimal>((val) => Decimal.isDecimal(val));
+export const bytesSchema = z.instanceof(Uint8Array);
+
 function getArgValue<T extends string | number | boolean>(expr: Expression | undefined): T | undefined {
     if (!expr || !ExpressionUtils.isLiteral(expr)) {
         return undefined;

--- a/packages/zod/test/factory.test.ts
+++ b/packages/zod/test/factory.test.ts
@@ -208,6 +208,12 @@ describe('SchemaFactory - makeModelSchema', () => {
             expect(userSchema.safeParse({ ...validUser, metadata: { key: BigInt(1) } }).success).toBe(false);
             expect(userSchema.safeParse({ ...validUser, metadata: [BigInt(1)] }).success).toBe(false);
         });
+
+        it('infers correct input types for DateTime fields', () => {
+            const _userSchema = factory.makeModelSchema('User');
+            type UserInput = z.input<typeof _userSchema>;
+            expectTypeOf<UserInput['birthdate']>().toEqualTypeOf<Date | null | undefined>();
+        });
     });
 
     describe('string validation attributes', () => {

--- a/packages/zod/test/factory.test.ts
+++ b/packages/zod/test/factory.test.ts
@@ -66,7 +66,7 @@ describe('SchemaFactory - makeModelSchema', () => {
             expectTypeOf<User['birthdate']>().toEqualTypeOf<Date | null | undefined>();
 
             // optional Bytes
-            expectTypeOf<User['avatar']>().toEqualTypeOf<Uint8Array<ArrayBuffer> | null | undefined>();
+            expectTypeOf<User['avatar']>().toEqualTypeOf<Uint8Array | null | undefined>();
 
             // optional Json
             expectTypeOf<User>().toHaveProperty('metadata');
@@ -214,7 +214,7 @@ describe('SchemaFactory - makeModelSchema', () => {
             type UserInput = z.input<typeof _userSchema>;
             expectTypeOf<UserInput['birthdate']>().toEqualTypeOf<Date | null | undefined>();
             expectTypeOf<UserInput['balance']>().toEqualTypeOf<Decimal>();
-            expectTypeOf<UserInput['avatar']>().toEqualTypeOf<Uint8Array<ArrayBuffer> | null | undefined>();
+            expectTypeOf<UserInput['avatar']>().toEqualTypeOf<Uint8Array | null | undefined>();
         });
     });
 

--- a/packages/zod/test/factory.test.ts
+++ b/packages/zod/test/factory.test.ts
@@ -66,7 +66,7 @@ describe('SchemaFactory - makeModelSchema', () => {
             expectTypeOf<User['birthdate']>().toEqualTypeOf<Date | null | undefined>();
 
             // optional Bytes
-            expectTypeOf<User['avatar']>().toEqualTypeOf<Uint8Array | null | undefined>();
+            expectTypeOf<User['avatar']>().toEqualTypeOf<Uint8Array<ArrayBuffer> | null | undefined>();
 
             // optional Json
             expectTypeOf<User>().toHaveProperty('metadata');
@@ -209,10 +209,12 @@ describe('SchemaFactory - makeModelSchema', () => {
             expect(userSchema.safeParse({ ...validUser, metadata: [BigInt(1)] }).success).toBe(false);
         });
 
-        it('infers correct input types for DateTime fields', () => {
+        it('infers correct input types for fields', () => {
             const _userSchema = factory.makeModelSchema('User');
             type UserInput = z.input<typeof _userSchema>;
             expectTypeOf<UserInput['birthdate']>().toEqualTypeOf<Date | null | undefined>();
+            expectTypeOf<UserInput['balance']>().toEqualTypeOf<Decimal>();
+            expectTypeOf<UserInput['avatar']>().toEqualTypeOf<Uint8Array<ArrayBuffer> | null | undefined>();
         });
     });
 


### PR DESCRIPTION
Closes #2673 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined scalar type mappings used for schema validation to improve type accuracy and consistency.

* **Tests**
  * Added type-level tests to verify correct input handling for date, binary, and numeric fields and ensure reliable validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->