### PR TITLE
fix(server): omit relations to sliced-away models from OpenAPI spec

### DIFF
--- a/packages/server/src/api/rpc/openapi.ts
+++ b/packages/server/src/api/rpc/openapi.ts
@@ -9,6 +9,7 @@ import {
     DEFAULT_SPEC_VERSION,
     getIncludedModels,
     getMetaDescription,
+    isModelIncluded,
     isOperationIncluded,
     isProcedureIncluded,
     mayDenyAccess,
@@ -685,6 +686,10 @@ export class RPCApiSpecGenerator<Schema extends SchemaDef = SchemaDef> {
             if (fieldDef.omit) continue;
 
             if (fieldDef.relation) {
+                // Skip relations pointing to a model that's sliced away — otherwise we'd emit
+                // a dangling `$ref` to a schema that's not in the spec.
+                if (!isModelIncluded(fieldDef.type, this.queryOptions)) continue;
+
                 // Relation fields appear only with `include` — mark as optional.
                 // To-one optional relations are nullable (the ORM returns null when not found).
                 const refSchema: ReferenceObject = { $ref: `#/components/schemas/${fieldDef.type}` };

--- a/packages/server/src/api/rpc/openapi.ts
+++ b/packages/server/src/api/rpc/openapi.ts
@@ -486,6 +486,10 @@ export class RPCApiSpecGenerator<Schema extends SchemaDef = SchemaDef> {
 
         if (this.isBuiltinType(returnType)) {
             base = this.builtinTypeToJsonSchema(returnType as BuiltinType);
+        } else if (this.schema.models?.[returnType] && !isModelIncluded(returnType, this.queryOptions)) {
+            // Return type is a model that's sliced away — its entity schema isn't emitted,
+            // so reference it with a generic schema instead of a dangling `$ref`.
+            base = {};
         } else if (
             this.schema.enums?.[returnType] ||
             this.schema.models?.[returnType] ||

--- a/packages/server/test/openapi/rpc-openapi.test.ts
+++ b/packages/server/test/openapi/rpc-openapi.test.ts
@@ -878,6 +878,30 @@ mutation procedure softDelete(id: Int?): User
         expect(schemaKeys.some((k) => k.startsWith('createUser'))).toBe(true);
     });
 
+    it('procedure returning an excluded model does not emit a dangling ref', async () => {
+        const client = await createTestClient(procSchema);
+        const handler = new RPCApiHandler({
+            schema: client.$schema,
+            queryOptions: { slicing: { excludedModels: ['User'] as any } },
+        });
+        // `getUser`/`createUser`/`optionalSearch` all return `User`, which is excluded.
+        // `generateSpec` validates, so a dangling `$ref` to the absent `User` schema would fail.
+        const spec = await generateSpec(handler);
+
+        expect(spec.components?.schemas?.['User']).toBeUndefined();
+
+        // the procedures themselves are still exposed, but their result shape is generic
+        const dataSchema = (spec.paths?.['/$procs/getUser']?.get as any)?.responses?.['200']?.content?.[
+            'application/json'
+        ]?.schema?.properties?.data;
+        expect(dataSchema).toEqual({});
+
+        const listDataSchema = (spec.paths?.['/$procs/optionalSearch']?.get as any)?.responses?.['200']?.content?.[
+            'application/json'
+        ]?.schema?.properties?.data;
+        expect(listDataSchema).toEqual({ type: 'array', items: {} });
+    });
+
     it('slicing includedProcedures removes non-listed procedure args from components schemas', async () => {
         const client = await createTestClient(procSchema);
         const handler = new RPCApiHandler({

--- a/packages/server/test/openapi/rpc-openapi.test.ts
+++ b/packages/server/test/openapi/rpc-openapi.test.ts
@@ -596,6 +596,26 @@ describe('RPC OpenAPI spec generation - queryOptions slicing', () => {
         expect(spec.components?.schemas?.['User']).toBeDefined();
     });
 
+    it('drops relation fields pointing to excluded models from entity schemas', async () => {
+        const client = await createTestClient(schema);
+        const handler = new RPCApiHandler({
+            schema: client.$schema,
+            queryOptions: { slicing: { excludedModels: ['Post'] as any } },
+        });
+        // `generateSpec` also validates the document, so a dangling `$ref` to the
+        // excluded `Post` schema would fail here.
+        const spec = await generateSpec(handler);
+
+        // referencing models keep their other fields but lose relations to the excluded model
+        const userProps = (spec.components?.schemas?.['User'] as any)?.properties;
+        expect(userProps?.['email']).toBeDefined();
+        expect(userProps?.['posts']).toBeUndefined();
+
+        const commentProps = (spec.components?.schemas?.['Comment'] as any)?.properties;
+        expect(commentProps?.['content']).toBeDefined();
+        expect(commentProps?.['post']).toBeUndefined();
+    });
+
     it('includedModels removes excluded model entity schemas from components', async () => {
         const client = await createTestClient(schema);
         const handler = new RPCApiHandler({


### PR DESCRIPTION
## Summary

Fixes #2628.

When a model is excluded via `slicing.excludedModels` (or not in `includedModels`), the RPC OpenAPI generator still emitted a `$ref` for relation fields on *other* models that point to the excluded model. For example, with `Workspace` excluded, the `Link` entity schema still contained:

```json
"workspace": { "$ref": "#/components/schemas/Workspace" }
```

Since the `Workspace` schema is (correctly) not generated, this is a **dangling `$ref`** — it leaks the excluded model and makes the generated spec structurally invalid (it even fails OpenAPI validation).

## Fix

`RPCApiSpecGenerator.buildModelEntitySchema` now skips relation fields whose target model is not included by the slicing options, mirroring the guard the REST generator already applies in its relation-emitting paths.

Note: per the issue scope this addresses **relation inclusion** only; FK scalar fields (e.g. `workspaceId`) are intentionally left unchanged for now.

## Test

Added a test under `RPC OpenAPI spec generation - queryOptions slicing` that excludes `Post` and asserts the referencing `User`/`Comment` entity schemas keep their scalar fields but drop the `posts`/`post` relations. Because `generateSpec` validates the document, the previously dangling `$ref` made this fail before the fix. Verified red→green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OpenAPI spec generation to avoid invalid references when models are excluded. Relation fields targeting omitted models are skipped and procedure responses that would reference excluded models now emit safe generic response schemas.

* **Tests**
  * Added tests validating that excluded models are removed from entity schemas and that procedure responses fall back to generic shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->