### PR TITLE
fix(orm): to-one relation filter missing delegate base join

### DIFF
--- a/packages/orm/src/client/crud/dialects/base-dialect.ts
+++ b/packages/orm/src/client/crud/dialects/base-dialect.ts
@@ -387,8 +387,9 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
             field,
             joinAlias,
         );
-        const baseJoin = this.eb
-            .selectFrom(`${fieldDef.type} as ${joinAlias}`)
+        // use `buildSelectModel` so that delegate base tables are joined - the filter may
+        // reference fields inherited from a base, which live on the base table
+        const baseJoin = this.buildSelectModel(fieldDef.type, joinAlias)
             .select(this.eb.lit(1).as('_'))
             .where(() =>
                 this.and(...joinPairs.map(([left, right]) => this.eb(this.eb.ref(left), '=', this.eb.ref(right)))),

--- a/tests/regression/test/issue-2768.test.ts
+++ b/tests/regression/test/issue-2768.test.ts
@@ -1,0 +1,94 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+const schema = `
+model Location {
+    id        String     @id @default(cuid())
+    name      String
+    resources Resource[]
+}
+
+enum ResourceType {
+    DESK
+}
+
+model Resource {
+    id         String       @id @default(cuid())
+    name       String
+    type       ResourceType
+    locationId String
+    location   Location     @relation(fields: [locationId], references: [id], onDelete: Cascade)
+
+    @@delegate(type)
+}
+
+model ResourceDesk extends Resource {
+    employeeDeskSessions EmployeeDeskSession[]
+
+    @@delegateMap(DESK)
+}
+
+model EmployeeDeskSession {
+    id     String       @id @default(cuid())
+    deskId String
+    desk   ResourceDesk @relation(fields: [deskId], references: [id], onDelete: Cascade)
+}
+`;
+
+describe('Regression for issue 2768', () => {
+    async function createData() {
+        const db = await createTestClient(schema);
+
+        const l1 = await db.location.create({ data: { id: 'l1', name: 'l1' } });
+        const l2 = await db.location.create({ data: { id: 'l2', name: 'l2' } });
+
+        const desk1 = await db.resourceDesk.create({ data: { name: 'desk1', locationId: l1.id } });
+        const desk2 = await db.resourceDesk.create({ data: { name: 'desk2', locationId: l2.id } });
+
+        await db.employeeDeskSession.create({ data: { id: 's1', deskId: desk1.id } });
+        await db.employeeDeskSession.create({ data: { id: 's2', deskId: desk2.id } });
+
+        return db;
+    }
+
+    it('filters a to-one relation by a base-model foreign key field', async () => {
+        const db = await createData();
+        await expect(db.employeeDeskSession.findMany({ where: { desk: { locationId: 'l1' } } })).resolves.toEqual([
+            expect.objectContaining({ id: 's1' }),
+        ]);
+    });
+
+    it('filters a to-one relation by a base-model scalar field', async () => {
+        const db = await createData();
+        await expect(
+            db.employeeDeskSession.findMany({ where: { desk: { name: { startsWith: 'desk1' } } } }),
+        ).resolves.toEqual([expect.objectContaining({ id: 's1' })]);
+    });
+
+    it('filters a to-one relation by a base-model relation', async () => {
+        const db = await createData();
+        await expect(
+            db.employeeDeskSession.findMany({ where: { desk: { location: { name: 'l2' } } } }),
+        ).resolves.toEqual([expect.objectContaining({ id: 's2' })]);
+    });
+
+    it('filters a to-many relation by a field inherited from the delegate base', async () => {
+        const db = await createTestClient(schema);
+
+        const l1 = await db.location.create({ data: { name: 'l1' } });
+        const l2 = await db.location.create({ data: { name: 'l2' } });
+
+        const desk1 = await db.resourceDesk.create({ data: { name: 'desk1', locationId: l1.id } });
+        await db.resourceDesk.create({ data: { name: 'desk2', locationId: l2.id } });
+
+        await db.employeeDeskSession.create({ data: { id: 's1', deskId: desk1.id } });
+
+        await expect(
+            db.location.findMany({ where: { resources: { some: { name: 'desk1' } } } }),
+        ).resolves.toEqual([expect.objectContaining({ id: l1.id })]);
+
+        await expect(
+            db.location.findMany({ where: { resources: { none: { name: 'desk1' } } } }),
+        ).resolves.toEqual([expect.objectContaining({ id: l2.id })]);
+    });
+});


### PR DESCRIPTION
Fixes #2768

## Problem

Filtering a to-one relation whose target is a polymorphic subtype, by a field inherited from the delegate base, failed at the database:

```
error: missing FROM-clause entry for table "Resource"   // Postgres
no such column: Resource.locationId                     // SQLite
```

```ts
await db.employeeDeskSession.findMany({
  where: { desk: { locationId } },   // `desk` is a ResourceDesk; `locationId` lives on the Resource base
});
```

The generated SQL referenced the base table without joining it:

```sql
where exists (
  select 1 from "ResourceDesk" as "$$t1"
  where "$$t1"."id" = "EmployeeDeskSession"."deskId"
    and "Resource"."locationId" = ?   -- ❌ "Resource" is not in the FROM clause
)
```

## Cause

`BaseCrudDialect.buildToOneRelationFilter` built its `exists` subquery with a bare `selectFrom` on the concrete model, so delegate base tables were never joined. `buildFilter` references base-inherited fields through `fieldDef.originModel` — qualified with the base model name — hence the dangling reference.

`buildToManyRelationFilter` already used `buildSelectModel`, which joins all delegate bases. That asymmetry is why `some`/`none` filters worked while the to-one form didn't.

## Fix

Use `buildSelectModel` in the to-one path as well.

```diff
-const baseJoin = this.eb
-    .selectFrom(`${fieldDef.type} as ${joinAlias}`)
+const baseJoin = this.buildSelectModel(fieldDef.type, joinAlias)
     .select(this.eb.lit(1).as('_'))
```

## Verification

- New regression test `tests/regression/test/issue-2768.test.ts` — 4 cases. The three to-one cases (base FK field, base scalar with `startsWith`, base relation) each failed before this change; the to-many case is included to lock in the path that already worked.
- Full regression suite: 154 files / 215 tests passed.
- e2e ORM suite: 126 files / 1042 tests passed, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering for relationships involving delegated models.
  * Ensured filters work correctly with inherited fields, scalar values, and nested relationships.
  * Corrected filtering for delegated one-to-many relationships using `some` and `none` conditions.

* **Tests**
  * Added regression coverage for delegated relationship filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->