### PR TITLE
feat(tanstack-query): re-export getQueryKey from all framework entry points

### DIFF
--- a/packages/clients/tanstack-query/src/common/client.ts
+++ b/packages/clients/tanstack-query/src/common/client.ts
@@ -33,7 +33,7 @@ export function getAllQueries(queryClient: QueryClient): readonly QueryInfo[] {
                 operation: parsed?.operation,
                 args: parsed?.args,
                 data: state.data,
-                optimisticUpdate: !!parsed.flags.optimisticUpdate,
+                optimisticUpdate: !!parsed.flags?.optimisticUpdate,
                 updateData: (data: unknown, cancelOnTheFlyQueries: boolean) => {
                     queryClient.setQueryData<unknown>(queryKey, data);
                     if (cancelOnTheFlyQueries) {

--- a/packages/clients/tanstack-query/src/react.ts
+++ b/packages/clients/tanstack-query/src/react.ts
@@ -84,6 +84,7 @@ export { AnyNull, DbNull, JsonNull } from '@zenstackhq/client-helpers';
 export type { InferExtResult, InferOptions, InferSchema } from '@zenstackhq/client-helpers';
 export type { FetchFn } from '@zenstackhq/client-helpers/fetch';
 export type { SchemaDef } from '@zenstackhq/schema';
+export { getQueryKey } from './common/query-key.js';
 
 type ProcedureHookFn<
     Schema extends SchemaDef,

--- a/packages/clients/tanstack-query/src/svelte/index.svelte.ts
+++ b/packages/clients/tanstack-query/src/svelte/index.svelte.ts
@@ -81,6 +81,7 @@ export { AnyNull, DbNull, JsonNull } from '@zenstackhq/client-helpers';
 export type { InferExtQueryArgs, InferExtResult, InferOptions, InferSchema } from '@zenstackhq/client-helpers';
 export type { FetchFn } from '@zenstackhq/client-helpers/fetch';
 export type { SchemaDef } from '@zenstackhq/schema';
+export { getQueryKey } from '../common/query-key.js';
 
 type ProcedureHookFn<
     Schema extends SchemaDef,

--- a/packages/clients/tanstack-query/src/vue.ts
+++ b/packages/clients/tanstack-query/src/vue.ts
@@ -79,6 +79,7 @@ export { AnyNull, DbNull, JsonNull } from '@zenstackhq/client-helpers';
 export type { InferExtQueryArgs, InferExtResult, InferOptions, InferSchema } from '@zenstackhq/client-helpers';
 export type { FetchFn } from '@zenstackhq/client-helpers/fetch';
 export type { SchemaDef } from '@zenstackhq/schema';
+export { getQueryKey } from './common/query-key.js';
 
 export const VueQueryContextKey = 'zenstack-vue-query-context';
 


### PR DESCRIPTION
## Summary

Re-exports the `getQueryKey` helper from all three framework entry points of `@zenstackhq/tanstack-query` (`/react`, `/vue`, `/svelte`), so users can compute ZenStack query keys (e.g., for manual cache invalidation or prefetching) without reaching into internal modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `getQueryKey` is now publicly available through the React, Svelte, and Vue client packages.
  * Helps provide a consistent way to generate query keys across frameworks.
* **Bug Fixes**
  * Improved safety when reading `optimisticUpdate` during query collection by handling cases where related flags may be missing, preventing potential runtime errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->