### PR TITLE
fix(language): allow @db.TinyInt on Boolean fields

### DIFF
--- a/packages/language/res/stdlib.zmodel
+++ b/packages/language/res/stdlib.zmodel
@@ -464,7 +464,7 @@ attribute @db.UnsignedInt() @@@targetField([IntField]) @@@prisma
 attribute @db.UnsignedSmallInt() @@@targetField([IntField]) @@@prisma
 attribute @db.MediumInt() @@@targetField([IntField]) @@@prisma
 attribute @db.UnsignedMediumInt() @@@targetField([IntField]) @@@prisma
-attribute @db.TinyInt(_ length: Int?) @@@targetField([IntField]) @@@prisma
+attribute @db.TinyInt(_ length: Int?) @@@targetField([IntField, BooleanField]) @@@prisma
 attribute @db.UnsignedTinyInt(_ length: Int?) @@@targetField([IntField]) @@@prisma
 attribute @db.Year() @@@targetField([IntField]) @@@prisma
 


### PR DESCRIPTION
Fixes #2758

## Problem

On the MySQL connector, Prisma's canonical native type for `Boolean` is `@db.TinyInt(1)`, and Prisma *rejects* `@db.Boolean` there (`P1012: Native type Boolean is not supported for mysql connector`). ZModel had the restriction inverted — the stdlib declared `@db.TinyInt` with `@@@targetField([IntField])`, so it could not be applied to `Boolean` fields:

```zmodel
model M {
    id Int     @id
    b  Boolean @db.TinyInt(1) // ZModel error: attribute "@db.TinyInt" cannot be used on this type of field
}
```

That made the MySQL Boolean native type inexpressible in the ZModel/Prisma common subset, breaking ports of Prisma schemas using `Boolean @db.TinyInt(1)` — the shape `prisma db pull` emits.

## Fix

Add `BooleanField` to the `@@@targetField` list of `@db.TinyInt` in `packages/language/res/stdlib.zmodel`, matching Prisma's MySQL connector. `@db.Bit` already targets `BooleanField`, so this brings `TinyInt` in line.

The default `Boolean` → `tinyint(1)` mapping (no native type attribute) is unaffected and already matches Prisma. `@db.UnsignedTinyInt` is intentionally left `IntField`-only, as Prisma does not accept it for `Boolean`.

## Verification

- `Boolean @db.TinyInt(1)` on a `mysql` datasource now loads without error; `Int @db.TinyInt` still loads; `String @db.TinyInt` is still rejected.
- The attribute carries through to the generated Prisma schema as `@db.TinyInt(1)` (native type attributes are passed through generically, no other code paths reference `TinyInt`).
- Language suite: 10 files / 90 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `@db.TinyInt` attribute can now be applied to Boolean fields in addition to integer fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->