### PR TITLE
fix(orm): enum field filter inside typed JSON compared as raw JSON

### DIFF
--- a/packages/orm/src/client/crud/dialects/base-dialect.ts
+++ b/packages/orm/src/client/crud/dialects/base-dialect.ts
@@ -814,8 +814,8 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
                         clauses.push(this.buildArrayFilter(fieldReceiver, fieldDef, value));
                     } else {
                         let _receiver = fieldReceiver;
-                        if (fieldDef.type === 'String') {
-                            // trim quotes for string fields
+                        if (fieldDef.type === 'String' || isEnum(this.schema, fieldDef.type)) {
+                            // trim quotes for string and enum fields (enums are stored as JSON strings)
                             _receiver = this.trimTextQuotes(this.castText(fieldReceiver));
                         }
                         clauses.push(this.buildPrimitiveFilter(_receiver, fieldDef, value));

--- a/tests/regression/test/issue-2755.test.ts
+++ b/tests/regression/test/issue-2755.test.ts
@@ -1,0 +1,57 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2755
+describe('Regression for issue 2755', () => {
+    it.each(['sqlite', 'postgresql'] as const)(
+        'supports filtering by enum fields in typed JSON (%s)',
+        async (provider) => {
+            const schema = `
+enum BKPType {
+    CAPSTONE
+    OTHER
+}
+
+type BKPProposal {
+    name    String
+    bkpType BKPType?
+}
+
+model BKP {
+    id       String      @id @default(cuid())
+    proposal BKPProposal @json
+}
+`;
+
+            const db = await createTestClient(schema, { provider });
+
+            await db.bKP.create({
+                data: { id: '1', proposal: { name: 'p1', bkpType: 'CAPSTONE' } },
+            });
+            await db.bKP.create({
+                data: { id: '2', proposal: { name: 'p2', bkpType: 'OTHER' } },
+            });
+            await db.bKP.create({
+                data: { id: '3', proposal: { name: 'p3' } },
+            });
+
+            await expect(
+                db.bKP.findMany({
+                    where: { proposal: { bkpType: 'CAPSTONE' } },
+                }),
+            ).resolves.toEqual([expect.objectContaining({ id: '1' })]);
+
+            await expect(
+                db.bKP.findMany({
+                    where: { proposal: { bkpType: { not: 'CAPSTONE' } } },
+                }),
+            ).resolves.toEqual([expect.objectContaining({ id: '2' })]);
+
+            await expect(
+                db.bKP.findMany({
+                    where: { proposal: { bkpType: { in: ['CAPSTONE', 'OTHER'] } } },
+                }),
+            ).resolves.toEqual([expect.objectContaining({ id: '1' }), expect.objectContaining({ id: '2' })]);
+        },
+    );
+});


### PR DESCRIPTION
Fixes #2755

## Problem

Filtering by an enum-typed field inside a typed JSON field failed:

```ts
db.bKP.findMany({ where: { proposal: { bkpType: 'CAPSTONE' } } });
```

On PostgreSQL this threw `invalid input syntax for type json` (the JSON-extracted value was compared directly against the bare enum literal), and on SQLite it silently matched nothing (quoted JSON text `"CAPSTONE"` never equals `CAPSTONE`).

## Fix

In `buildTypeJsonNonArrayFilter`, the cast-to-text + quote-trim treatment applied to `String` fields is extended to enum fields, since enum values are stored as JSON strings. The comparison then flows through `buildEnumFilter` on a plain-text receiver, covering `equals`, `not`, `in`, and `notIn`.

## Testing

- New regression test `tests/regression/test/issue-2755.test.ts` covering direct equality, `not`, and `in` filters on both SQLite and PostgreSQL (failed with the issue's exact error before the fix).
- Existing e2e suites `json-filter.test.ts` and `typed-json-fields.test.ts` pass on both SQLite and PostgreSQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON filtering for enum values.
  * Fixed equality, negation, and inclusion filters for enums stored inside JSON fields across SQLite and PostgreSQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->