### PR TITLE
perf(orm): memoize implicit m2m join-table and model lookups (#2715)

### DIFF
--- a/packages/orm/src/client/query-utils.ts
+++ b/packages/orm/src/client/query-utils.ts
@@ -20,8 +20,38 @@ export function hasModel(schema: SchemaDef, model: string) {
         .includes(model.toLowerCase());
 }
 
+/**
+ * Structural lookups derived purely from the (immutable) schema. The schema does not
+ * change for a client's lifetime, so these results are memoized per-schema and shared
+ * across every consumer (orm query building + plugins). Keyed by the schema object so
+ * the cache dies with the schema and never leaks across schemas. See issue #2715.
+ */
+interface SchemaLookupCache {
+    model: Map<string, ModelDef | undefined>;
+    m2mRelation: Map<string, ReturnType<typeof computeManyToManyRelation>>;
+    m2mJoinTable?: Map<string, ManyToManyJoinTableEndpoints | undefined>;
+}
+
+const schemaLookupCache = new WeakMap<SchemaDef, SchemaLookupCache>();
+
+function getSchemaLookupCache(schema: SchemaDef): SchemaLookupCache {
+    let cache = schemaLookupCache.get(schema);
+    if (!cache) {
+        cache = { model: new Map(), m2mRelation: new Map() };
+        schemaLookupCache.set(schema, cache);
+    }
+    return cache;
+}
+
 export function getModel(schema: SchemaDef, model: string) {
-    return Object.values(schema.models).find((m) => m.name.toLowerCase() === model.toLowerCase());
+    const cache = getSchemaLookupCache(schema);
+    const key = model.toLowerCase();
+    if (cache.model.has(key)) {
+        return cache.model.get(key);
+    }
+    const result = Object.values(schema.models).find((m) => m.name.toLowerCase() === key);
+    cache.model.set(key, result);
+    return result;
 }
 
 export function getTypeDef(schema: SchemaDef, type: string) {
@@ -260,6 +290,58 @@ export function makeDefaultOrderBy(schema: SchemaDef, model: string) {
 }
 
 export function getManyToManyRelation(schema: SchemaDef, model: string, field: string) {
+    const cache = getSchemaLookupCache(schema);
+    const key = `${model} ${field}`;
+    if (cache.m2mRelation.has(key)) {
+        return cache.m2mRelation.get(key);
+    }
+    const result = computeManyToManyRelation(schema, model, field);
+    cache.m2mRelation.set(key, result);
+    return result;
+}
+
+/**
+ * Endpoints of an implicit many-to-many relation, identified by its join table name.
+ */
+export interface ManyToManyJoinTableEndpoints {
+    model: string;
+    field: string;
+    otherModel: string;
+    otherField: string;
+}
+
+/**
+ * Resolve the relation endpoints for an implicit many-to-many join table by its table
+ * name, or `undefined` if the table is not an implicit m2m join table. The join-table
+ * index is built once per schema (single pass) and reused, making this an O(1) lookup.
+ * See issue #2715.
+ */
+export function getManyToManyJoinTable(
+    schema: SchemaDef,
+    joinTableName: string,
+): ManyToManyJoinTableEndpoints | undefined {
+    const cache = getSchemaLookupCache(schema);
+    if (!cache.m2mJoinTable) {
+        const map = new Map<string, ManyToManyJoinTableEndpoints>();
+        for (const model of Object.values(schema.models)) {
+            for (const field of Object.values(model.fields)) {
+                const m2m = getManyToManyRelation(schema, model.name, field.name);
+                if (m2m?.joinTable && !map.has(m2m.joinTable)) {
+                    map.set(m2m.joinTable, {
+                        model: model.name,
+                        field: field.name,
+                        otherModel: m2m.otherModel,
+                        otherField: m2m.otherField,
+                    });
+                }
+            }
+        }
+        cache.m2mJoinTable = map;
+    }
+    return cache.m2mJoinTable.get(joinTableName);
+}
+
+function computeManyToManyRelation(schema: SchemaDef, model: string, field: string) {
     const fieldDef = requireField(schema, model, field);
     if (!fieldDef.array || !fieldDef.relation?.opposite) {
         return undefined;

--- a/packages/plugins/policy/src/policy-handler.ts
+++ b/packages/plugins/policy/src/policy-handler.ts
@@ -1290,40 +1290,39 @@ export class PolicyHandler<Schema extends SchemaDef> extends OperationNodeTransf
     }
 
     private resolveManyToManyJoinTable(tableName: string) {
-        for (const model of Object.values(this.client.$schema.models)) {
-            for (const field of Object.values(model.fields)) {
-                const m2m = QueryUtils.getManyToManyRelation(this.client.$schema, model.name, field.name);
-                if (m2m?.joinTable === tableName) {
-                    const sortedRecord = [
-                        {
-                            model: model.name,
-                            field: field.name,
-                        },
-                        {
-                            model: m2m.otherModel,
-                            field: m2m.otherField,
-                        },
-                    ].sort(this.manyToManySorter);
-
-                    const firstIdFields = QueryUtils.requireIdFields(this.client.$schema, sortedRecord[0]!.model);
-                    const secondIdFields = QueryUtils.requireIdFields(this.client.$schema, sortedRecord[1]!.model);
-                    invariant(
-                        firstIdFields.length === 1 && secondIdFields.length === 1,
-                        'only single-field id is supported for implicit many-to-many join table',
-                    );
-
-                    return {
-                        firstModel: sortedRecord[0]!.model,
-                        firstField: sortedRecord[0]!.field,
-                        firstIdField: firstIdFields[0]!,
-                        secondModel: sortedRecord[1]!.model,
-                        secondField: sortedRecord[1]!.field,
-                        secondIdField: secondIdFields[0]!,
-                    };
-                }
-            }
+        // O(1) lookup backed by a per-schema index (built once); previously this scanned
+        // the entire schema on every call for every table. See issue #2715.
+        const endpoints = QueryUtils.getManyToManyJoinTable(this.client.$schema, tableName);
+        if (!endpoints) {
+            return undefined;
         }
-        return undefined;
+
+        const sortedRecord = [
+            {
+                model: endpoints.model,
+                field: endpoints.field,
+            },
+            {
+                model: endpoints.otherModel,
+                field: endpoints.otherField,
+            },
+        ].sort(this.manyToManySorter);
+
+        const firstIdFields = QueryUtils.requireIdFields(this.client.$schema, sortedRecord[0]!.model);
+        const secondIdFields = QueryUtils.requireIdFields(this.client.$schema, sortedRecord[1]!.model);
+        invariant(
+            firstIdFields.length === 1 && secondIdFields.length === 1,
+            'only single-field id is supported for implicit many-to-many join table',
+        );
+
+        return {
+            firstModel: sortedRecord[0]!.model,
+            firstField: sortedRecord[0]!.field,
+            firstIdField: firstIdFields[0]!,
+            secondModel: sortedRecord[1]!.model,
+            secondField: sortedRecord[1]!.field,
+            secondIdField: secondIdFields[0]!,
+        };
     }
 
     private manyToManySorter(a: { model: string; field: string }, b: { model: string; field: string }): number {

--- a/tests/regression/test/issue-2715.test.ts
+++ b/tests/regression/test/issue-2715.test.ts
@@ -1,0 +1,74 @@
+import { QueryUtils } from '@zenstackhq/orm';
+import { createPolicyTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2715
+// Resolving an implicit many-to-many join table is a pure function of (schema, tableName),
+// but it used to re-scan the entire schema on every call, for every table in every query.
+// The resolution is now memoized per (immutable) schema. These tests guard that the
+// memoization holds (so the per-query full-schema scan cannot silently regress) and that
+// the resolved endpoints are correct across the shapes implicit m2m relations can take:
+// plain two-model, self-relation, explicit @relation name, and multiple relations at once.
+describe('Regression for issue #2715', () => {
+    it('resolves implicit m2m join tables correctly and caches each per schema', async () => {
+        const db = await createPolicyTestClient(
+            `
+model User {
+    id     Int     @id @default(autoincrement())
+    groups Group[]
+    @@allow('all', true)
+}
+
+model Group {
+    id    Int    @id @default(autoincrement())
+    users User[]
+    @@allow('all', true)
+}
+
+// self-relation m2m with an explicit join-table name
+model Person {
+    id        Int      @id @default(autoincrement())
+    following Person[] @relation('follows')
+    followers Person[] @relation('follows')
+    @@allow('all', true)
+}
+            `,
+        );
+
+        const schema = db.$schema;
+
+        // plain two-model m2m: join table follows Prisma's `_<A>To<B>` (sorted) convention,
+        // endpoints come from the first declared side (User.groups), other side is Group.users
+        const groupToUser = QueryUtils.getManyToManyJoinTable(schema, '_GroupToUser');
+        expect(groupToUser).toEqual({
+            model: 'User',
+            field: 'groups',
+            otherModel: 'Group',
+            otherField: 'users',
+        });
+
+        // self-relation m2m with explicit name: join table is `_<name>`, both endpoints are
+        // the same model, fields are the two relation fields (first declared side first)
+        const follows = QueryUtils.getManyToManyJoinTable(schema, '_follows');
+        expect(follows).toEqual({
+            model: 'Person',
+            field: 'following',
+            otherModel: 'Person',
+            otherField: 'followers',
+        });
+
+        // memoized: repeated resolution returns the SAME object reference (the index is built
+        // once and reused). An un-memoized re-scan would construct a fresh descriptor each call,
+        // so these `toBe`s are what fail if the per-query scan regresses.
+        expect(QueryUtils.getManyToManyJoinTable(schema, '_GroupToUser')).toBe(groupToUser);
+        expect(QueryUtils.getManyToManyJoinTable(schema, '_follows')).toBe(follows);
+
+        // distinct relations are cached independently (no cross-contamination)
+        expect(groupToUser).not.toBe(follows);
+
+        // non-m2m table names and unknown tables resolve to undefined (negative results are
+        // part of the cached index, not an uncached miss)
+        expect(QueryUtils.getManyToManyJoinTable(schema, 'User')).toBeUndefined();
+        expect(QueryUtils.getManyToManyJoinTable(schema, '_DoesNotExist')).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Fixes #2715.

## Summary

`PolicyHandler.resolveManyToManyJoinTable(tableName)` performed an `O(models × fields)` scan of the **entire schema on every call** — and it's called once per table per (sub)query while building policy filters (plus on the mutation/validation path). For a regular non-m2m table the scan runs to completion and returns `undefined`, so every query pays a full schema scan per referenced table. On a CPU profile of a deep, policy-filtered read this (`getModelPolicyFilterForManyToManyJoinTable`) was ~29% self-time, with `getModel` (16%) close behind; the database itself was 0.3%.

The resolution is a pure function of `(schema, tableName)`, and the schema is immutable for a client's lifetime. This PR memoizes it.

## What changed

Rather than caching inside the policy plugin, the structural lookups are memoized once in `@zenstackhq/orm`'s `QueryUtils`, keyed by the immutable schema, so **every consumer** (ORM query building + all plugins) shares them:

- `query-utils.ts`: a `WeakMap<SchemaDef, …>` index memoizing `getModel` and `getManyToManyRelation`, plus a new O(1) `getManyToManyJoinTable(schema, tableName)` that builds a `Map<joinTable, endpoints>` in a single pass on first use.
- `policy-handler.ts`: `resolveManyToManyJoinTable` is now a thin O(1) lookup into that index (the per-call scan is gone). The descriptor it returns is unchanged.

Typed throughout (no `any`/`as`).

## Why it's access-control-safe

`resolveManyToManyJoinTable` reads only `schema.models` + the table name and returns a **structural** descriptor (`{firstModel, firstField, firstIdField, …}`). It takes no `$auth`/per-request state and mutates nothing. The **per-user policy filter is still built fresh, per call, downstream** in `getModelPolicyFilterForManyToManyJoinTable` from that descriptor + `auth()`. So the cache cannot change any access-control outcome — it only skips recomputing a deterministic lookup.

What this deliberately does **not** cache (to stay forward-compatible):
- the compiled policy filter node — left per-call, so the newly-created-side skip from #2531 and future field-level relation policies (#856, #2382) keep working;
- anything `auth()`/value-dependent.

The `WeakMap` is keyed by the schema object, so the cache dies with the schema (no leak, no cross-schema collision), and the negative (`undefined`) result is cached too — which matters because non-m2m tables are the dominant call pattern.

## Benchmarks

Deep, policy-filtered read on a ~114-model schema (Bun 1.3.2 / JavaScriptCore; medians). Bun is the worst case for this JS-bound path; Node/V8 shows the same ranking at ~¼ the magnitude.

| scenario | before | after | Δ |
|---|--:|--:|--:|
| warm deep read (reused client) | 92.7 ms | 10.5 ms | −89% |
| cold deep read (chain rebuilt per call) | 136.8 ms | 31.6 ms | −77% |
| warm PK lookup | 6.9 ms | 0.65 ms | −91% |
| cold PK lookup | 42.7 ms | 14.9 ms | −65% |
| concurrency c=8 (wall) | 698 ms | 46.5 ms | −93% |
| concurrency c=16 (wall) | 1380 ms | 87 ms | −94% |

The PK-lookup wins (which touch no m2m code at all) come from memoizing `getModel` — that's why the index lives in `QueryUtils` rather than the policy plugin.

A sanitized CPU profile (`.cpuprofile`) backing the original 29%/16% attribution is available — happy to attach or gist it.

## Tests

- New `tests/regression/test/issue-2715.test.ts` guards the memoization (resolution is correct for two-model, self-relation, explicit `@relation` name, and multiple relations; repeat resolution returns the same cached descriptor; negative results are cached). Verified it fails if the memoization is removed.
- Existing m2m + policy e2e suites (`relation/many-to-many`, `policy/migrated/relation-many-to-many-filter`, `connect-disconnect`, `self-relation`) pass unchanged — the behavior-preservation gate.

## Questions for maintainers

1. **Where should the index live?** I put it as a module-level `WeakMap<SchemaDef, …>` inside `QueryUtils`. If you'd prefer no module-level state, it could hang off the long-lived client/schema object instead — happy to move it.
2. **Scope:** I included `getModel`/`getManyToManyRelation` memoization alongside the join-table fix because the profile and the PK-lookup numbers show `getModel` is the larger lever. I can split it out if you'd rather keep this PR to `resolveManyToManyJoinTable` only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Model resolution queries now execute faster
  * Many-to-many relationship handling optimized for improved performance

* **New Features**
  * Enhanced support for implicit many-to-many join table discovery and resolution

* **Tests**
  * Added regression test for many-to-many join table functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->