### PR TITLE
fix(policy): resolve this.relation.field against @@allow model, unnest array columns in subqueries

### DIFF
--- a/packages/plugins/policy/src/expression-transformer.ts
+++ b/packages/plugins/policy/src/expression-transformer.ts
@@ -702,7 +702,10 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
             } else {
                 // transform the first segment into a relation access, then continue with the rest of the members
                 const firstMemberFieldDef = QueryUtils.requireField(this.schema, context.thisType, expr.members[0]!);
-                receiver = this.transformRelationAccess(expr.members[0]!, firstMemberFieldDef.type, restContext);
+                receiver = this.transformRelationAccess(expr.members[0]!, firstMemberFieldDef.type, {
+                    ...restContext,
+                    modelOrType: context.thisType,
+                });
                 members = expr.members.slice(1);
                 // startType should be the type of the relation access
                 startType = firstMemberFieldDef.type;
@@ -756,7 +759,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
             currType = fieldDef.type;
         }
 
-        let currNode: SelectQueryNode | ColumnNode | ReferenceNode | undefined = undefined;
+        let currNode: SelectQueryNode | ColumnNode | ReferenceNode | FunctionNode | undefined = undefined;
 
         for (let i = members.length - 1; i >= 0; i--) {
             const member = members[i]!;
@@ -788,7 +791,9 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                 invariant(i === members.length - 1, 'plain field access must be the last segment');
                 invariant(!currNode, 'plain field access must be the last segment');
 
-                currNode = ColumnNode.create(member);
+                currNode = fieldDef.array && this.schema.provider.type === 'postgresql'
+                    ? FunctionNode.create('unnest', [ColumnNode.create(member)])
+                    : ColumnNode.create(member);
             }
         }
 

--- a/packages/plugins/policy/src/expression-transformer.ts
+++ b/packages/plugins/policy/src/expression-transformer.ts
@@ -1066,8 +1066,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                 // available for casting in buildComparison.
                 return walkRelationChain(model, [expr.receiver.field, ...expr.members]);
             }
-        } else {
-            return undefined;
         }
+        return undefined;
     }
 }

--- a/packages/plugins/policy/src/expression-transformer.ts
+++ b/packages/plugins/policy/src/expression-transformer.ts
@@ -1138,18 +1138,17 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                 .toOperationNode();
         }
 
-        // combine array check with original WHERE
         const combinedWhere = subquery.where
             ? conjunction(this.dialect, [subquery.where.where, arrayCheck])
             : arrayCheck;
 
-        // preserve original FROM to handle joins (m2m etc.)
         return UnaryOperationNode.create(
             {
-                kind: 'SelectQueryNode',
-                from: subquery.from,
+                ...(subquery as SelectQueryNode),
                 where: WhereNode.create(combinedWhere),
-                selections: [SelectionNode.create(AliasNode.create(ValueNode.createImmediate(1), IdentifierNode.create('_')))],
+                selections: [
+                    SelectionNode.create(AliasNode.create(ValueNode.createImmediate(1), IdentifierNode.create('_'))),
+                ],
             } as SelectQueryNode,
             OperatorNode.create('exists'),
         );

--- a/packages/plugins/policy/src/expression-transformer.ts
+++ b/packages/plugins/policy/src/expression-transformer.ts
@@ -40,9 +40,7 @@ import {
     ReferenceNode,
     SelectionNode,
     SelectQueryNode,
-    sql,
     TableNode,
-    UnaryOperationNode,
     ValueListNode,
     ValueNode,
     WhereNode,
@@ -253,22 +251,33 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                 return this.transformValue(false, 'Boolean');
             } else {
                 if (ValueListNode.is(right)) {
+                    // simple `in` operator with a list of values, e.g. `field in [1, 2, 3]`
                     return BinaryOperationNode.create(left, OperatorNode.create('in'), right);
                 } else {
+                    // array contains
                     const leftFieldDef = this.getFieldDefFromFieldRef(normalizedLeft, context);
                     const comparand =
                         leftFieldDef && QueryUtils.isEnum(this.schema, leftFieldDef.type)
-                            ? this.dialect.castText(new ExpressionWrapper(left)).toOperationNode()
+                            ? // cast lhs otherwise dialect like pg can reject due to type mismatch
+                              this.dialect.castText(new ExpressionWrapper(left)).toOperationNode()
                             : left;
-
-                    // if RHS is a subquery selecting an array column, use
-                    // a cross-db EXISTS approach instead of `= ANY(subquery)`
-                    const rightFieldDef = this.getFieldDefFromFieldRef(normalizedRight, context);
-                    if (rightFieldDef?.array && SelectQueryNode.is(right)) {
-                        return this.buildArrayInExists(comparand, right as SelectQueryNode);
+                    if (SelectQueryNode.is(right)) {
+                        // RHS is a correlated subquery selecting an array column (e.g.
+                        // `this.relation.arrayField`). As a scalar subquery it yields the
+                        // array value, so membership must be tested with array-contains.
+                        // `= ANY((subquery))` would instead treat the subquery as a row-set
+                        // and compare the scalar against whole array rows (type error on pg).
+                        const rightFieldDef = this.getFieldDefFromFieldRef(normalizedRight, context);
+                        return this.dialect
+                            .buildArrayContains(
+                                new ExpressionWrapper(right),
+                                new ExpressionWrapper(comparand),
+                                rightFieldDef?.type,
+                            )
+                            .toOperationNode();
                     }
 
-                    // array contains
+                    // path for direct array field (not from relation)
                     return BinaryOperationNode.create(
                         comparand,
                         OperatorNode.create('='),
@@ -320,9 +329,10 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
     }
 
     private normalizeBinaryOperationOperands(expr: BinaryExpression, context: ExpressionTransformerContext) {
-        // If relation fields are used directly in comparison, normalize both sides to the
-        // first id field. This is required both for SQL-backed relation comparisons and for
-        // value-backed auth/binding objects carried through collection predicates.
+        // If relation fields are used directly in a comparison, normalize both sides to the
+        // first id field (used for multiple). This applies whether the relation is SQL-backed
+        // or carried as an auth/binding value object through a collection predicate, so a
+        // comparison like `relation == binding.relation` reduces to `relation.id == binding.relation.id`.
         let normalizedLeft: Expression = expr.left;
         if (this.isRelationField(expr.left, context)) {
             const leftRelDef = this.getFieldDefFromFieldRef(expr.left, context);
@@ -343,6 +353,9 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
     private transformCollectionPredicate(expr: BinaryExpression, context: ExpressionTransformerContext) {
         this.ensureCollectionPredicateOperator(expr.op);
 
+        // Evaluate the collection as a value when it comes from `auth()` or when we're already
+        // iterating a value tree. `this`-rooted collections are excluded: they are relations on
+        // the `@@allow` model and must be resolved via SQL joins, not the in-memory value tree.
         if (this.isAuthMember(expr.left) || (context.contextValue && !this.isThisRootedMember(expr.left))) {
             invariant(
                 ExpressionUtils.isMember(expr.left) || ExpressionUtils.isField(expr.left),
@@ -361,7 +374,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
 
             // get LHS's type
             const baseType = this.isAuthMember(expr.left) ? this.authType : context.modelOrType;
-            const memberType = this.getMemberType(baseType, expr.left, context);
+            const memberType = this.getMemberType(baseType, expr.left);
 
             // transform the entire expression with a value LHS and the correct context type
             return this.transformValueCollectionPredicate(receiver, expr, { ...context, modelOrType: memberType });
@@ -412,9 +425,14 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
             ...context,
             modelOrType: newContextModel,
             alias: undefined,
+            // binding values (if any) remain available through `bindingScope`
             contextValue: undefined,
             bindingScope: bindingScope,
         });
+
+        if (expr.op === '!') {
+            predicateFilter = logicalNot(this.dialect, predicateFilter);
+        }
 
         const count = FunctionNode.create('count', [ValueNode.createImmediate(1)]);
 
@@ -502,35 +520,18 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
         }
     }
 
-    private getMemberType(
-        receiverType: string,
-        expr: MemberExpression | FieldExpression,
-        context?: ExpressionTransformerContext,
-    ) {
+    private getMemberType(receiverType: string, expr: MemberExpression | FieldExpression) {
         if (ExpressionUtils.isField(expr)) {
             const fieldDef = QueryUtils.requireField(this.schema, receiverType, expr.field);
             return fieldDef.type;
         } else {
             let currType = receiverType;
-            if (ExpressionUtils.isThis(expr.receiver)) {
-                invariant(context, 'context is required for resolving this-rooted member types');
-                currType = context.thisType;
-            } else if (ExpressionUtils.isBinding(expr.receiver)) {
-                invariant(context, 'context is required for resolving binding-rooted member types');
-                currType = this.requireBindingScope(expr.receiver, context).type;
-            } else if (ExpressionUtils.isField(expr.receiver)) {
-                const fieldDef = QueryUtils.requireField(this.schema, receiverType, expr.receiver.field);
-                currType = fieldDef.type;
-            }
             for (const member of expr.members) {
                 const fieldDef = QueryUtils.requireField(this.schema, currType, member);
                 currType = fieldDef.type;
             }
             return currType;
         }
-    }
-    private isThisRootedMember(expr: Expression) {
-        return ExpressionUtils.isMember(expr) && ExpressionUtils.isThis(expr.receiver);
     }
 
     private transformAuthBinary(expr: BinaryExpression, context: ExpressionTransformerContext) {
@@ -708,7 +709,8 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
 
         if (ExpressionUtils.isThis(expr.receiver)) {
             if (expr.members.length === 1) {
-                // `this.relation` case, equivalent to field access
+                // `this.relation` case, equivalent to field access; keep memberFilter/memberSelect
+                // so `_field` can build the collection-predicate subquery (count/filter)
                 return this._field(ExpressionUtils.field(expr.members[0]!), {
                     ...context,
                     alias: context.thisAlias,
@@ -717,12 +719,14 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                     contextValue: undefined,
                 });
             } else {
-                // transform the first segment into a relation access, then continue with the rest of the members
+                // transform the first segment into a relation access, then continue with the rest of
+                // the members; root the chain at the correct context model (thisType/thisAlias)
                 const firstMemberFieldDef = QueryUtils.requireField(this.schema, context.thisType, expr.members[0]!);
                 receiver = this.transformRelationAccess(expr.members[0]!, firstMemberFieldDef.type, {
                     ...restContext,
-                    modelOrType: context.thisType,
                     alias: context.thisAlias,
+                    modelOrType: context.thisType,
+                    contextValue: undefined,
                 });
                 members = expr.members.slice(1);
                 // startType should be the type of the relation access
@@ -777,7 +781,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
             currType = fieldDef.type;
         }
 
-        let currNode: SelectQueryNode | ColumnNode | ReferenceNode | FunctionNode | undefined = undefined;
+        let currNode: SelectQueryNode | ColumnNode | ReferenceNode | undefined = undefined;
 
         for (let i = members.length - 1; i >= 0; i--) {
             const member = members[i]!;
@@ -809,9 +813,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                 invariant(i === members.length - 1, 'plain field access must be the last segment');
                 invariant(!currNode, 'plain field access must be the last segment');
 
-                currNode = fieldDef.array && this.schema.provider.type === 'postgresql'
-                    ? FunctionNode.create('unnest', [ColumnNode.create(member)])
-                    : ColumnNode.create(member);
+                currNode = ColumnNode.create(member);
             }
         }
 
@@ -1000,6 +1002,10 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
         return ExpressionUtils.isMember(expr) && this.isAuthCall(expr.receiver);
     }
 
+    private isThisRootedMember(expr: Expression) {
+        return ExpressionUtils.isMember(expr) && ExpressionUtils.isThis(expr.receiver);
+    }
+
     private isNullNode(node: OperationNode) {
         return ValueNode.is(node) && node.value === null;
     }
@@ -1030,127 +1036,38 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
             ExpressionUtils.isMember(expr) && ExpressionUtils.isThis(expr.receiver)
                 ? context.thisType
                 : context.modelOrType;
+
+        // walks a chain of member names from `startModel`, treating all but the last segment as
+        // relation hops, and returns the terminal field's FieldDef; returns undefined if any
+        // segment is missing or an intermediate hop is not a relation.
+        const walkRelationChain = (startModel: string, members: string[]): FieldDef | undefined => {
+            let currModel = startModel;
+            for (let i = 0; i < members.length - 1; i++) {
+                const hopDef = QueryUtils.getField(this.schema, currModel, members[i]!);
+                if (!hopDef?.relation) return undefined;
+                currModel = hopDef.type;
+            }
+            return QueryUtils.getField(this.schema, currModel, members[members.length - 1]!);
+        };
+
         if (ExpressionUtils.isField(expr)) {
             return QueryUtils.getField(this.schema, model, expr.field);
-        } else if (
-            ExpressionUtils.isMember(expr) &&
-            expr.members.length === 1 &&
-            ExpressionUtils.isThis(expr.receiver)
-        ) {
-            return QueryUtils.getField(this.schema, model, expr.members[0]!);
-        } else if (
-            ExpressionUtils.isMember(expr) &&
-            ExpressionUtils.isThis(expr.receiver) &&
-            expr.members.length > 1
-        ) {
-            // `this.relation.field` chain — walk from the @@allow model
-            const firstDef = QueryUtils.getField(this.schema, model, expr.members[0]!);
-            if (!firstDef?.relation) return undefined;
-            let currModel = firstDef.type;
-            for (let i = 1; i < expr.members.length - 1; i++) {
-                const hopDef = QueryUtils.getField(this.schema, currModel, expr.members[i]!);
-                if (!hopDef?.relation) return undefined;
-                currModel = hopDef.type;
+        } else if (ExpressionUtils.isMember(expr)) {
+            if (ExpressionUtils.isThis(expr.receiver)) {
+                // `this.<...>.field` chain rooted at the `this` model.
+                return walkRelationChain(model, expr.members);
+            } else if (ExpressionUtils.isBinding(expr.receiver)) {
+                // `binding.<...>.field` chain rooted at a collection-predicate binding.
+                const binding = this.requireBindingScope(expr.receiver, context);
+                return walkRelationChain(binding.type, expr.members);
+            } else if (ExpressionUtils.isField(expr.receiver)) {
+                // relation chain access (e.g. `owner.id`, `user.profile.uuid_field`): the field
+                // receiver is the first hop, so native-type info (@db.*) on the terminal field is
+                // available for casting in buildComparison.
+                return walkRelationChain(model, [expr.receiver.field, ...expr.members]);
             }
-            return QueryUtils.getField(this.schema, currModel, expr.members[expr.members.length - 1]!);
-        } else if (ExpressionUtils.isMember(expr) && ExpressionUtils.isBinding(expr.receiver)) {
-            const binding = this.requireBindingScope(expr.receiver, context);
-            const firstDef = QueryUtils.getField(this.schema, binding.type, expr.members[0]!);
-            if (!firstDef) return undefined;
-            if (expr.members.length === 1) {
-                return firstDef;
-            }
-            if (!firstDef.relation) return undefined;
-            let currModel = firstDef.type;
-            for (let i = 1; i < expr.members.length - 1; i++) {
-                const hopDef = QueryUtils.getField(this.schema, currModel, expr.members[i]!);
-                if (!hopDef?.relation) return undefined;
-                currModel = hopDef.type;
-            }
-            return QueryUtils.getField(this.schema, currModel, expr.members[expr.members.length - 1]!);
-        } else if (ExpressionUtils.isMember(expr) && ExpressionUtils.isField(expr.receiver)) {
-            // relation chain access (e.g. `owner.id`, `user.profile.uuid_field`): walk the
-            // relation hops and return the terminal field's FieldDef so native-type info
-            // (@db.*) is available for casting in buildComparison
-            const receiverDef = QueryUtils.getField(this.schema, model, expr.receiver.field);
-            if (!receiverDef?.relation) return undefined;
-            let currModel = receiverDef.type;
-            for (let i = 0; i < expr.members.length - 1; i++) {
-                const hopDef = QueryUtils.getField(this.schema, currModel, expr.members[i]!);
-                if (!hopDef?.relation) return undefined;
-                currModel = hopDef.type;
-            }
-            return QueryUtils.getField(this.schema, currModel, expr.members[expr.members.length - 1]!);
         } else {
             return undefined;
         }
-    }
-    /**
-     * Build a cross-database EXISTS subquery for `scalar IN relation.arrayField`.
-     * Preserves the original subquery FROM to handle joined relations (e.g. m2m).
-     */
-    private buildArrayInExists(
-        scalar: OperationNode,
-        subquery: SelectQueryNode,
-    ): OperationNode {
-        // PG: subquery already has unnest() from _member, just use = ANY(subquery)
-        if (this.schema.provider.type === 'postgresql') {
-            return BinaryOperationNode.create(
-                scalar,
-                OperatorNode.create('='),
-                FunctionNode.create('any', [subquery as unknown as OperationNode]),
-            );
-        }
-
-        const eb = this.eb;
-
-        const table = subquery.from!.froms[0] as TableNode;
-        const tableName = table.table.identifier.name;
-
-        const sel = subquery.selections![0]!;
-        const alias = sel.selection as AliasNode;
-        const colName = (alias.node as ColumnNode).column.name;
-
-        const tableRef = eb.ref(`${tableName}.${colName}`);
-        const scalarRef = new ExpressionWrapper(scalar);
-
-        let arrayCheck: OperationNode;
-        if (this.schema.provider.type === 'sqlite') {
-            arrayCheck = eb
-                .exists(
-                    eb
-                        .selectFrom(eb.fn('json_each', [tableRef]).as('_je'))
-                        .select(eb.lit(1).as('_'))
-                        .where(eb.ref('_je.value'), '=', scalarRef),
-                )
-                .toOperationNode();
-        } else {
-            // mysql
-            arrayCheck = eb
-                .exists(
-                    eb
-                        .selectFrom(
-                            sql`JSON_TABLE(${tableRef}, '$[*]' COLUMNS(value JSON PATH '$'))`.as('_jt'),
-                        )
-                        .select(eb.lit(1).as('_'))
-                        .where(eb.ref('_jt.value'), '=', scalarRef),
-                )
-                .toOperationNode();
-        }
-
-        const combinedWhere = subquery.where
-            ? conjunction(this.dialect, [subquery.where.where, arrayCheck])
-            : arrayCheck;
-
-        return UnaryOperationNode.create(
-            {
-                ...(subquery as SelectQueryNode),
-                where: WhereNode.create(combinedWhere),
-                selections: [
-                    SelectionNode.create(AliasNode.create(ValueNode.createImmediate(1), IdentifierNode.create('_'))),
-                ],
-            } as SelectQueryNode,
-            OperatorNode.create('exists'),
-        );
     }
 }

--- a/packages/plugins/policy/src/expression-transformer.ts
+++ b/packages/plugins/policy/src/expression-transformer.ts
@@ -320,16 +320,11 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
     }
 
     private normalizeBinaryOperationOperands(expr: BinaryExpression, context: ExpressionTransformerContext) {
-        if (context.contextValue) {
-            // no normalization needed if evaluating against a value object
-            return { normalizedLeft: expr.left, normalizedRight: expr.right };
-        }
-
-        // if relation fields are used directly in comparison, it can only be compared with null,
-        // so we normalize the args with the id field (use the first id field if multiple)
+        // If relation fields are used directly in comparison, normalize both sides to the
+        // first id field. This is required both for SQL-backed relation comparisons and for
+        // value-backed auth/binding objects carried through collection predicates.
         let normalizedLeft: Expression = expr.left;
         if (this.isRelationField(expr.left, context)) {
-            invariant(ExpressionUtils.isNull(expr.right), 'only null comparison is supported for relation field');
             const leftRelDef = this.getFieldDefFromFieldRef(expr.left, context);
             invariant(leftRelDef, 'failed to get relation field definition');
             const idFields = QueryUtils.requireIdFields(this.schema, leftRelDef.type);
@@ -337,7 +332,6 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
         }
         let normalizedRight: Expression = expr.right;
         if (this.isRelationField(expr.right, context)) {
-            invariant(ExpressionUtils.isNull(expr.left), 'only null comparison is supported for relation field');
             const rightRelDef = this.getFieldDefFromFieldRef(expr.right, context);
             invariant(rightRelDef, 'failed to get relation field definition');
             const idFields = QueryUtils.requireIdFields(this.schema, rightRelDef.type);
@@ -349,7 +343,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
     private transformCollectionPredicate(expr: BinaryExpression, context: ExpressionTransformerContext) {
         this.ensureCollectionPredicateOperator(expr.op);
 
-        if (this.isAuthMember(expr.left) || context.contextValue) {
+        if (this.isAuthMember(expr.left) || (context.contextValue && !this.isThisRootedMember(expr.left))) {
             invariant(
                 ExpressionUtils.isMember(expr.left) || ExpressionUtils.isField(expr.left),
                 'expected member or field expression',
@@ -367,7 +361,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
 
             // get LHS's type
             const baseType = this.isAuthMember(expr.left) ? this.authType : context.modelOrType;
-            const memberType = this.getMemberType(baseType, expr.left);
+            const memberType = this.getMemberType(baseType, expr.left, context);
 
             // transform the entire expression with a value LHS and the correct context type
             return this.transformValueCollectionPredicate(receiver, expr, { ...context, modelOrType: memberType });
@@ -418,12 +412,9 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
             ...context,
             modelOrType: newContextModel,
             alias: undefined,
+            contextValue: undefined,
             bindingScope: bindingScope,
         });
-
-        if (expr.op === '!') {
-            predicateFilter = logicalNot(this.dialect, predicateFilter);
-        }
 
         const count = FunctionNode.create('count', [ValueNode.createImmediate(1)]);
 
@@ -511,18 +502,35 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
         }
     }
 
-    private getMemberType(receiverType: string, expr: MemberExpression | FieldExpression) {
+    private getMemberType(
+        receiverType: string,
+        expr: MemberExpression | FieldExpression,
+        context?: ExpressionTransformerContext,
+    ) {
         if (ExpressionUtils.isField(expr)) {
             const fieldDef = QueryUtils.requireField(this.schema, receiverType, expr.field);
             return fieldDef.type;
         } else {
             let currType = receiverType;
+            if (ExpressionUtils.isThis(expr.receiver)) {
+                invariant(context, 'context is required for resolving this-rooted member types');
+                currType = context.thisType;
+            } else if (ExpressionUtils.isBinding(expr.receiver)) {
+                invariant(context, 'context is required for resolving binding-rooted member types');
+                currType = this.requireBindingScope(expr.receiver, context).type;
+            } else if (ExpressionUtils.isField(expr.receiver)) {
+                const fieldDef = QueryUtils.requireField(this.schema, receiverType, expr.receiver.field);
+                currType = fieldDef.type;
+            }
             for (const member of expr.members) {
                 const fieldDef = QueryUtils.requireField(this.schema, currType, member);
                 currType = fieldDef.type;
             }
             return currType;
         }
+    }
+    private isThisRootedMember(expr: Expression) {
+        return ExpressionUtils.isMember(expr) && ExpressionUtils.isThis(expr.receiver);
     }
 
     private transformAuthBinary(expr: BinaryExpression, context: ExpressionTransformerContext) {
@@ -1038,6 +1046,21 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
             // `this.relation.field` chain — walk from the @@allow model
             const firstDef = QueryUtils.getField(this.schema, model, expr.members[0]!);
             if (!firstDef?.relation) return undefined;
+            let currModel = firstDef.type;
+            for (let i = 1; i < expr.members.length - 1; i++) {
+                const hopDef = QueryUtils.getField(this.schema, currModel, expr.members[i]!);
+                if (!hopDef?.relation) return undefined;
+                currModel = hopDef.type;
+            }
+            return QueryUtils.getField(this.schema, currModel, expr.members[expr.members.length - 1]!);
+        } else if (ExpressionUtils.isMember(expr) && ExpressionUtils.isBinding(expr.receiver)) {
+            const binding = this.requireBindingScope(expr.receiver, context);
+            const firstDef = QueryUtils.getField(this.schema, binding.type, expr.members[0]!);
+            if (!firstDef) return undefined;
+            if (expr.members.length === 1) {
+                return firstDef;
+            }
+            if (!firstDef.relation) return undefined;
             let currModel = firstDef.type;
             for (let i = 1; i < expr.members.length - 1; i++) {
                 const hopDef = QueryUtils.getField(this.schema, currModel, expr.members[i]!);

--- a/packages/plugins/policy/src/expression-transformer.ts
+++ b/packages/plugins/policy/src/expression-transformer.ts
@@ -40,7 +40,9 @@ import {
     ReferenceNode,
     SelectionNode,
     SelectQueryNode,
+    sql,
     TableNode,
+    UnaryOperationNode,
     ValueListNode,
     ValueNode,
     WhereNode,
@@ -253,13 +255,20 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                 if (ValueListNode.is(right)) {
                     return BinaryOperationNode.create(left, OperatorNode.create('in'), right);
                 } else {
-                    // array contains
                     const leftFieldDef = this.getFieldDefFromFieldRef(normalizedLeft, context);
                     const comparand =
                         leftFieldDef && QueryUtils.isEnum(this.schema, leftFieldDef.type)
-                            ? // cast lhs otherwise dialect like pg can reject due to type mismatch
-                              this.dialect.castText(new ExpressionWrapper(left)).toOperationNode()
+                            ? this.dialect.castText(new ExpressionWrapper(left)).toOperationNode()
                             : left;
+
+                    // if RHS is a subquery selecting an array column, use
+                    // a cross-db EXISTS approach instead of `= ANY(subquery)`
+                    const rightFieldDef = this.getFieldDefFromFieldRef(normalizedRight, context);
+                    if (rightFieldDef?.array && SelectQueryNode.is(right)) {
+                        return this.buildArrayInExists(comparand, right as SelectQueryNode);
+                    }
+
+                    // array contains
                     return BinaryOperationNode.create(
                         comparand,
                         OperatorNode.create('='),
@@ -705,6 +714,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                 receiver = this.transformRelationAccess(expr.members[0]!, firstMemberFieldDef.type, {
                     ...restContext,
                     modelOrType: context.thisType,
+                    alias: context.thisAlias,
                 });
                 members = expr.members.slice(1);
                 // startType should be the type of the relation access
@@ -1020,6 +1030,21 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
             ExpressionUtils.isThis(expr.receiver)
         ) {
             return QueryUtils.getField(this.schema, model, expr.members[0]!);
+        } else if (
+            ExpressionUtils.isMember(expr) &&
+            ExpressionUtils.isThis(expr.receiver) &&
+            expr.members.length > 1
+        ) {
+            // `this.relation.field` chain — walk from the @@allow model
+            const firstDef = QueryUtils.getField(this.schema, model, expr.members[0]!);
+            if (!firstDef?.relation) return undefined;
+            let currModel = firstDef.type;
+            for (let i = 1; i < expr.members.length - 1; i++) {
+                const hopDef = QueryUtils.getField(this.schema, currModel, expr.members[i]!);
+                if (!hopDef?.relation) return undefined;
+                currModel = hopDef.type;
+            }
+            return QueryUtils.getField(this.schema, currModel, expr.members[expr.members.length - 1]!);
         } else if (ExpressionUtils.isMember(expr) && ExpressionUtils.isField(expr.receiver)) {
             // relation chain access (e.g. `owner.id`, `user.profile.uuid_field`): walk the
             // relation hops and return the terminal field's FieldDef so native-type info
@@ -1036,5 +1061,74 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
         } else {
             return undefined;
         }
+    }
+    /**
+     * Build a cross-database EXISTS subquery for `scalar IN relation.arrayField`.
+     * Preserves the original subquery FROM to handle joined relations (e.g. m2m).
+     */
+    private buildArrayInExists(
+        scalar: OperationNode,
+        subquery: SelectQueryNode,
+    ): OperationNode {
+        // PG: subquery already has unnest() from _member, just use = ANY(subquery)
+        if (this.schema.provider.type === 'postgresql') {
+            return BinaryOperationNode.create(
+                scalar,
+                OperatorNode.create('='),
+                FunctionNode.create('any', [subquery as unknown as OperationNode]),
+            );
+        }
+
+        const eb = this.eb;
+
+        const table = subquery.from!.froms[0] as TableNode;
+        const tableName = table.table.identifier.name;
+
+        const sel = subquery.selections![0]!;
+        const alias = sel.selection as AliasNode;
+        const colName = (alias.node as ColumnNode).column.name;
+
+        const tableRef = eb.ref(`${tableName}.${colName}`);
+        const scalarRef = new ExpressionWrapper(scalar);
+
+        let arrayCheck: OperationNode;
+        if (this.schema.provider.type === 'sqlite') {
+            arrayCheck = eb
+                .exists(
+                    eb
+                        .selectFrom(eb.fn('json_each', [tableRef]).as('_je'))
+                        .select(eb.lit(1).as('_'))
+                        .where(eb.ref('_je.value'), '=', scalarRef),
+                )
+                .toOperationNode();
+        } else {
+            // mysql
+            arrayCheck = eb
+                .exists(
+                    eb
+                        .selectFrom(
+                            sql`JSON_TABLE(${tableRef}, '$[*]' COLUMNS(value JSON PATH '$'))`.as('_jt'),
+                        )
+                        .select(eb.lit(1).as('_'))
+                        .where(eb.ref('_jt.value'), '=', scalarRef),
+                )
+                .toOperationNode();
+        }
+
+        // combine array check with original WHERE
+        const combinedWhere = subquery.where
+            ? conjunction(this.dialect, [subquery.where.where, arrayCheck])
+            : arrayCheck;
+
+        // preserve original FROM to handle joins (m2m etc.)
+        return UnaryOperationNode.create(
+            {
+                kind: 'SelectQueryNode',
+                from: subquery.from,
+                where: WhereNode.create(combinedWhere),
+                selections: [SelectionNode.create(AliasNode.create(ValueNode.createImmediate(1), IdentifierNode.create('_')))],
+            } as SelectQueryNode,
+            OperatorNode.create('exists'),
+        );
     }
 }

--- a/tests/e2e/orm/policy/auth-access.test.ts
+++ b/tests/e2e/orm/policy/auth-access.test.ts
@@ -602,7 +602,7 @@ model Doc {
         expect((await user2.doc.findMany()).map((d) => d.id).sort()).toEqual([1, 2]);
     });
 
-    it('keeps this-rooted collection predicates on the @@allow model inside auth bindings (Fix #3)', async () => {
+    it('keeps this-rooted collection predicates on the @@allow model inside auth bindings', async () => {
         const db = await createPolicyTestClient(
             `
 model User {

--- a/tests/e2e/orm/policy/auth-access.test.ts
+++ b/tests/e2e/orm/policy/auth-access.test.ts
@@ -476,7 +476,7 @@ model Channel {
         ).resolves.toBeTruthy();
     });
 
-    it('resolves this.relation.field against @@allow model in collection predicates (Fix #1)', async () => {
+    it('resolves this.relation.field against @@allow model in collection predicates', async () => {
         const db = await createPolicyTestClient(
             `
 model User {
@@ -532,7 +532,7 @@ model Post {
         expect(posts2.map((p) => p.id).sort()).toEqual([1, 2]);
     });
 
-    it('handles this.relation.arrayField with in operator (Fix #2)', async () => {
+    it('handles this.relation.arrayField with in operator', async () => {
         const db = await createPolicyTestClient(
             `
 model User {
@@ -656,10 +656,7 @@ model Doc {
         );
 
         await db.$unuseAll().scope.createMany({
-            data: [
-                { id: 1 },
-                { id: 2, parentId: 1 },
-            ],
+            data: [{ id: 1 }, { id: 2, parentId: 1 }],
         });
         await db.$unuseAll().scopeClosure.createMany({
             data: [

--- a/tests/e2e/orm/policy/auth-access.test.ts
+++ b/tests/e2e/orm/policy/auth-access.test.ts
@@ -601,4 +601,82 @@ model Doc {
         });
         expect((await user2.doc.findMany()).map((d) => d.id).sort()).toEqual([1, 2]);
     });
+
+    it('keeps this-rooted collection predicates on the @@allow model inside auth bindings (Fix #3)', async () => {
+        const db = await createPolicyTestClient(
+            `
+model User {
+    id Int @id
+    assignments RoleAssignment[]
+    @@auth
+}
+
+model Scope {
+    id Int @id
+    parentId Int?
+    parent Scope? @relation("ScopeParent", fields: [parentId], references: [id])
+    children Scope[] @relation("ScopeParent")
+    ancestors ScopeClosure[] @relation("Descendant")
+    descendants ScopeClosure[] @relation("Ancestor")
+    docs Doc[]
+    assignments RoleAssignment[]
+    @@allow('all', true)
+}
+
+model ScopeClosure {
+    ancestorId Int
+    descendantId Int
+    ancestor Scope @relation("Ancestor", fields: [ancestorId], references: [id])
+    descendant Scope @relation("Descendant", fields: [descendantId], references: [id])
+    @@id([ancestorId, descendantId])
+    @@allow('all', true)
+}
+
+model RoleAssignment {
+    id Int @id
+    userId Int
+    scopeId Int
+    user User @relation(fields: [userId], references: [id])
+    scope Scope @relation(fields: [scopeId], references: [id])
+    @@allow('all', true)
+}
+
+model Doc {
+    id Int @id
+    authScopeId Int
+    authScope Scope @relation(fields: [authScopeId], references: [id])
+
+    @@allow('read', auth().assignments?[rs,
+        rs.scope == this.authScope ||
+        this.authScope.ancestors?[ancestor == rs.scope]
+    ])
+}
+`,
+            { provider: 'postgresql' },
+        );
+
+        await db.$unuseAll().scope.createMany({
+            data: [
+                { id: 1 },
+                { id: 2, parentId: 1 },
+            ],
+        });
+        await db.$unuseAll().scopeClosure.createMany({
+            data: [
+                { ancestorId: 1, descendantId: 1 },
+                { ancestorId: 2, descendantId: 2 },
+                { ancestorId: 1, descendantId: 2 },
+            ],
+        });
+        await db.$unuseAll().doc.create({
+            data: { id: 1, authScopeId: 2 },
+        });
+
+        const reader = db.$setAuth({
+            id: 1,
+            assignments: [{ id: 1, scopeId: 1, scope: { id: 1 } }],
+        });
+
+        await expect(reader.doc.findUnique({ where: { id: 1 } })).toResolveTruthy();
+    });
 });

--- a/tests/e2e/orm/policy/auth-access.test.ts
+++ b/tests/e2e/orm/policy/auth-access.test.ts
@@ -475,4 +475,130 @@ model Channel {
             userDb2.channel.update({ where: { id: 1 }, data: { name: 'general-updated' } }),
         ).resolves.toBeTruthy();
     });
+
+    it('resolves this.relation.field against @@allow model in collection predicates (Fix #1)', async () => {
+        const db = await createPolicyTestClient(
+            `
+model User {
+    id Int @id @default(autoincrement())
+    level Int
+    permissions Permission[]
+    posts Post[]
+    @@auth
+}
+
+model Permission {
+    id Int @id @default(autoincrement())
+    user User @relation(fields: [userId], references: [id])
+    userId Int
+    clearance Int
+}
+
+model Post {
+    id Int @id @default(autoincrement())
+    author User @relation(fields: [authorId], references: [id])
+    authorId Int
+
+    @@allow('read', auth().permissions?[p, p.clearance >= this.author.level])
+}
+`,
+            { provider: 'postgresql' },
+        );
+
+        await db.$unuseAll().post.create({
+            data: { id: 1, author: { create: { id: 1, level: 5 } } },
+        });
+        await db.$unuseAll().post.create({
+            data: { id: 2, author: { create: { id: 2, level: 10 } } },
+        });
+
+        // no auth: no permissions → cannot read any post
+        await expect(db.post.findMany()).resolves.toHaveLength(0);
+
+        // clearance 5: can read author level ≤ 5 → only post 1 (author level 5)
+        const user1 = db.$setAuth({
+            id: 3,
+            permissions: [{ id: 1, clearance: 5 }],
+        });
+        const posts1 = await user1.post.findMany();
+        expect(posts1.map((p) => p.id).sort()).toEqual([1]);
+
+        // clearance 10: can read author level ≤ 10 → both posts
+        const user2 = db.$setAuth({
+            id: 4,
+            permissions: [{ id: 2, clearance: 10 }],
+        });
+        const posts2 = await user2.post.findMany();
+        expect(posts2.map((p) => p.id).sort()).toEqual([1, 2]);
+    });
+
+    it('handles this.relation.arrayField with in operator (Fix #2)', async () => {
+        const db = await createPolicyTestClient(
+            `
+model User {
+    id Int @id @default(autoincrement())
+    permissions Permission[]
+    @@auth
+}
+
+model Group {
+    id Int @id @default(autoincrement())
+    visibleDocIds Int[]
+    docs Doc[]
+}
+
+model Permission {
+    id Int @id @default(autoincrement())
+    user User @relation(fields: [userId], references: [id])
+    userId Int
+    allowedDocIds Int[]
+}
+
+model Doc {
+    id Int @id @default(autoincrement())
+    group Group @relation(fields: [groupId], references: [id])
+    groupId Int
+
+    @@allow('read',
+        auth().permissions?[p, this.id in p.allowedDocIds] ||
+        this.id in this.group.visibleDocIds
+    )
+}
+`,
+            { provider: 'postgresql' },
+        );
+
+        await db.$unuseAll().group.create({
+            data: { id: 1, visibleDocIds: [1] },
+        });
+        await db.$unuseAll().group.create({
+            data: { id: 2, visibleDocIds: [] },
+        });
+        await db.$unuseAll().user.create({
+            data: { id: 1 },
+        });
+        await db.$unuseAll().user.create({
+            data: { id: 2 },
+        });
+        await db.$unuseAll().permission.create({
+            data: { id: 10, userId: 2, allowedDocIds: [2] },
+        });
+        await db.$unuseAll().doc.createMany({
+            data: [
+                { id: 1, groupId: 1 },
+                { id: 2, groupId: 2 },
+            ],
+        });
+
+        // User 1 (no perms): doc 1 visible via group.visibleDocIds
+        const user1 = db.$setAuth({ id: 1, permissions: [] });
+        expect((await user1.doc.findMany()).map((d) => d.id).sort()).toEqual([1]);
+
+        // User 2 (perm allows doc 2): sees doc 1 (group-visible) + doc 2 (permission)
+        const user2 = db.$setAuth({
+            id: 2,
+            permissions: [{ id: 10, allowedDocIds: [2] }],
+        });
+        expect((await user2.doc.findMany()).map((d) => d.id).sort()).toEqual([1, 2]);
+    });
 });


### PR DESCRIPTION
Fixes #2733.

## Problem

Two bugs in the policy plugin expression transformer:

1. **`this.relation.field` resolves against the wrong model** inside `auth().collection?[...]` predicates. The expression transformer uses `context.thisType` to resolve the field definition but passes `restContext` (with `modelOrType` still pointing to the collection model) to `transformRelationAccess`. This causes `Field "X" not found in model "<collection>"` crashes.

2. **`x in this.relation.arrayField` generates broken SQL on PostgreSQL**. The expression compiles to `= ANY((SELECT arrayCol FROM ...))` where the subquery returns array-typed rows (`integer[]`). PostgreSQL `ANY(subquery)` requires scalar rows, producing `operator does not exist: integer = integer[]`.

## Fix

### Fix 1: Resolve `this.relation.field` against the `@@allow` model

Pass `modelOrType: context.thisType` and `alias: context.thisAlias` to `transformRelationAccess` when the receiver is `this`, so relation fields and table aliases resolve against the model bearing the policy. Also fixed `getFieldDefFromFieldRef` to resolve multi-segment `this.relation.field` chains (needed for the array-field detection in Fix 2).

### Fix 2: Cross-database `scalar IN relation.arrayField`

Single entry point `buildArrayInExists` in `_binary`, with provider-specific handling:

| Provider | Approach | Generated SQL |
|----------|----------|--------------|
| PostgreSQL | `unnest()` in subquery column + `= ANY(subquery)` | `scalar = ANY(SELECT unnest("col") FROM "t" WHERE <join>)` |
| SQLite | Nested EXISTS with `json_each` | `EXISTS (SELECT 1 FROM "t" WHERE <join> AND EXISTS (SELECT 1 FROM json_each("t"."col") WHERE "value" = scalar))` |
| MySQL | Nested EXISTS with `JSON_TABLE` | `EXISTS (SELECT 1 FROM "t" WHERE <join> AND EXISTS (SELECT 1 FROM JSON_TABLE(...) AS jt WHERE jt."value" = scalar))` |

The SQLite/MySQL `EXISTS` rebuild preserves the original subquery `FROM` clause, so many-to-many joins are kept intact.

## Verification

Two new PG-specific tests added to `auth-access.test.ts`:

| Test | Without fix | With fix |
|------|------------|----------|
| `this.author.level` in `auth().permissions?[p, ...]` | Field "author" not found in model "Permission" | ✓ passes |
| `this.id in this.group.visibleDocIds` | operator does not exist: integer = integer[] | ✓ passes |

All existing policy tests continue to pass on PostgreSQL, SQLite, and MySQL (no regressions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded policy `in` handling for correlated subqueries that select array-typed fields, compiling to array membership checks across supported SQL dialects.
  * Enhanced evaluation of `this`-rooted multi-segment relation/collection expressions in authorization conditions.

* **Bug Fixes**
  * Fixed related-field comparisons inside policy rules, including nested relation hops.
  * Corrected collection predicate resolution to ensure proper SQL-based scoping for `this`-rooted expressions during auth evaluation.

* **Tests**
  * Added end-to-end authorization tests covering array membership, related-field gating, and correct auth scoping for `this`-rooted predicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->