### PR TITLE
fix(sdk): unnamed relation resolving to the wrong opposite field

### DIFF
--- a/packages/sdk/src/ts-schema-generator.ts
+++ b/packages/sdk/src/ts-schema-generator.ts
@@ -1074,13 +1074,10 @@ export class TsSchemaGenerator {
                 continue;
             }
             if (otherField.type.reference?.ref === sourceModel) {
-                if (relationName) {
-                    // if relation has a name, the opposite side must match
-                    const otherRelationName = this.getRelationName(otherField);
-                    if (otherRelationName === relationName) {
-                        return otherField;
-                    }
-                } else {
+                // relation names must match on both sides, including the case where neither side
+                // is named - otherwise an unnamed relation can be paired with a named one that
+                // happens to be declared first
+                if (this.getRelationName(otherField) === relationName) {
                     return otherField;
                 }
             }

--- a/tests/e2e/github-repos/trigger.dev/schema.ts
+++ b/tests/e2e/github-repos/trigger.dev/schema.ts
@@ -1028,7 +1028,7 @@ export class SchemaType implements SchemaDef {
                     name: "workerGroups",
                     type: "WorkerInstanceGroup",
                     array: true,
-                    relation: { opposite: "defaultForProjects" }
+                    relation: { opposite: "project" }
                 },
                 workers: {
                     name: "workers",

--- a/tests/regression/test/issue-2757.test.ts
+++ b/tests/regression/test/issue-2757.test.ts
@@ -1,0 +1,94 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+describe('Regression for issue 2757', () => {
+    it('resolves the correct opposite field when only one of two relation pairs is named', async () => {
+        const db = await createTestClient(
+            `
+model Category {
+    id       String    @id @default(cuid())
+    products Product[]                       // unnamed - opposite should be Product.category
+    featured Product[] @relation("Featured")
+}
+
+model Product {
+    id           String    @id @default(cuid())
+    category     Category  @relation(fields: [categoryId], references: [id])
+    categoryId   String
+    featuredIn   Category? @relation("Featured", fields: [featuredInId], references: [id])
+    featuredInId String?
+}
+            `,
+        );
+
+        const c1 = await db.category.create({ data: {} });
+        const c2 = await db.category.create({ data: {} });
+
+        // p1 belongs to c1, and is featured in c2
+        await db.product.create({
+            data: { id: 'p1', category: { connect: { id: c1.id } }, featuredIn: { connect: { id: c2.id } } },
+        });
+
+        // nested read traverses the right column
+        await expect(db.category.findUnique({ where: { id: c1.id }, include: { products: true } })).resolves.toMatchObject(
+            { products: [expect.objectContaining({ id: 'p1' })] },
+        );
+        await expect(db.category.findUnique({ where: { id: c1.id }, include: { featured: true } })).resolves.toMatchObject(
+            { featured: [] },
+        );
+        await expect(db.category.findUnique({ where: { id: c2.id }, include: { products: true } })).resolves.toMatchObject(
+            { products: [] },
+        );
+        await expect(db.category.findUnique({ where: { id: c2.id }, include: { featured: true } })).resolves.toMatchObject(
+            { featured: [expect.objectContaining({ id: 'p1' })] },
+        );
+
+        // relation filters traverse the right column
+        await expect(db.category.findMany({ where: { products: { none: {} } } })).resolves.toEqual([
+            expect.objectContaining({ id: c2.id }),
+        ]);
+        await expect(db.category.findMany({ where: { products: { some: {} } } })).resolves.toEqual([
+            expect.objectContaining({ id: c1.id }),
+        ]);
+        await expect(db.category.findMany({ where: { featured: { none: {} } } })).resolves.toEqual([
+            expect.objectContaining({ id: c1.id }),
+        ]);
+        await expect(db.category.findMany({ where: { featured: { some: {} } } })).resolves.toEqual([
+            expect.objectContaining({ id: c2.id }),
+        ]);
+    });
+
+    it('resolves the correct opposite field when the named relation is declared first', async () => {
+        const db = await createTestClient(
+            `
+model Category {
+    id       String    @id @default(cuid())
+    featured Product[] @relation("Featured")
+    products Product[]
+}
+
+model Product {
+    id           String    @id @default(cuid())
+    featuredIn   Category? @relation("Featured", fields: [featuredInId], references: [id])
+    featuredInId String?
+    category     Category  @relation(fields: [categoryId], references: [id])
+    categoryId   String
+}
+            `,
+        );
+
+        const c1 = await db.category.create({ data: {} });
+        const c2 = await db.category.create({ data: {} });
+
+        await db.product.create({
+            data: { id: 'p1', category: { connect: { id: c1.id } }, featuredIn: { connect: { id: c2.id } } },
+        });
+
+        await expect(db.category.findMany({ where: { products: { some: {} } } })).resolves.toEqual([
+            expect.objectContaining({ id: c1.id }),
+        ]);
+        await expect(db.category.findMany({ where: { featured: { some: {} } } })).resolves.toEqual([
+            expect.objectContaining({ id: c2.id }),
+        ]);
+    });
+});


### PR DESCRIPTION
Fixes #2757

## Problem

When two relations connect the same pair of models and only one pair carries `@relation("name")`, the **unnamed** pair could resolve to the **named** pair's field. The generated schema then had e.g. `Category.products.relation.opposite = "featuredIn"`, so relation filters (`some`/`none`/`every`) and nested reads traversed the wrong FK column and silently returned wrong results — no error, types still compile. Prisma resolves the same schema correctly.

```zmodel
model Category {
  id       String    @id @default(cuid())
  products Product[]                       // opposite should be Product.category
  featured Product[] @relation("Featured")
}

model Product {
  id           String    @id @default(cuid())
  featuredIn   Category? @relation("Featured", fields: [featuredInId], references: [id])
  featuredInId String?
  category     Category  @relation(fields: [categoryId], references: [id])
  categoryId   String
}
```

`category.findMany({ where: { products: { none: {} } } })` joined on `featuredInId` instead of `categoryId`.

## Cause

`TsSchemaGenerator.getOppositeRelationField` matched relation names asymmetrically — a *named* field required a name match, but an *unnamed* field returned the first back-pointing field regardless of its relation name. Resolution therefore depended on field declaration order, which is exactly the ordering sensitivity the reporter observed.

## Fix

Require the relation name to match on both sides, including the case where neither side is named. This is the same rule the language validator already applies when pairing relation fields (`datamodel-validator.ts`), so the generator and validation now agree, and declaration order no longer matters. Schemas that name only one side are already rejected by validation, so nothing that previously validated changes meaning.

Nothing else computes the opposite field — the ORM runtime only reads `relation.opposite` from the generated schema.

## Verification

- New regression test `tests/regression/test/issue-2757.test.ts` covers both declaration orders, nested reads, and `some`/`none` filters on both sides. The "named relation declared first" case failed before this change.
- Full regression suite: 154 files / 213 tests passed (18 pre-existing skips).
- e2e ORM suite: 122 files / 1039 tests passed.
- Regenerating the checked-in e2e schemas changed exactly one file, and it is a genuine instance of this bug in the wild: trigger.dev's `Project.workerGroups` resolved to `defaultForProjects` (the `@relation("ProjectDefaultWorkerGroup")` pair) and now correctly resolves to `WorkerInstanceGroup.project`, the field carrying `projectId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected relationship mapping when named and unnamed relationships are used together.
  * Fixed generated relationship metadata so bidirectional links resolve to the correct fields.
  * Nested reads and relationship filters now return accurate results for models with multiple relationships.

* **Tests**
  * Added regression coverage for relationship traversal, filtering, and nested data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->