### PR TITLE
fix(orm): support _count nested inside an include

### DIFF
--- a/packages/orm/src/client/crud/dialects/lateral-join-dialect-base.ts
+++ b/packages/orm/src/client/crud/dialects/lateral-join-dialect-base.ts
@@ -301,9 +301,19 @@ export abstract class LateralJoinDialectBase<Schema extends SchemaDef> extends B
                 objArgs,
                 ...Object.entries<any>((payload as any).include)
                     .filter(([, value]) => value)
-                    .map(([field]) => ({
-                        [field]: eb.ref(`${parentResultName}$${field}.$data`),
-                    })),
+                    .map(([field, value]) => {
+                        if (field === '_count') {
+                            return {
+                                [field]: this.buildCountJson(
+                                    relationModel as GetModels<Schema>,
+                                    eb,
+                                    relationModelAlias,
+                                    value,
+                                ),
+                            };
+                        }
+                        return { [field]: eb.ref(`${parentResultName}$${field}.$data`) };
+                    }),
             );
         }
 

--- a/packages/orm/src/client/crud/dialects/sqlite.ts
+++ b/packages/orm/src/client/crud/dialects/sqlite.ts
@@ -317,6 +317,15 @@ export class SqliteCrudDialect<Schema extends SchemaDef> extends BaseCrudDialect
                     ...Object.entries<any>((payload as any).include)
                         .filter(([, value]) => value)
                         .map(([field, value]) => {
+                            if (field === '_count') {
+                                const subJson = this.buildCountJson(
+                                    relationModel,
+                                    eb,
+                                    tmpAlias(`${parentAlias}$${relationField}`),
+                                    value,
+                                );
+                                return [sql.lit(field), subJson];
+                            }
                             const subJson = this.buildRelationJSON(
                                 relationModel,
                                 eb,

--- a/tests/e2e/orm/client-api/find.test.ts
+++ b/tests/e2e/orm/client-api/find.test.ts
@@ -1189,6 +1189,57 @@ describe('Client find tests ', () => {
         expect(result3?._count.posts).toBe(1);
     });
 
+    it('supports _count nested inside an include', async () => {
+        // regression for https://github.com/zenstackhq/zenstack/issues/2669
+        const user = await createUser(client, 'u1@test.com');
+        const [post1] = await createPosts(client, user.id);
+        await client.comment.createMany({
+            data: [
+                { content: 'c1', postId: post1.id },
+                { content: 'c2', postId: post1.id },
+            ],
+        });
+
+        // _count nested inside a relation's `include` (not `select`)
+        const result = await client.user.findFirst({
+            include: {
+                posts: {
+                    include: {
+                        _count: { select: { comments: true } },
+                    },
+                },
+            },
+        });
+
+        expect(result?.posts).toHaveLength(2);
+        const p1 = result?.posts.find((p) => p.id === post1.id);
+        const p2 = result?.posts.find((p) => p.id !== post1.id);
+        expect(p1?._count).toEqual({ comments: 2 });
+        expect(p2?._count).toEqual({ comments: 0 });
+
+        // `_count: true` nested inside an include
+        const result2 = await client.user.findFirst({
+            include: {
+                posts: {
+                    include: { _count: true },
+                },
+            },
+        });
+        expect(result2?.posts.find((p) => p.id === post1.id)?._count).toEqual({ comments: 2 });
+
+        // _count nested inside an include, with a filter on the counted relation
+        const result3 = await client.user.findFirst({
+            include: {
+                posts: {
+                    include: {
+                        _count: { select: { comments: { where: { content: 'c1' } } } },
+                    },
+                },
+            },
+        });
+        expect(result3?.posts.find((p) => p.id === post1.id)?._count).toEqual({ comments: 1 });
+    });
+
     it('rejects orderBy array elements with multiple keys', async () => {
         await createUser(client, 'u1@test.com');
 

--- a/tests/regression/test/issue-2669.test.ts
+++ b/tests/regression/test/issue-2669.test.ts
@@ -1,0 +1,72 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2669
+describe.each([{ provider: 'sqlite' as const }, { provider: 'postgresql' as const }])(
+    'Regression for issue 2669 ($provider)',
+    ({ provider }) => {
+        const schema = `
+datasource db {
+    provider = '${provider}'
+    url = '${provider === 'sqlite' ? 'file:./dev.db' : '$DB_URL'}'
+}
+
+model User {
+    id    Int    @id @default(autoincrement())
+    email String @unique
+    posts Post[]
+}
+
+model Post {
+    id        Int       @id @default(autoincrement())
+    title     String
+    author    User      @relation(fields: [authorId], references: [id])
+    authorId  Int
+    comments  Comment[]
+}
+
+model Comment {
+    id      Int    @id @default(autoincrement())
+    content String
+    post    Post   @relation(fields: [postId], references: [id])
+    postId  Int
+}
+`;
+
+        it('supports _count inside a nested include', async () => {
+            const db = await createTestClient(schema, {
+                provider,
+            });
+
+            await db.user.create({
+                data: {
+                    email: 'user1@test.com',
+                    posts: {
+                        create: {
+                            title: 'Post1',
+                            comments: {
+                                create: [{ content: 'c1' }, { content: 'c2' }],
+                            },
+                        },
+                    },
+                },
+            });
+
+            const result = await db.user.findMany({
+                include: {
+                    posts: {
+                        include: {
+                            _count: {
+                                select: { comments: true },
+                            },
+                        },
+                    },
+                },
+            });
+
+            expect(result).toHaveLength(1);
+            expect(result[0]!.posts).toHaveLength(1);
+            expect(result[0]!.posts[0]!._count).toEqual({ comments: 2 });
+        });
+    },
+);


### PR DESCRIPTION
## Problem

Fixes #2669.

Using `_count` inside a **nested** relation's `include` throws at runtime:

```ts
await db.user.findMany({
  include: {
    posts: {
      include: {
        _count: { select: { comments: true } },
      },
    },
  },
});
```

- **SQLite:** `QueryError: Field "_count" not found in model "Post"`
- **Postgres/MySQL:** `missing FROM-clause entry for table "$$t3"`

This is valid Prisma syntax (verified against Prisma 6 — it returns `posts[].​_count.comments`), so it's a Prisma-compatibility gap.

## Root cause

The relation-JSON builder resolves a nested payload through two separate branches — one for `select` and one for `include`. The `select` branch already special-cased `_count` (calling `buildCountJson`), but the `include` branch did not:

- SQLite called `requireField(schema, 'Post', '_count')` → throws.
- Postgres/MySQL emitted a reference to a lateral join (`$$..._count.$data`) that `buildRelationJoins` never creates (it only joins real relation fields).

## Fix

Apply the same `_count` handling to the `include` branch in both dialects, calling `buildCountJson` with the relation's alias so the count subquery correlates correctly:

- `packages/orm/src/client/crud/dialects/sqlite.ts`
- `packages/orm/src/client/crud/dialects/lateral-join-dialect-base.ts`

## Why it wasn't caught

The e2e suite covered `_count` at the top level of `select`/`include` and `_count` nested inside a relation's **`select`** — all of which hit the (working) select path. No test nested `_count` inside an **`include`**, the one broken path.

## Tests

- Added `'supports _count nested inside an include'` to `tests/e2e/orm/client-api/find.test.ts`, covering `_count: { select: ... }`, `_count: true`, and `_count` with a `where` filter on the counted relation. Verified it fails against the un-fixed build with the exact issue error and passes with the fix.
- Added `tests/regression/test/issue-2669.test.ts` (SQLite + Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed aggregation count functionality when nested within relation queries.

* **Tests**
  * Added regression test for nested aggregation counts in relation queries across multiple database providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->