### PR TITLE
chore(cli): mute telemetry without removing instrumentation

### DIFF
--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -1,8 +1,7 @@
-import { init, type Mixpanel } from 'mixpanel';
+import { type Mixpanel } from 'mixpanel';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import * as os from 'os';
-import { TELEMETRY_TRACKING_TOKEN } from './constants';
 import { isInCi } from './utils/is-ci';
 import { isInContainer } from './utils/is-container';
 import isDocker from './utils/is-docker';
@@ -44,11 +43,14 @@ export class Telemetry {
     private readonly isCi = isInCi;
 
     constructor() {
-        if (process.env['DO_NOT_TRACK'] !== '1' && TELEMETRY_TRACKING_TOKEN) {
-            this.mixpanel = init(TELEMETRY_TRACKING_TOKEN, {
-                geolocate: true,
-            });
-        }
+        // if (process.env['DO_NOT_TRACK'] !== '1' && TELEMETRY_TRACKING_TOKEN) {
+        //     this.mixpanel = init(TELEMETRY_TRACKING_TOKEN, {
+        //         geolocate: true,
+        //     });
+        // }
+
+        // Telemetry is currently muted
+        return;
     }
 
     get isTracking() {


### PR DESCRIPTION
## Summary

Mutes all CLI telemetry without deleting the telemetry code. The Mixpanel client is no longer initialized in the `Telemetry` constructor, so every `track()` call short-circuits on its `if (this.mixpanel)` guard and no events are sent.

## Changes

- `packages/cli/src/telemetry.ts`: early-return in the constructor before Mixpanel `init()`; the original init logic is preserved as a comment. Removed now-unused `init` / `TELEMETRY_TRACKING_TOKEN` imports.

## Why this is sufficient

- `this.mixpanel` stays `undefined`, so all events (`cli:*`, `cli:command:*`, `cli:plugin:*`, errors) no-op — no network requests to Mixpanel.
- `isTracking` returns `false`, so the exit-flush delay in `index.ts` is also skipped.

## Not removed

The full instrumentation pipeline (`trackSpan`, `trackCommand`, `trackCli`, payload assembly, all call sites) is intact. Re-enabling is just restoring the constructor body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled telemetry data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->