### PR TITLE
fix(language): forbid duplicate `@default` applications

### DIFF
--- a/packages/language/res/stdlib.zmodel
+++ b/packages/language/res/stdlib.zmodel
@@ -218,7 +218,7 @@ attribute @id(map: String?, length: Int?, sort: SortOrder?, clustered: Boolean?)
  * Defines a default value for a field.
  * @param value: An expression (e.g. 5, true, now(), auth()).
  */
-attribute @default(_ value: ContextType, map: String?) @@@prisma
+attribute @default(_ value: ContextType, map: String?) @@@prisma @@@once
 
 /**
  * Defines a unique constraint for this field.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Attributes**
  * The `@default` attribute is now restricted to single application per declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->