### PR TITLE
fix: pageParam in seInternalInfiniteQuery for Vue

### DIFF
--- a/packages/clients/tanstack-query/src/vue.ts
+++ b/packages/clients/tanstack-query/src/vue.ts
@@ -651,8 +651,8 @@ export function useInternalInfiniteQuery<TQueryFnData, TData, TPageParam = unkno
         const argsValue = toValue(args);
         return {
             queryKey: queryKey.value,
-            queryFn: ({ signal }: any) => {
-                const reqUrl = makeUrl(endpoint, model, operation, argsValue);
+            queryFn: ({ pageParam, signal }: any) => {
+                const reqUrl = makeUrl(endpoint, model, operation, pageParam ?? argsValue);
                 return fetcher<TQueryFnData>(reqUrl, { signal }, fetch);
             },
             initialPageParam: toValue(argsValue) as TPageParam,


### PR DESCRIPTION
Closes #2713

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed infinite-query pagination to correctly use the current page parameter when constructing requests, instead of reusing the initial request parameters for subsequent pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->