### PR TITLE
fix(policy): support `in` operator against enum list with native enums

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Run Claude Code Review
               id: claude-review
               if: ${{ !contains(github.event.pull_request.title, '[WIP]') }}
-              uses: anthropics/claude-code-action@beta
+              uses: anthropics/claude-code-action@v1
               with:
                   claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -37,7 +37,7 @@ jobs:
                   # model: "claude-opus-4-20250514"
 
                   # Direct prompt for automated review (no @claude mention needed)
-                  direct_prompt: |
+                  prompt: |
                       Please review this pull request and provide feedback on:
                       - Code quality and best practices
                       - Potential bugs or issues
@@ -46,24 +46,3 @@ jobs:
                       - Test coverage
 
                       Be constructive and helpful in your feedback.
-
-                  # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-                  # use_sticky_comment: true
-
-                  # Optional: Customize review based on file types
-                  # direct_prompt: |
-                  #   Review this PR focusing on:
-                  #   - For TypeScript files: Type safety and proper interface usage
-                  #   - For API endpoints: Security, input validation, and error handling
-                  #   - For React components: Performance, accessibility, and best practices
-                  #   - For tests: Coverage, edge cases, and test quality
-
-                  # Optional: Different prompts for different authors
-                  # direct_prompt: |
-                  #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
-                  #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-                  #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-
-                  # Optional: Add specific tools for running tests or linting
-                  # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-

--- a/packages/plugins/policy/src/expression-transformer.ts
+++ b/packages/plugins/policy/src/expression-transformer.ts
@@ -254,8 +254,14 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                     return BinaryOperationNode.create(left, OperatorNode.create('in'), right);
                 } else {
                     // array contains
+                    const leftFieldDef = this.getFieldDefFromFieldRef(normalizedLeft, context);
+                    const comparand =
+                        leftFieldDef && QueryUtils.isEnum(this.schema, leftFieldDef.type)
+                            ? // cast lhs otherwise dialect like pg can reject due to type mismatch
+                              this.dialect.castText(new ExpressionWrapper(left)).toOperationNode()
+                            : left;
                     return BinaryOperationNode.create(
-                        left,
+                        comparand,
                         OperatorNode.create('='),
                         FunctionNode.create('any', [right]),
                     );

--- a/tests/regression/test/issue-2669.test.ts
+++ b/tests/regression/test/issue-2669.test.ts
@@ -2,15 +2,8 @@ import { createTestClient } from '@zenstackhq/testtools';
 import { describe, expect, it } from 'vitest';
 
 // https://github.com/zenstackhq/zenstack/issues/2669
-describe.each([{ provider: 'sqlite' as const }, { provider: 'postgresql' as const }])(
-    'Regression for issue 2669 ($provider)',
-    ({ provider }) => {
-        const schema = `
-datasource db {
-    provider = '${provider}'
-    url = '${provider === 'sqlite' ? 'file:./dev.db' : '$DB_URL'}'
-}
-
+describe('Regression for issue 2669 ($provider)', () => {
+    const schema = `
 model User {
     id    Int    @id @default(autoincrement())
     email String @unique
@@ -33,40 +26,37 @@ model Comment {
 }
 `;
 
-        it('supports _count inside a nested include', async () => {
-            const db = await createTestClient(schema, {
-                provider,
-            });
+    it('supports _count inside a nested include', async () => {
+        const db = await createTestClient(schema);
 
-            await db.user.create({
-                data: {
-                    email: 'user1@test.com',
-                    posts: {
-                        create: {
-                            title: 'Post1',
-                            comments: {
-                                create: [{ content: 'c1' }, { content: 'c2' }],
-                            },
+        await db.user.create({
+            data: {
+                email: 'user1@test.com',
+                posts: {
+                    create: {
+                        title: 'Post1',
+                        comments: {
+                            create: [{ content: 'c1' }, { content: 'c2' }],
                         },
                     },
                 },
-            });
-
-            const result = await db.user.findMany({
-                include: {
-                    posts: {
-                        include: {
-                            _count: {
-                                select: { comments: true },
-                            },
-                        },
-                    },
-                },
-            });
-
-            expect(result).toHaveLength(1);
-            expect(result[0]!.posts).toHaveLength(1);
-            expect(result[0]!.posts[0]!._count).toEqual({ comments: 2 });
+            },
         });
-    },
-);
+
+        const result = await db.user.findMany({
+            include: {
+                posts: {
+                    include: {
+                        _count: {
+                            select: { comments: true },
+                        },
+                    },
+                },
+            },
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0]!.posts).toHaveLength(1);
+        expect(result[0]!.posts[0]!._count).toEqual({ comments: 2 });
+    });
+});

--- a/tests/regression/test/issue-2669.test.ts
+++ b/tests/regression/test/issue-2669.test.ts
@@ -2,7 +2,7 @@ import { createTestClient } from '@zenstackhq/testtools';
 import { describe, expect, it } from 'vitest';
 
 // https://github.com/zenstackhq/zenstack/issues/2669
-describe('Regression for issue 2669 ($provider)', () => {
+describe('Regression for issue 2669', () => {
     const schema = `
 model User {
     id    Int    @id @default(autoincrement())

--- a/tests/regression/test/issue-2718.test.ts
+++ b/tests/regression/test/issue-2718.test.ts
@@ -1,0 +1,73 @@
+import { createPolicyTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+describe('Regression for issue 2718', () => {
+    it('handles `in` operator against a list of enum values with native PostgreSQL enums', async () => {
+        const db = await createPolicyTestClient(
+            `
+enum State {
+    IN_PROGRESS
+    DONE
+    REVIEWED
+}
+
+model Post {
+    id    String @id @default(cuid())
+    title String
+    state State
+
+    @@allow('read,create', true)
+    // only allow deleting posts whose state is DONE or REVIEWED
+    @@deny('delete', !(state in [DONE, REVIEWED]))
+    @@allow('delete', true)
+}
+            `,
+            { usePrismaPush: true, provider: 'postgresql' },
+        );
+
+        await db.post.create({ data: { id: '1', title: 'p1', state: 'IN_PROGRESS' } });
+        await db.post.create({ data: { id: '2', title: 'p2', state: 'DONE' } });
+        await db.post.create({ data: { id: '3', title: 'p3', state: 'REVIEWED' } });
+
+        // IN_PROGRESS is not in [DONE, REVIEWED] -> delete denied
+        await expect(db.post.delete({ where: { id: '1' } })).toBeRejectedNotFound();
+
+        // DONE and REVIEWED are in the list -> delete allowed
+        await expect(db.post.delete({ where: { id: '2' } })).toResolveTruthy();
+        await expect(db.post.delete({ where: { id: '3' } })).toResolveTruthy();
+    });
+
+    it('handles `in` operator against a list of enum values with SQLite', async () => {
+        const db = await createPolicyTestClient(
+            `
+enum State {
+    IN_PROGRESS
+    DONE
+    REVIEWED
+}
+
+model Post {
+    id    String @id @default(cuid())
+    title String
+    state State
+
+    @@allow('create', true)
+    // only readable when state is DONE or REVIEWED
+    @@allow('read', state in [DONE, REVIEWED])
+}
+            `,
+        );
+
+        await db.$unuseAll().post.createMany({
+            data: [
+                { id: '1', title: 'p1', state: 'IN_PROGRESS' },
+                { id: '2', title: 'p2', state: 'DONE' },
+                { id: '3', title: 'p3', state: 'REVIEWED' },
+            ],
+        });
+
+        await expect(db.post.findMany()).resolves.toHaveLength(2);
+        await expect(db.post.findUnique({ where: { id: '1' } })).resolves.toBeNull();
+        await expect(db.post.findUnique({ where: { id: '2' } })).toResolveTruthy();
+    });
+});


### PR DESCRIPTION
## Problem

When an `in` policy expression compares a native enum column against a list of enum literals, e.g.:

```zmodel
enum State { IN_PROGRESS DONE REVIEWED }

model Post {
    state State
    @@deny('delete', !(state in [DONE, REVIEWED]))
}
```

the generated SQL is `"state" = any(cast(ARRAY[$1,$2] as text[]))`. The right-hand array is built with enum elements reduced to `text`, but the left-hand enum column kept its native enum type, so PostgreSQL rejected the comparison:

```
42883 — operator does not exist: "State" = text
```

The `==` operator was unaffected because it routes through `buildComparison`, which already reconciles enum type compatibility. (Workaround in the issue was rewriting `in [DONE, REVIEWED]` as `state == DONE || state == REVIEWED`.)

## Fix

In the `in`/array-contains branch of the expression transformer, cast the left operand to text via `dialect.castText` when it is a native enum column, so it matches the `text[]` array. Non-enum fields and databases without native enum types (SQLite/MySQL) are unaffected.

## Tests

Added `tests/regression/test/issue-2718.test.ts`:
- **PostgreSQL** — reproduces the exact failure with a `@@deny('delete', ...)` rule (fails before the fix, passes after).
- **SQLite** — `@@allow('read', state in [DONE, REVIEWED])` to guard the non-native-enum path.

Existing policy e2e tests (incl. `supports in with field`, `collection-predicate`, `isempty-function-pg`) pass, and `tsc --noEmit` on the policy package is clean.

Fixes #2718

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `in` operator handling when comparing enum fields against inline lists, ensuring consistent policy behavior across supported database engines.

* **Tests**
  * Added regression coverage for the `in` + enum inline-list scenario, verifying expected allow/deny and null-read behavior on both PostgreSQL and SQLite.
  * Refreshed an existing regression test to simplify execution setup while keeping the original assertions intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->