### PR TITLE
Add opt-in deep exact query argument checking

### DIFF
--- a/packages/orm/src/client/contract.ts
+++ b/packages/orm/src/client/contract.ts
@@ -529,7 +529,7 @@ type CommonModelOperations<
      * ```
      */
     findMany<T extends CrudArgsType<Schema, Model, 'findMany', Options, ExtQueryArgs, ExtResult>>(
-        args?: SelectSubset<T, CrudArgsType<Schema, Model, 'findMany', Options, ExtQueryArgs, ExtResult>>,
+        args?: SelectSubset<T, CrudArgsType<Schema, Model, 'findMany', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'findMany', T, Options, ExtResult>>;
 
     /**
@@ -539,7 +539,7 @@ type CommonModelOperations<
      * @see {@link findMany}
      */
     findUnique<T extends CrudArgsType<Schema, Model, 'findUnique', Options, ExtQueryArgs, ExtResult>>(
-        args: SelectSubset<T, CrudArgsType<Schema, Model, 'findUnique', Options, ExtQueryArgs, ExtResult>>,
+        args: SelectSubset<T, CrudArgsType<Schema, Model, 'findUnique', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'findUnique', T, Options, ExtResult>>;
 
     /**
@@ -549,7 +549,11 @@ type CommonModelOperations<
      * @see {@link findMany}
      */
     findUniqueOrThrow<T extends CrudArgsType<Schema, Model, 'findUniqueOrThrow', Options, ExtQueryArgs, ExtResult>>(
-        args: SelectSubset<T, CrudArgsType<Schema, Model, 'findUniqueOrThrow', Options, ExtQueryArgs, ExtResult>>,
+        args: SelectSubset<
+            T,
+            CrudArgsType<Schema, Model, 'findUniqueOrThrow', Options, ExtQueryArgs, ExtResult>,
+            Options
+        >,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'findUniqueOrThrow', T, Options, ExtResult>>;
 
     /**
@@ -559,7 +563,7 @@ type CommonModelOperations<
      * @see {@link findMany}
      */
     findFirst<T extends CrudArgsType<Schema, Model, 'findFirst', Options, ExtQueryArgs, ExtResult>>(
-        args?: SelectSubset<T, CrudArgsType<Schema, Model, 'findFirst', Options, ExtQueryArgs, ExtResult>>,
+        args?: SelectSubset<T, CrudArgsType<Schema, Model, 'findFirst', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'findFirst', T, Options, ExtResult>>;
 
     /**
@@ -569,7 +573,11 @@ type CommonModelOperations<
      * @see {@link findMany}
      */
     findFirstOrThrow<T extends CrudArgsType<Schema, Model, 'findFirstOrThrow', Options, ExtQueryArgs, ExtResult>>(
-        args?: SelectSubset<T, CrudArgsType<Schema, Model, 'findFirstOrThrow', Options, ExtQueryArgs, ExtResult>>,
+        args?: SelectSubset<
+            T,
+            CrudArgsType<Schema, Model, 'findFirstOrThrow', Options, ExtQueryArgs, ExtResult>,
+            Options
+        >,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'findFirstOrThrow', T, Options, ExtResult>>;
 
     /**
@@ -846,7 +854,7 @@ type CommonModelOperations<
      * ```
      */
     delete<T extends CrudArgsType<Schema, Model, 'delete', Options, ExtQueryArgs, ExtResult>>(
-        args: SelectSubset<T, CrudArgsType<Schema, Model, 'delete', Options, ExtQueryArgs, ExtResult>>,
+        args: SelectSubset<T, CrudArgsType<Schema, Model, 'delete', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'delete', T, Options, ExtResult>>;
 
     /**
@@ -869,7 +877,7 @@ type CommonModelOperations<
      * ```
      */
     deleteMany<T extends CrudArgsType<Schema, Model, 'deleteMany', Options, ExtQueryArgs, ExtResult>>(
-        args?: Subset<T, CrudArgsType<Schema, Model, 'deleteMany', Options, ExtQueryArgs, ExtResult>>,
+        args?: Subset<T, CrudArgsType<Schema, Model, 'deleteMany', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'deleteMany', T, Options, ExtResult>>;
 
     /**
@@ -891,7 +899,7 @@ type CommonModelOperations<
      * }); // result: `{ _all: number, email: number }`
      */
     count<T extends CrudArgsType<Schema, Model, 'count', Options, ExtQueryArgs, ExtResult>>(
-        args?: Subset<T, CrudArgsType<Schema, Model, 'count', Options, ExtQueryArgs, ExtResult>>,
+        args?: Subset<T, CrudArgsType<Schema, Model, 'count', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<Simplify<CrudReturnType<Schema, Model, 'count', T, Options, ExtResult>>>;
 
     /**
@@ -912,7 +920,7 @@ type CommonModelOperations<
      * }); // result: `{ _count: number, _avg: { age: number }, ... }`
      */
     aggregate<T extends CrudArgsType<Schema, Model, 'aggregate', Options, ExtQueryArgs, ExtResult>>(
-        args: Subset<T, CrudArgsType<Schema, Model, 'aggregate', Options, ExtQueryArgs, ExtResult>>,
+        args: Subset<T, CrudArgsType<Schema, Model, 'aggregate', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<Simplify<CrudReturnType<Schema, Model, 'aggregate', T, Options, ExtResult>>>;
 
     /**
@@ -949,7 +957,7 @@ type CommonModelOperations<
      * });
      */
     groupBy<T extends CrudArgsType<Schema, Model, 'groupBy', Options, ExtQueryArgs, ExtResult>>(
-        args: Subset<T, CrudArgsType<Schema, Model, 'groupBy', Options, ExtQueryArgs, ExtResult>>,
+        args: Subset<T, CrudArgsType<Schema, Model, 'groupBy', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<Simplify<CrudReturnType<Schema, Model, 'groupBy', T, Options, ExtResult>>>;
 
     /**
@@ -970,7 +978,7 @@ type CommonModelOperations<
      * }); // result: `boolean`
      */
     exists<T extends CrudArgsType<Schema, Model, 'exists', Options, ExtQueryArgs, ExtResult>>(
-        args?: Subset<T, CrudArgsType<Schema, Model, 'exists', Options, ExtQueryArgs, ExtResult>>,
+        args?: Subset<T, CrudArgsType<Schema, Model, 'exists', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'exists', T, Options, ExtResult>>;
 };
 

--- a/packages/orm/src/client/contract.ts
+++ b/packages/orm/src/client/contract.ts
@@ -393,7 +393,8 @@ export type AllModelOperations<
               >(
                   args?: SelectSubset<
                       T,
-                      CrudArgsType<Schema, Model, 'createManyAndReturn', Options, ExtQueryArgs, ExtResult>
+                      CrudArgsType<Schema, Model, 'createManyAndReturn', Options, ExtQueryArgs, ExtResult>,
+                      Options
                   >,
               ): ZenStackPromise<CrudReturnType<Schema, Model, 'createManyAndReturn', T, Options, ExtResult>>;
 
@@ -422,7 +423,11 @@ export type AllModelOperations<
               updateManyAndReturn<
                   T extends CrudArgsType<Schema, Model, 'updateManyAndReturn', Options, ExtQueryArgs, ExtResult>,
               >(
-                  args: Subset<T, CrudArgsType<Schema, Model, 'updateManyAndReturn', Options, ExtQueryArgs, ExtResult>>,
+                  args: Subset<
+                      T,
+                      CrudArgsType<Schema, Model, 'updateManyAndReturn', Options, ExtQueryArgs, ExtResult>,
+                      Options
+                  >,
               ): ZenStackPromise<CrudReturnType<Schema, Model, 'updateManyAndReturn', T, Options, ExtResult>>;
           });
 
@@ -620,7 +625,7 @@ type CommonModelOperations<
      * ```
      */
     create<T extends CrudArgsType<Schema, Model, 'create', Options, ExtQueryArgs, ExtResult>>(
-        args: SelectSubset<T, CrudArgsType<Schema, Model, 'create', Options, ExtQueryArgs, ExtResult>>,
+        args: SelectSubset<T, CrudArgsType<Schema, Model, 'create', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'create', T, Options, ExtResult>>;
 
     /**
@@ -649,7 +654,7 @@ type CommonModelOperations<
      * ```
      */
     createMany<T extends CrudArgsType<Schema, Model, 'createMany', Options, ExtQueryArgs, ExtResult>>(
-        args?: SelectSubset<T, CrudArgsType<Schema, Model, 'createMany', Options, ExtQueryArgs, ExtResult>>,
+        args?: SelectSubset<T, CrudArgsType<Schema, Model, 'createMany', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'createMany', T, Options, ExtResult>>;
 
     /**
@@ -770,7 +775,7 @@ type CommonModelOperations<
      * ```
      */
     update<T extends CrudArgsType<Schema, Model, 'update', Options, ExtQueryArgs, ExtResult>>(
-        args: SelectSubset<T, CrudArgsType<Schema, Model, 'update', Options, ExtQueryArgs, ExtResult>>,
+        args: SelectSubset<T, CrudArgsType<Schema, Model, 'update', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'update', T, Options, ExtResult>>;
 
     /**
@@ -794,7 +799,7 @@ type CommonModelOperations<
      * });
      */
     updateMany<T extends CrudArgsType<Schema, Model, 'updateMany', Options, ExtQueryArgs, ExtResult>>(
-        args: Subset<T, CrudArgsType<Schema, Model, 'updateMany', Options, ExtQueryArgs, ExtResult>>,
+        args: Subset<T, CrudArgsType<Schema, Model, 'updateMany', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'updateMany', T, Options, ExtResult>>;
 
     /**
@@ -818,7 +823,7 @@ type CommonModelOperations<
      * ```
      */
     upsert<T extends CrudArgsType<Schema, Model, 'upsert', Options, ExtQueryArgs, ExtResult>>(
-        args: SelectSubset<T, CrudArgsType<Schema, Model, 'upsert', Options, ExtQueryArgs, ExtResult>>,
+        args: SelectSubset<T, CrudArgsType<Schema, Model, 'upsert', Options, ExtQueryArgs, ExtResult>, Options>,
     ): ZenStackPromise<CrudReturnType<Schema, Model, 'upsert', T, Options, ExtResult>>;
 
     /**

--- a/packages/orm/src/client/crud-types.ts
+++ b/packages/orm/src/client/crud-types.ts
@@ -41,6 +41,7 @@ import type {
     MapBaseType,
     MaybePromise,
     NonEmptyArray,
+    NoExtraProperties,
     NullableIf,
     Optional,
     OrArray,
@@ -1311,17 +1312,22 @@ export type IncludeInput<
         : {}
     : {});
 
-export type Subset<T, U> = {
-    [key in keyof T]: key extends keyof U ? T[key] : never;
-};
+type StrictArgs<T, U, Options> = Options extends { typing: { exactQueryArgs: true } }
+    ? NoExtraProperties<T, U>
+    : unknown;
 
-export type SelectSubset<T, U> = {
+export type Subset<T, U, Options = {}> = {
     [key in keyof T]: key extends keyof U ? T[key] : never;
-} & (T extends { select: any; include: any }
-    ? 'Please either choose `select` or `include`.'
-    : T extends { select: any; omit: any }
-      ? 'Please either choose `select` or `omit`.'
-      : {});
+} & StrictArgs<T, U, Options>;
+
+export type SelectSubset<T, U, Options = {}> = {
+    [key in keyof T]: key extends keyof U ? T[key] : never;
+} & StrictArgs<T, U, Options> &
+    (T extends { select: any; include: any }
+        ? 'Please either choose `select` or `include`.'
+        : T extends { select: any; omit: any }
+          ? 'Please either choose `select` or `omit`.'
+          : {});
 
 type ToManyRelationFilter<
     in out Schema extends SchemaDef,
@@ -1453,7 +1459,11 @@ type OppositeRelationAndFK<
 
 //#region Find args
 
-type FilterArgs<in out Schema extends SchemaDef, in out Model extends GetModels<Schema>, in out Options extends QueryOptions<Schema>> = {
+type FilterArgs<
+    in out Schema extends SchemaDef,
+    in out Model extends GetModels<Schema>,
+    in out Options extends QueryOptions<Schema>,
+> = {
     /**
      * Filter conditions
      */

--- a/packages/orm/src/client/options.ts
+++ b/packages/orm/src/client/options.ts
@@ -140,6 +140,17 @@ type FieldSlicingOptions = {
  */
 export type QueryOptions<Schema extends SchemaDef> = {
     /**
+     * Type-checking options for query arguments.
+     */
+    typing?: {
+        /**
+         * Recursively rejects unknown properties in query arguments. This is opt-in because the
+         * additional precision requires more work from the TypeScript checker.
+         */
+        exactQueryArgs?: boolean;
+    };
+
+    /**
      * Options for omitting fields in ORM query results.
      */
     omit?: OmitConfig<Schema>;
@@ -158,7 +169,7 @@ export type QueryOptions<Schema extends SchemaDef> = {
 
 /**
  * Projects a (typically inferred) client options type down to only the members that influence
- * ORM typing - the {@link QueryOptions} fields (`omit`, `allowQueryTimeOmitOverride`, `slicing`).
+ * ORM typing - the {@link QueryOptions} fields (`typing`, `omit`, `allowQueryTimeOmitOverride`, `slicing`).
  *
  * The full options object inferred at `new ZenStackClient(...)` carries heavy function types for
  * `computedFields` and `procedures`. Those are never read by the model/operation types, but if the

--- a/packages/orm/src/utils/type-utils.ts
+++ b/packages/orm/src/utils/type-utils.ts
@@ -90,3 +90,32 @@ export type UnwrapTuplePromises<T extends readonly unknown[]> = {
 };
 
 export type Exact<T, Shape> = T extends Shape ? (Exclude<keyof T, keyof Shape> extends never ? T : never) : never;
+
+type _ExactLeaf = Date | Function | Decimal | Uint8Array;
+type _ObjectKeys<T> = T extends object ? keyof T : never;
+type _ObjectValue<T, K extends PropertyKey> = T extends object ? (K extends keyof T ? T[K] : never) : never;
+type _ArrayItem<T> = T extends readonly (infer Item)[] ? Item : never;
+
+type _NoExtraObject<T extends object, Shape, Keys extends PropertyKey = _ObjectKeys<Shape>> = [Keys] extends [never]
+    ? never
+    : string extends Keys
+      ? unknown
+      : {
+            [K in keyof T]: K extends Keys ? NoExtraProperties<T[K], _ObjectValue<Shape, K>> : never;
+        };
+
+/**
+ * Rejects unknown keys by walking only the finite inferred input. Expected unions are distributed
+ * only when looking up the current property, avoiding reconstruction of the input per union branch.
+ */
+export type NoExtraProperties<T, Shape> = unknown extends Shape
+    ? unknown
+    : T extends _ExactLeaf
+      ? unknown
+      : T extends readonly (infer Item)[]
+        ? [_ArrayItem<Shape>] extends [never]
+            ? never
+            : NoExtraProperties<Item, _ArrayItem<Shape>>[]
+        : T extends object
+          ? _NoExtraObject<T, Shape>
+          : unknown;

--- a/packages/orm/src/utils/type-utils.ts
+++ b/packages/orm/src/utils/type-utils.ts
@@ -96,13 +96,11 @@ type _ObjectKeys<T> = T extends object ? keyof T : never;
 type _ObjectValue<T, K extends PropertyKey> = T extends object ? (K extends keyof T ? T[K] : never) : never;
 type _ArrayItem<T> = T extends readonly (infer Item)[] ? Item : never;
 
-type _NoExtraObject<T extends object, Shape, Keys extends PropertyKey = _ObjectKeys<Shape>> = [Keys] extends [never]
-    ? never
-    : string extends Keys
-      ? unknown
-      : {
-            [K in keyof T]: K extends Keys ? NoExtraProperties<T[K], _ObjectValue<Shape, K>> : never;
-        };
+type _NoExtraObject<T extends object, Shape, Keys extends PropertyKey = _ObjectKeys<Shape>> = string extends Keys
+    ? unknown
+    : {
+          [K in keyof T]: K extends Keys ? NoExtraProperties<T[K], _ObjectValue<Shape, K>> : never;
+      };
 
 /**
  * Rejects unknown keys by walking only the finite inferred input. Expected unions are distributed

--- a/packages/orm/src/utils/type-utils.ts
+++ b/packages/orm/src/utils/type-utils.ts
@@ -91,7 +91,7 @@ export type UnwrapTuplePromises<T extends readonly unknown[]> = {
 
 export type Exact<T, Shape> = T extends Shape ? (Exclude<keyof T, keyof Shape> extends never ? T : never) : never;
 
-type _ExactLeaf = Date | Function | Decimal | Uint8Array;
+type _ExactLeaf = string | number | bigint | boolean | symbol | Date | Function | Decimal | Uint8Array;
 type _ObjectKeys<T> = T extends object ? keyof T : never;
 type _ObjectValue<T, K extends PropertyKey> = T extends object ? (K extends keyof T ? T[K] : never) : never;
 type _ArrayItem<T> = T extends readonly (infer Item)[] ? Item : never;
@@ -109,11 +109,11 @@ type _NoExtraObject<T extends object, Shape, Keys extends PropertyKey = _ObjectK
 export type NoExtraProperties<T, Shape> = unknown extends Shape
     ? unknown
     : T extends _ExactLeaf
-      ? unknown
+      ? T
       : T extends readonly (infer Item)[]
         ? [_ArrayItem<Shape>] extends [never]
             ? never
             : NoExtraProperties<Item, _ArrayItem<Shape>>[]
         : T extends object
           ? _NoExtraObject<T, Shape>
-          : unknown;
+          : T;

--- a/tests/e2e/orm/schemas/typing/typecheck.ts
+++ b/tests/e2e/orm/schemas/typing/typecheck.ts
@@ -17,6 +17,20 @@ const client = new ZenStackClient(schema, {
     },
 });
 
+const strictClient = new ZenStackClient(schema, {
+    dialect: new SqliteDialect({ database: new SQLite('./zenstack/test.db') }),
+    computedFields: {
+        user: {
+            postCount: (eb) =>
+                eb
+                    .selectFrom('Post')
+                    .whereRef('Post.authorId', '=', 'id')
+                    .select(({ fn }) => fn.countAll<number>().as('postCount')),
+        },
+    },
+    typing: { exactQueryArgs: true },
+});
+
 async function main() {
     await find();
     await create();
@@ -31,6 +45,60 @@ async function main() {
 }
 
 async function find() {
+    await client.user.findMany({
+        where: {
+            posts: {
+                some: {
+                    // @ts-expect-error unknown nested where field
+                    missingField: true,
+                },
+            },
+        },
+    });
+
+    await client.user.findMany({
+        select: {
+            posts: {
+                select: {
+                    // @ts-expect-error unknown deeply nested select field
+                    missingField: true,
+                },
+            },
+        },
+    });
+
+    await client.user.findMany({
+        include: {
+            posts: {
+                where: {
+                    // @ts-expect-error unknown where field nested in include
+                    missingField: true,
+                },
+            },
+        },
+    });
+
+    await client.user.findMany({
+        select: {
+            _count: {
+                select: {
+                    // @ts-expect-error unknown nested count field
+                    missingField: true,
+                },
+            },
+        },
+    });
+
+    const invalidArgs = {
+        where: {
+            posts: {
+                some: { missingField: true },
+            },
+        },
+    };
+    // @ts-expect-error hoisted arguments are recursively checked too
+    await client.user.findMany(invalidArgs);
+
     const user1 = await client.user.findFirst({
         where: {
             name: 'Alex',
@@ -223,6 +291,96 @@ async function find() {
 }
 
 async function create() {
+    // Exact nested argument checking stays opt-in for compatibility.
+    await client.user.create({
+        data: {
+            name: 'Alex',
+            email: 'alex@zenstack.dev',
+            profile: {
+                create: {
+                    age: 20,
+                    missingField: true,
+                },
+            },
+        },
+    });
+
+    await strictClient.user.create({
+        data: {
+            name: 'Alex',
+            email: 'alex@zenstack.dev',
+            profile: {
+                create: {
+                    age: 20,
+                    // @ts-expect-error unknown nested create field in exact mode
+                    missingField: true,
+                },
+            },
+        },
+    });
+
+    const invalidNestedCreateArgs = {
+        data: {
+            name: 'Alex',
+            email: 'alex@zenstack.dev',
+            profile: { create: { age: 20, missingField: true } },
+        },
+    };
+    // @ts-expect-error hoisted nested write arguments are checked in exact mode
+    await strictClient.user.create(invalidNestedCreateArgs);
+
+    const invalidNestedCreateArrayArgs = {
+        data: {
+            title: 'post',
+            content: 'content',
+            author: { connect: { id: 1 } },
+            tags: {
+                create: [{ name: 'valid' }, { name: 'invalid', missingField: true }],
+            },
+        },
+    };
+    // @ts-expect-error exactness recurses into array elements
+    await strictClient.post.create(invalidNestedCreateArrayArgs);
+
+    await strictClient.profile.create({
+        data: { age: 20, user: { connect: { id: 1 } } },
+    });
+
+    await strictClient.profile.create({
+        data: { age: 20, userId: 1 },
+    });
+
+    await strictClient.profile.create({
+        // @ts-expect-error checked and unchecked create branches cannot be mixed
+        data: {
+            age: 20,
+            userId: 1,
+            user: { connect: { id: 1 } },
+        },
+    });
+
+    await strictClient.user.create({
+        data: {
+            name: 'JSON user',
+            email: 'json@example.com',
+            createdAt: new Date(),
+            identity: { providers: [{ id: 'github', name: 'GitHub' }] },
+        },
+    });
+
+    await strictClient.profile.create({
+        data: {
+            age: 20,
+            user: {
+                connect: {
+                    id: 1,
+                    // @ts-expect-error unknown nested connect field
+                    missingField: true,
+                },
+            },
+        },
+    });
+
     await client.user.create({
         // @ts-expect-error email is required
         data: { name: 'Alex' },
@@ -372,7 +530,7 @@ async function create() {
             tags: { create: [{ name: 'tag2' }, { name: 'tag3' }] },
         },
     });
-    await client.tag.create({
+    await strictClient.tag.create({
         data: {
             name: 'tag4',
             posts: {
@@ -382,6 +540,8 @@ async function create() {
                         title: 'Hello World',
                         content: 'This is a test post',
                         author: { connect: { id: 1 } },
+                        // @ts-expect-error unknown nested connectOrCreate field
+                        missingField: true,
                     },
                 },
             },
@@ -406,7 +566,22 @@ async function update() {
         },
     });
 
-    await client.user.update({
+    const invalidMutationWhereArgs = {
+        where: { id: 1, missingField: true },
+        data: { name: 'Alex' },
+    };
+    // @ts-expect-error exact mode checks hoisted mutation where arguments
+    await strictClient.user.update(invalidMutationWhereArgs);
+
+    const invalidMutationSelectArgs = {
+        where: { id: 1 },
+        data: { name: 'Alex' },
+        select: { posts: { select: { missingField: true } } },
+    };
+    // @ts-expect-error exact mode checks hoisted mutation relation selects
+    await strictClient.user.update(invalidMutationSelectArgs);
+
+    await strictClient.user.update({
         where: { id: 1 },
         data: {
             posts: {
@@ -440,6 +615,8 @@ async function update() {
                     data: {
                         title: 'Hello World',
                         content: 'This is a test post',
+                        // @ts-expect-error unknown deeply nested update field
+                        missingField: true,
                     },
                 },
                 upsert: {
@@ -451,6 +628,8 @@ async function update() {
                     update: {
                         title: 'Hello World',
                         content: 'This is a test post',
+                        // @ts-expect-error unknown deeply nested upsert field
+                        missingField: true,
                     },
                 },
                 updateMany: {
@@ -462,6 +641,22 @@ async function update() {
                 },
             },
         },
+    });
+
+    await strictClient.user.upsert({
+        where: { id: 1 },
+        create: {
+            name: 'Alex',
+            email: 'alex@zenstack.dev',
+            profile: {
+                create: {
+                    age: 20,
+                    // @ts-expect-error unknown field in a top-level upsert create payload
+                    missingField: true,
+                },
+            },
+        },
+        update: { name: 'Alex' },
     });
 
     await client.user.update({

--- a/tests/e2e/orm/schemas/typing/typecheck.ts
+++ b/tests/e2e/orm/schemas/typing/typecheck.ts
@@ -1,4 +1,4 @@
-import { ZenStackClient } from '@zenstackhq/orm';
+import { ZenStackClient, type Subset } from '@zenstackhq/orm';
 import SQLite from 'better-sqlite3';
 import { SqliteDialect } from 'kysely';
 import { Role, Status, type Identity, type IdentityProvider } from './models';
@@ -912,6 +912,15 @@ function enums() {
 }
 
 function typeDefs() {
+    const emptyExactObject: Subset<{}, {}, { typing: { exactQueryArgs: true } }> = {};
+    console.log(emptyExactObject);
+
+    const invalidEmptyExactObject: Subset<{ extra: true }, {}, { typing: { exactQueryArgs: true } }> = {
+        // @ts-expect-error finite empty shapes still reject supplied properties
+        extra: true,
+    };
+    console.log(invalidEmptyExactObject);
+
     const identityProvider: IdentityProvider = {
         id: '123',
         name: 'GitHub',

--- a/tests/e2e/orm/schemas/typing/typecheck.ts
+++ b/tests/e2e/orm/schemas/typing/typecheck.ts
@@ -99,6 +99,25 @@ async function find() {
     // @ts-expect-error hoisted arguments are recursively checked too
     await client.user.findMany(invalidArgs);
 
+    const invalidExactReadArgs = {
+        where: {
+            posts: {
+                some: { title: 'post', missingField: true },
+            },
+        },
+        select: {
+            posts: {
+                where: { title: 'post', missingField: true },
+                orderBy: { title: 'asc' as const, missingField: 'asc' as const },
+                cursor: { id: 1, missingField: true },
+                select: { id: true, missingField: true },
+            },
+        },
+    };
+    await client.user.findMany(invalidExactReadArgs);
+    // @ts-expect-error exact mode recursively checks all supplied read arguments
+    await strictClient.user.findMany(invalidExactReadArgs);
+
     const user1 = await client.user.findFirst({
         where: {
             name: 'Alex',
@@ -752,6 +771,16 @@ async function update() {
 }
 
 async function del() {
+    const invalidDeleteArgs = { where: { id: 1, missingField: true }, select: { id: true } };
+    await client.user.delete(invalidDeleteArgs);
+    // @ts-expect-error exact mode checks delete arguments
+    await strictClient.user.delete(invalidDeleteArgs);
+
+    const invalidDeleteManyArgs = { where: { name: 'Alex', missingField: true } };
+    await client.user.deleteMany(invalidDeleteManyArgs);
+    // @ts-expect-error exact mode checks deleteMany arguments
+    await strictClient.user.deleteMany(invalidDeleteManyArgs);
+
     // @ts-expect-error where is required
     await client.user.delete({});
 
@@ -768,6 +797,16 @@ async function del() {
 }
 
 async function count() {
+    const invalidCountArgs = { where: { name: 'Alex', missingField: true } };
+    await client.user.count(invalidCountArgs);
+    // @ts-expect-error exact mode checks count arguments
+    await strictClient.user.count(invalidCountArgs);
+
+    const invalidExistsArgs = { where: { id: 1, missingField: true } };
+    await client.user.exists(invalidExistsArgs);
+    // @ts-expect-error exact mode checks exists arguments
+    await strictClient.user.exists(invalidExistsArgs);
+
     await client.user.count();
     await client.user.count({
         where: {
@@ -786,6 +825,11 @@ async function count() {
 }
 
 async function aggregate() {
+    const invalidAggregateArgs = { _avg: { age: true as const, missingField: true } };
+    await client.profile.aggregate(invalidAggregateArgs);
+    // @ts-expect-error exact mode checks aggregate arguments
+    await strictClient.profile.aggregate(invalidAggregateArgs);
+
     const r = await client.profile.aggregate({
         _count: true,
         _avg: { age: true },
@@ -812,6 +856,14 @@ async function aggregate() {
 }
 
 async function groupBy() {
+    const invalidGroupByArgs = {
+        by: 'regionCountry' as const,
+        _sum: { age: true as const, missingField: true },
+    };
+    await client.profile.groupBy(invalidGroupByArgs);
+    // @ts-expect-error exact mode checks groupBy arguments
+    await strictClient.profile.groupBy(invalidGroupByArgs);
+
     const r = await client.profile.groupBy({
         by: ['regionCountry', 'regionCity'],
         _count: true,

--- a/tests/e2e/orm/schemas/typing/typecheck.ts
+++ b/tests/e2e/orm/schemas/typing/typecheck.ts
@@ -118,6 +118,27 @@ async function find() {
     // @ts-expect-error exact mode recursively checks all supplied read arguments
     await strictClient.user.findMany(invalidExactReadArgs);
 
+    const optionalInvalidWhere: { posts: { some: { title: string; missingField: true } } } | undefined =
+        Math.random() > 0.5 ? { posts: { some: { title: 'post', missingField: true } } } : undefined;
+    await client.user.findMany({ where: optionalInvalidWhere });
+    // @ts-expect-error exact mode preserves checking across optional unions
+    await strictClient.user.findMany({ where: optionalInvalidWhere });
+
+    const nullableInvalidSelect: { posts: { select: { id: true; missingField: true } } } | null =
+        Math.random() > 0.5 ? { posts: { select: { id: true, missingField: true } } } : null;
+    await client.user.findMany({ select: nullableInvalidSelect });
+    // @ts-expect-error exact mode preserves checking across nullable unions
+    await strictClient.user.findMany({ select: nullableInvalidSelect });
+
+    type BrandedUserId = number & { readonly __brand: 'UserId' };
+    type BrandedEmail = string & { readonly __brand: 'Email' };
+    const brandedUserId = 1 as BrandedUserId;
+    const brandedEmail = 'alex@zenstack.dev' as BrandedEmail;
+    await client.user.findUnique({ where: { id: brandedUserId } });
+    await strictClient.user.findUnique({ where: { id: brandedUserId } });
+    await client.user.findUnique({ where: { email: brandedEmail } });
+    await strictClient.user.findUnique({ where: { email: brandedEmail } });
+
     const user1 = await client.user.findFirst({
         where: {
             name: 'Alex',


### PR DESCRIPTION
## Summary

Fixes #2719 by adding an opt-in exactness check for inferred query arguments:

```ts
const db = new ZenStackClient(schema, {
    // ...
    typing: { exactQueryArgs: true },
});
```

With the option enabled, unknown properties are rejected recursively in inline and hoisted arguments across read, create, update, delete, count, aggregate, groupBy, and exists operations. Covered structures include nested relations, arrays, `where`, `select`, `include`, `orderBy`, `cursor`, `connect`, `connectOrCreate`, and nested mutation branches.

## Design

`NoExtraProperties<T, Shape>` walks only the keys present in the argument inferred from user code. Expected input unions are consulted property by property, so the checker does not eagerly rebuild every possible schema branch. There is no arbitrary recursion-depth cap.

The check preserves property-local diagnostics and treats runtime leaf/open-value types such as `Date`, `Decimal`, `Uint8Array`, functions, and JSON-style open records appropriately. The empty finite-shape case also preserves a valid `{}` while continuing to reject supplied unknown keys.

The option remains disabled by default because the type-checking cost depends on schema and query complexity. There are no runtime client changes.

## Performance

Measured on Node 26.5 using the same final e2e corpus with exactness off and on. Values are medians of three isolated sequential runs per state.

| Compiler | Metric | Overhead |
| --- | --- | ---: |
| TypeScript 6.0.3 | Memory | +17,047K (+1.80%) |
| TypeScript 6.0.3 | Type instantiations | +31,921 (+1.34%) |
| TypeScript 6.0.3 | Check time | +0.53s (+10.19%) |
| TS7 native preview | Memory | +7,604K (+1.18%) |
| TS7 native preview | Type instantiations | +25,445 (+0.81%) |
| TS7 native preview | Allocations | +63,382 (+0.61%) |
| TS7 native preview | Check time | +0.215s (+27.42%) |

The relative TS7 timing increase is larger than the structural deltas, but the absolute median check-time increase is 0.215 seconds on this corpus. The cost is workload-dependent, which is why the feature remains opt-in.

## Validation

- `pnpm --filter @zenstackhq/orm build`
- `pnpm --filter e2e test:typecheck` (TypeScript 6.0.3)
- `pnpm exec tsgo -p tests/e2e/tsconfig.json --noEmit --pretty false` (TS7 native preview)
- `pnpm --filter @zenstackhq/orm lint`
- Prettier check on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in “exact query arguments” mode (`typing.exactQueryArgs`) for stricter TypeScript validation.
  * Query argument types now enforce exact shapes (rejecting extra/unknown fields), including deeply nested relation payloads.
  * Updated selection/subset typing to support an options parameter while preserving existing compile-time safeguards (e.g., `select` vs `include`/`omit`).

* **Tests**
  * Expanded type-level checks to confirm correct acceptance/rejection across read/write and aggregate/mutation operations in exact mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->