### PR TITLE
fix(orm): forbid selecting @omit fields when allowQueryTimeOmitOverride is false

### DIFF
--- a/packages/orm/src/client/zod/factory.ts
+++ b/packages/orm/src/client/zod/factory.ts
@@ -1153,7 +1153,13 @@ export class ZodSchemaFactory<
                     fields[field] = this.makeRelationSelectIncludeSchema(model, field, options).optional();
                 }
             } else {
-                fields[field] = z.boolean().optional();
+                if (this.options.allowQueryTimeOmitOverride === false && this.isFieldOmittedByConfig(model, field)) {
+                    // when query-time omit override is disallowed, an omitted field cannot be
+                    // un-omitted by explicitly selecting it, so only allow `false`
+                    fields[field] = z.literal(false).optional();
+                } else {
+                    fields[field] = z.boolean().optional();
+                }
             }
         }
 
@@ -1259,6 +1265,24 @@ export class ZodSchemaFactory<
         const result = z.union([z.boolean(), objSchema]);
         this.registerSchema(`${model}${upperCaseFirst(field)}RelationInput`, result);
         return result;
+    }
+
+    /**
+     * Determines whether a field is configured to be omitted at the schema or client-options level
+     * (query-level omit is excluded as it's mutually exclusive with `select`).
+     */
+    private isFieldOmittedByConfig(model: string, field: string): boolean {
+        // options-level omit
+        const omitConfig =
+            (this.options.omit as Record<string, any> | undefined)?.[lowerCaseFirst(model)] ??
+            (this.options.omit as Record<string, any> | undefined)?.[model];
+        if (omitConfig && typeof omitConfig[field] === 'boolean') {
+            return omitConfig[field];
+        }
+
+        // schema-level omit
+        const fieldDef = requireField(this.schema, model, field);
+        return !!fieldDef.omit;
     }
 
     @cache()

--- a/tests/regression/test/issue-2671.test.ts
+++ b/tests/regression/test/issue-2671.test.ts
@@ -1,0 +1,59 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2671
+describe('Regression for issue 2671', () => {
+    const schema = `
+model User {
+    id           String @id @default(cuid())
+    email        String @unique
+    passwordHash String @omit
+}
+        `;
+
+    it('allows selecting omitted fields when override is allowed (default)', async () => {
+        const db = await createTestClient(schema);
+
+        await db.user.create({
+            data: { email: 'user1@test.com', passwordHash: 'secret-hash' },
+        });
+
+        // by default query-time override is allowed, so explicit select returns the field
+        const selected = await db.user.findFirst({
+            where: { email: 'user1@test.com' },
+            select: { passwordHash: true },
+        });
+        expect(selected?.passwordHash).toBe('secret-hash');
+    });
+
+    it('forbids selecting omitted fields when allowQueryTimeOmitOverride is false', async () => {
+        const base = await createTestClient(schema);
+        const db = base.$setOptions({ ...base.$options, allowQueryTimeOmitOverride: false });
+
+        await db.user.create({
+            data: { email: 'user1@test.com', passwordHash: 'secret-hash' },
+        });
+
+        // explicitly selecting the omitted field must be rejected
+        await expect(
+            db.user.findFirst({
+                where: { email: 'user1@test.com' },
+                select: { passwordHash: true },
+            }),
+        ).toBeRejectedByValidation();
+
+        // selecting non-omitted fields still works
+        const ok = await db.user.findFirst({
+            where: { email: 'user1@test.com' },
+            select: { email: true },
+        });
+        expect(ok).toEqual({ email: 'user1@test.com' });
+
+        // explicitly excluding the omitted field via select is fine
+        const excluded = await db.user.findFirst({
+            where: { email: 'user1@test.com' },
+            select: { email: true, passwordHash: false },
+        });
+        expect(excluded).toEqual({ email: 'user1@test.com' });
+    });
+});


### PR DESCRIPTION
## Problem

Fixes #2671.

Fields marked with `@omit` are excluded from default query results, but they could be leaked by explicitly selecting them via `select: { field: true }`. Setting `allowQueryTimeOmitOverride: false` was supposed to forbid un-omitting fields at query time, but it only guarded the `omit` clause — the `select`-based override path remained open.

```ts
// allowQueryTimeOmitOverride: false
await db.user.findFirst({ select: { passwordHash: true } });
// previously: { passwordHash: "$2a$12$..." }  ← leak
```

## Fix

`makeSelectSchema` now consults a new `isFieldOmittedByConfig` helper (checking options-level and schema-level omit; query-level is excluded as it's mutually exclusive with `select`). When `allowQueryTimeOmitOverride === false` and a field is omitted by config, its select schema only accepts `false` (`z.literal(false)`), so `select: { field: true }` is rejected by validation — consistent with how `omit: { field: false }` is already rejected. This applies recursively to nested relation selects.

Default behavior (`allowQueryTimeOmitOverride` unset/`true`) is unchanged: explicit select of an `@omit` field still returns it, by design.

## Tests

Added `tests/regression/test/issue-2671.test.ts`:
- default: explicit select of an `@omit` field returns it
- `allowQueryTimeOmitOverride: false`: `select: { passwordHash: true }` is rejected; selecting non-omitted fields and `select: { passwordHash: false }` still work

Existing `omit.test.ts` suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed field selection behavior for omitted fields when query-time omit override is disabled. Omitted fields now correctly reject selection attempts and enforce validation rules, while non-omitted fields remain accessible.

* **Tests**
  * Added regression test suite to verify field omission handling under different query-time override configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->