### PR TITLE
fix(language): detect @@@onceInModel duplicates across inheritance

### DIFF
--- a/packages/language/src/validators/attribute-application-validator.ts
+++ b/packages/language/src/validators/attribute-application-validator.ts
@@ -26,7 +26,6 @@ import {
 } from '../generated/ast';
 import {
     getAllAttributes,
-    getAllFields,
     getAttributeArg,
     getContainingDataModel,
     getDataSourceProvider,
@@ -82,7 +81,6 @@ export default class AttributeApplicationValidator implements AstValidator<Attri
 
         this.checkDeprecation(attr, accept);
         this.checkDuplicatedAttributes(attr, accept, contextDataModel);
-        this.checkOnceInModel(attr, accept);
 
         const filledParams = new Set<AttributeParam>();
 
@@ -162,31 +160,6 @@ export default class AttributeApplicationValidator implements AstValidator<Attri
         const duplicates = allAttributes.filter((a) => a.decl.ref === attrDecl && a !== attr);
         if (duplicates.length > 0) {
             accept('error', `Attribute "${attrDecl.name}" can only be applied once`, { node: attr });
-        }
-    }
-
-    private checkOnceInModel(attr: AttributeApplication, accept: ValidationAcceptor) {
-        const attrDecl = attr.decl.ref;
-        if (!attrDecl?.attributes.some((a) => a.decl.ref?.name === '@@@onceInModel')) {
-            return;
-        }
-
-        // only meaningful for field-level attributes within a data model
-        const field = attr.$container;
-        if (!isDataField(field)) {
-            return;
-        }
-        const dataModel = getContainingDataModel(attr);
-        if (!dataModel) {
-            return;
-        }
-
-        // count distinct fields (including inherited) carrying this attribute
-        const fieldsWithAttr = getAllFields(dataModel).filter((f) =>
-            f.attributes.some((a) => a.decl.ref === attrDecl),
-        );
-        if (fieldsWithAttr.length > 1) {
-            accept('error', `Attribute "${attrDecl.name}" can only be applied to one field per model`, { node: attr });
         }
     }
 

--- a/packages/language/src/validators/datamodel-validator.ts
+++ b/packages/language/src/validators/datamodel-validator.ts
@@ -3,7 +3,9 @@ import { AstUtils, type AstNode, type DiagnosticInfo, type ValidationAcceptor } 
 import { IssueCodes, SCALAR_TYPES } from '../constants';
 import {
     ArrayExpr,
+    Attribute,
     DataField,
+    DataFieldAttribute,
     DataModel,
     DataModelAttribute,
     ReferenceExpr,
@@ -38,6 +40,7 @@ export default class DataModelValidator implements AstValidator<DataModel> {
         validateDuplicatedDeclarations(dm, getAllFields(dm), accept);
         this.validateAttributes(dm, accept);
         this.validateFields(dm, accept);
+        this.validateOnceInModelAttributes(dm, accept);
         if (dm.mixins.length > 0) {
             this.validateMixins(dm, accept);
         }
@@ -141,6 +144,40 @@ export default class DataModelValidator implements AstValidator<DataModel> {
 
     private validateAttributes(dm: DataModel, accept: ValidationAcceptor) {
         getAllAttributes(dm).forEach((attr) => validateAttributeApplication(attr, accept, dm));
+    }
+
+    // Validates field-level attributes marked with `@@@onceInModel`, which may be applied to at
+    // most one field per model (including fields inherited from base models and mixins). This must
+    // run at the model level so that duplicates which only co-occur through inheritance are detected
+    // — per-field validation only sees the model that physically declares each field.
+    private validateOnceInModelAttributes(dm: DataModel, accept: ValidationAcceptor) {
+        // group field attributes carrying `@@@onceInModel` by their attribute declaration
+        const occurrences = new Map<Attribute, DataFieldAttribute[]>();
+        for (const field of getAllFields(dm)) {
+            for (const attr of field.attributes) {
+                const decl = attr.decl.ref;
+                if (decl && hasAttribute(decl, '@@@onceInModel')) {
+                    const list = occurrences.get(decl) ?? [];
+                    list.push(attr);
+                    occurrences.set(decl, list);
+                }
+            }
+        }
+
+        for (const [decl, attrs] of occurrences) {
+            if (attrs.length <= 1) {
+                continue;
+            }
+            const message = `Attribute "${decl.name}" can only be applied to one field per model`;
+            // prefer reporting on offending attributes declared on this model's own fields; if all
+            // offending fields are inherited, report on the model declaration itself
+            const local = attrs.filter((attr) => dm.fields.includes(attr.$container as DataField));
+            if (local.length > 0) {
+                local.forEach((attr) => accept('error', message, { node: attr }));
+            } else {
+                accept('error', message, { node: dm });
+            }
+        }
     }
 
     private parseRelation(field: DataField, accept?: ValidationAcceptor) {

--- a/packages/language/test/attribute-application.test.ts
+++ b/packages/language/test/attribute-application.test.ts
@@ -558,6 +558,34 @@ describe('Attribute application validation tests', () => {
                 /Attribute "@softDelete" can only be applied to one field per model/,
             );
         });
+
+        // Duplicates that only co-occur through inheritance (none declared on the leaf model itself)
+        // are detected at the model level via `getAllFields`.
+        it('rejects when the attribute arrives only through inheritance (two mixins)', async () => {
+            await loadSchemaWithError(
+                `
+                datasource db {
+                    provider = 'sqlite'
+                    url      = 'file:./dev.db'
+                }
+
+                attribute @softDelete() @@@targetField([DateTimeField]) @@@onceInModel
+
+                type Base1 {
+                    deletedAt DateTime? @softDelete
+                }
+
+                type Base2 {
+                    removedAt DateTime? @softDelete
+                }
+
+                model Foo with Base1 Base2 {
+                    id Int @id @default(autoincrement())
+                }
+                `,
+                /Attribute "@softDelete" can only be applied to one field per model/,
+            );
+        });
     });
 
     it('requires relation and fk to have consistent optionality', async () => {


### PR DESCRIPTION
## Problem

Field-level attributes marked with `@@@onceInModel` (e.g. `@deletedAt` from the soft-delete plugin) may be applied to at most one field per model, **including inherited fields**. The check ran per-attribute against the model that physically declares each field, so duplicates that only co-occur in a *derived* model slipped through.

Specifically uncaught: when every field carrying the attribute is inherited from a **separate** mixin/base (none declared on the leaf model itself). The locally-declared and mixed (one local + one inherited) cases were already caught.

```zmodel
attribute @softDelete() @@@targetField([DateTimeField]) @@@onceInModel
type Base1 { deletedAt DateTime? @softDelete }
type Base2 { removedAt DateTime? @softDelete }
model Foo with Base1 Base2 {   // two @softDelete fields, both inherited -> previously NOT flagged
    id Int @id @default(autoincrement())
}
```

## Fix

Move the check to the model level (`DataModelValidator`), where `getAllFields(dm)` already exposes the full inherited field set. Field attributes are grouped by their `@@@onceInModel`-marked declaration; any group with more than one occurrence is an error. Errors report on the offending **local** field attributes when present (preserving the per-field diagnostic), falling back to the **model declaration** when all duplicates are inherited.

The old per-attribute `checkOnceInModel` (and its now-unused import) is removed.

## Tests

- New regression test in `attribute-application.test.ts` for the inheritance-only (two-mixin) case, alongside the existing local-only and mixed cases.
- Language suite: 84 passed. Soft-delete plugin suite (the real consumer): 15 passed, no regressions. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Validation & Constraint Enforcement**
  * Improved `@@onceInModel` attribute validation to properly handle inherited fields and mixins within models, ensuring the "only one field per model" constraint is enforced across the entire model hierarchy.

* **Tests**
  * Added validation test case for `@@onceInModel` attribute behavior with inherited field scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->