### PR TITLE
fix(cli): prevent silent zero-exit when the version-check fetch stalls

### DIFF
--- a/packages/cli/src/utils/version-utils.ts
+++ b/packages/cli/src/utils/version-utils.ts
@@ -20,11 +20,27 @@ export function getVersion() {
 export async function checkNewVersion() {
     const currVersion = getVersion();
     let latestVersion: string;
+    // race against a ref'd, always-settling timer: if the fetch's connection dies in a
+    // way that strands its promise (leaving no active handle), the pending `await` would
+    // otherwise drain the event loop and silently exit the process with code 0 mid-command;
+    // the timer both keeps the loop alive and guarantees this await settles
+    let timer: NodeJS.Timeout | undefined;
     try {
-        latestVersion = await getLatestVersion();
+        const fetchPromise = getLatestVersion();
+        // if the timer wins the race, a later settlement of the fetch must not surface
+        // as an unhandled rejection
+        fetchPromise.catch(() => {});
+        latestVersion = await Promise.race([
+            fetchPromise,
+            new Promise<never>((_, reject) => {
+                timer = setTimeout(() => reject(new Error('version check timed out')), CHECK_VERSION_TIMEOUT + 1000);
+            }),
+        ]);
     } catch {
         // noop
         return;
+    } finally {
+        clearTimeout(timer);
     }
 
     if (latestVersion && currVersion && semver.gt(latestVersion, currVersion)) {

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -117,5 +117,14 @@ export async function createProject(
 
 export function runCli(command: string, cwd: string) {
     const cli = path.join(__dirname, '../dist/index.mjs');
-    execSync(`node ${cli} ${command}`, { cwd });
+    try {
+        return execSync(`node ${cli} ${command}`, { cwd, encoding: 'utf8' });
+    } catch (err: any) {
+        // surface the child's output in the test log — without this, CLI failures show up
+        // as bare assertion errors with no clue about what the CLI actually did
+        console.error(`[runCli] "${command}" failed in ${cwd} (status=${err.status}, signal=${err.signal})`);
+        console.error(`[runCli] stdout:\n${err.stdout}`);
+        console.error(`[runCli] stderr:\n${err.stderr}`);
+        throw err;
+    }
 }


### PR DESCRIPTION
## What

Fixes the intermittent CI failures where a random `packages/cli` test fails with "output file missing after a successful CLI run" (recently hit #2744's CI repeatedly, and reproduces on `main`).

## Root cause

Every `zen` command awaits `checkNewVersion()` in a commander `preAction` hook, which fetches `registry.npmjs.org` with `AbortSignal.timeout(2000)`. If the connection stalls in a way that strands the fetch promise with **no active handle**, nothing keeps the event loop alive — `AbortSignal.timeout`'s internal timer is unref'd — so node **exits with code 0 mid-command**, before the action runs. The caller sees success; nothing was done.

On CI this struck ~1 in 100–300 invocations. With ~360 CLI invocations per Build-and-Test run, most runs failed — each time in whatever random test the stall struck (observed across `generate`, `db push`, `db pull`, `migrate`, on both sqlite and mysql matrix jobs, and even once in a sample-app build step).

## Evidence

Diagnosed on throwaway draft PR #2766 by instrumenting the CLI. Failing invocations show exactly:

```
[zen-diag] main start pid=... argv=db push
[zen-diag] checkNewVersion start
[zen-diag] beforeExit fired! code=0 — event loop drained mid-execution
```

(`beforeExit` fires only on natural event-loop drain, never on `process.exit` — proving the stranded await.)

## Fix

Race the fetch against a **ref'd, always-settling** timer (cleared in `finally`). The timer keeps the event loop alive and guarantees the await settles into the existing `catch`. A noop `.catch` on the losing fetch promise avoids unhandled rejections in long-lived modes (watch/proxy/studio).

Also hardens `runCli` in the CLI test harness to print the child's stdout/stderr on failure, so future failures of this kind are self-diagnosing instead of bare `expected false to be true` assertions.

## Verification

Verified on #2766 (same fix, plus instrumentation): **3 consecutive green Build-and-Test runs** with the version check still enabled (~1000+ exercised invocations, zero drain-exits), versus 5-of-6 runs failing before the fix.

Possible follow-up (not in this PR): pass `--no-version-check` from the CLI test harness so CI doesn't depend on npm-registry health at all — needs the option added to every command first, since it's currently per-command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version checks now time out promptly when the update service is slow or unavailable, allowing the CLI to continue without hanging.

* **Tests**
  * Improved CLI test diagnostics by including the command, working directory, exit details, and captured output when execution fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->