### PR TITLE
perf(orm): reuse QueryNameMapper across derived executors and clients

### DIFF
--- a/packages/orm/src/client/client-impl.ts
+++ b/packages/orm/src/client/client-impl.ts
@@ -51,6 +51,13 @@ type ExtResultFieldDef = {
 };
 
 /**
+ * Returns the name mapper held by a ZenStack executor, or undefined for a plain kysely one.
+ */
+function getExecutorNameMapper(executor: QueryExecutor | undefined) {
+    return executor instanceof ZenStackQueryExecutor ? executor.getNameMapper() : undefined;
+}
+
+/**
  * ZenStack ORM client.
  */
 export const ZenStackClient = function <Schema extends SchemaDef>(
@@ -99,6 +106,16 @@ export class ClientImpl {
                         baseClient.kyselyProps.dialect.createQueryCompiler(),
                         baseClient.kyselyProps.dialect.createAdapter(),
                         new DefaultConnectionProvider(baseClient.kyselyProps.driver),
+                        [],
+                        false,
+                        // A name mapper is derived purely from `$schema` and `$options`, so it can be
+                        // reused when neither changed - which is the case for derived clients like the
+                        // one `$transaction` creates. Rebuilding it is O(models x fields). See #2773.
+                        // Deliberately an identity check: `$use`/`$setOptions` and friends pass a new
+                        // options object, and the mapper's dialect is built from those options.
+                        baseClient.$schema === schema && baseClient.$options === options
+                            ? getExecutorNameMapper(baseClient.kyselyProps.executor)
+                            : undefined,
                     ),
             };
             this.kyselyRaw = baseClient.kyselyRaw;

--- a/packages/orm/src/client/executor/zenstack-query-executor.ts
+++ b/packages/orm/src/client/executor/zenstack-query-executor.ts
@@ -86,17 +86,30 @@ export class ZenStackQueryExecutor extends DefaultQueryExecutor {
         private readonly connectionProvider: ConnectionProvider,
         plugins: KyselyPlugin[] = [],
         private suppressMutationHooks: boolean = false,
+        nameMapper?: QueryNameMapper,
     ) {
         super(compiler, adapter, connectionProvider, plugins);
 
-        if (
-            client.$schema.provider.type === 'postgresql' || // postgres queries need to be schema-qualified
+        // A `QueryNameMapper` is derived purely from the client's `$schema` and `$options`, and building
+        // it is O(models x fields) (plus an O(models x relations) pass for postgres). Reuse the one from
+        // the executor/client we're derived from when it was built from the same schema and options,
+        // otherwise every derived executor rebuilds whole-schema state. See issue #2773.
+        this.nameMapper =
+            nameMapper ??
+            (client.$schema.provider.type === 'postgresql' || // postgres queries need to be schema-qualified
             this.schemaHasMappedNames(client.$schema)
-        ) {
-            this.nameMapper = new QueryNameMapper(client as unknown as ClientContract<SchemaDef>);
-        }
+                ? new QueryNameMapper(client as unknown as ClientContract<SchemaDef>)
+                : undefined);
 
         this.dialect = getCrudDialect(client.$schema, client.$options);
+    }
+
+    /**
+     * The name mapper built for this executor's schema, if the schema needs one. Exposed so that
+     * derived clients built from the same schema and options can reuse it instead of rebuilding it.
+     */
+    getNameMapper() {
+        return this.nameMapper;
     }
 
     private schemaHasMappedNames(schema: SchemaDef) {
@@ -770,6 +783,7 @@ In such cases, ZenStack cannot reliably determine the IDs of the mutated entitie
             this.connectionProvider,
             [...this.plugins, plugin],
             this.suppressMutationHooks,
+            this.nameMapper,
         );
     }
 
@@ -782,6 +796,7 @@ In such cases, ZenStack cannot reliably determine the IDs of the mutated entitie
             this.connectionProvider,
             [...this.plugins, ...plugins],
             this.suppressMutationHooks,
+            this.nameMapper,
         );
     }
 
@@ -794,6 +809,7 @@ In such cases, ZenStack cannot reliably determine the IDs of the mutated entitie
             this.connectionProvider,
             [plugin, ...this.plugins],
             this.suppressMutationHooks,
+            this.nameMapper,
         );
     }
 
@@ -806,6 +822,7 @@ In such cases, ZenStack cannot reliably determine the IDs of the mutated entitie
             this.connectionProvider,
             [],
             this.suppressMutationHooks,
+            this.nameMapper,
         );
     }
 
@@ -818,6 +835,7 @@ In such cases, ZenStack cannot reliably determine the IDs of the mutated entitie
             connectionProvider,
             this.plugins as KyselyPlugin[],
             this.suppressMutationHooks,
+            this.nameMapper,
         );
         // replace client with a new one associated with the new executor
         newExecutor.client = this.client.withExecutor(newExecutor);

--- a/packages/orm/src/client/executor/zenstack-query-executor.ts
+++ b/packages/orm/src/client/executor/zenstack-query-executor.ts
@@ -1,5 +1,5 @@
 import { invariant } from '@zenstackhq/common-helpers';
-import type { ModelDef, SchemaDef, TypeDefDef } from '@zenstackhq/schema';
+import type { SchemaDef } from '@zenstackhq/schema';
 import type { QueryId } from 'kysely';
 import {
     AndNode,
@@ -37,7 +37,7 @@ import { getCrudDialect } from '../crud/dialects';
 import type { BaseCrudDialect } from '../crud/dialects/base-dialect';
 import { createDBQueryError, createInternalError, ORMError } from '../errors';
 import type { AfterEntityMutationCallback, OnKyselyQueryCallback } from '../plugin';
-import { requireIdFields, stripAlias } from '../query-utils';
+import { requireIdFields, schemaHasMappedNames, stripAlias } from '../query-utils';
 import { QueryNameMapper } from './name-mapper';
 import { TempAliasTransformer } from './temp-alias-transformer';
 import type { ZenStackDriver } from './zenstack-driver';
@@ -97,7 +97,7 @@ export class ZenStackQueryExecutor extends DefaultQueryExecutor {
         this.nameMapper =
             nameMapper ??
             (client.$schema.provider.type === 'postgresql' || // postgres queries need to be schema-qualified
-            this.schemaHasMappedNames(client.$schema)
+            schemaHasMappedNames(client.$schema)
                 ? new QueryNameMapper(client as unknown as ClientContract<SchemaDef>)
                 : undefined);
 
@@ -110,17 +110,6 @@ export class ZenStackQueryExecutor extends DefaultQueryExecutor {
      */
     getNameMapper() {
         return this.nameMapper;
-    }
-
-    private schemaHasMappedNames(schema: SchemaDef) {
-        const hasMapAttr = (decl: ModelDef | TypeDefDef) => {
-            if (decl.attributes?.some((attr) => attr.name === '@@map')) {
-                return true;
-            }
-            return Object.values(decl.fields).some((field) => field.attributes?.some((attr) => attr.name === '@map'));
-        };
-
-        return Object.values(schema.models).some(hasMapAttr) || Object.values(schema.typeDefs ?? []).some(hasMapAttr);
     }
 
     private get kysely() {

--- a/packages/orm/src/client/query-utils.ts
+++ b/packages/orm/src/client/query-utils.ts
@@ -1,5 +1,12 @@
 import { invariant } from '@zenstackhq/common-helpers';
-import { ExpressionUtils, type FieldDef, type GetModels, type ModelDef, type SchemaDef } from '@zenstackhq/schema';
+import {
+    ExpressionUtils,
+    type FieldDef,
+    type GetModels,
+    type ModelDef,
+    type SchemaDef,
+    type TypeDefDef,
+} from '@zenstackhq/schema';
 import {
     AliasNode,
     ColumnNode,
@@ -30,6 +37,7 @@ interface SchemaLookupCache {
     model: Map<string, ModelDef | undefined>;
     m2mRelation: Map<string, ReturnType<typeof computeManyToManyRelation>>;
     m2mJoinTable?: Map<string, ManyToManyJoinTableEndpoints | undefined>;
+    hasMappedNames?: boolean;
 }
 
 const schemaLookupCache = new WeakMap<SchemaDef, SchemaLookupCache>();
@@ -56,6 +64,26 @@ export function getModel(schema: SchemaDef, model: string) {
 
 export function getTypeDef(schema: SchemaDef, type: string) {
     return schema.typeDefs?.[type];
+}
+
+/**
+ * Whether any model, type def, or field in the schema carries `@@map`/`@map`. Answering it walks
+ * every model and field, and it is asked once per query-executor construction, so the (immutable)
+ * answer is memoized per schema alongside the other structural lookups. See issue #2773.
+ */
+export function schemaHasMappedNames(schema: SchemaDef) {
+    const cache = getSchemaLookupCache(schema);
+    if (cache.hasMappedNames === undefined) {
+        const hasMapAttr = (decl: ModelDef | TypeDefDef) => {
+            if (decl.attributes?.some((attr) => attr.name === '@@map')) {
+                return true;
+            }
+            return Object.values(decl.fields).some((field) => field.attributes?.some((attr) => attr.name === '@map'));
+        };
+        cache.hasMappedNames =
+            Object.values(schema.models).some(hasMapAttr) || Object.values(schema.typeDefs ?? []).some(hasMapAttr);
+    }
+    return cache.hasMappedNames;
 }
 
 export function requireModel(schema: SchemaDef, model: string) {

--- a/packages/orm/src/client/query-utils.ts
+++ b/packages/orm/src/client/query-utils.ts
@@ -1,5 +1,6 @@
 import { invariant } from '@zenstackhq/common-helpers';
 import {
+    type EnumDef,
     ExpressionUtils,
     type FieldDef,
     type GetModels,
@@ -74,14 +75,20 @@ export function getTypeDef(schema: SchemaDef, type: string) {
 export function schemaHasMappedNames(schema: SchemaDef) {
     const cache = getSchemaLookupCache(schema);
     if (cache.hasMappedNames === undefined) {
-        const hasMapAttr = (decl: ModelDef | TypeDefDef) => {
+        // `fields` is optional on `EnumDef` (required on the other two), hence the `?? {}`.
+        const hasMapAttr = (decl: ModelDef | TypeDefDef | EnumDef) => {
             if (decl.attributes?.some((attr) => attr.name === '@@map')) {
                 return true;
             }
-            return Object.values(decl.fields).some((field) => field.attributes?.some((attr) => attr.name === '@map'));
+            return Object.values(decl.fields ?? {}).some((field) =>
+                field.attributes?.some((attr) => attr.name === '@map'),
+            );
         };
         cache.hasMappedNames =
-            Object.values(schema.models).some(hasMapAttr) || Object.values(schema.typeDefs ?? []).some(hasMapAttr);
+            Object.values(schema.models).some(hasMapAttr) ||
+            Object.values(schema.typeDefs ?? {}).some(hasMapAttr) ||
+            // Enums carry name mapping too — `@@map` on the enum and `@map` on its members.
+            Object.values(schema.enums ?? {}).some(hasMapAttr);
     }
     return cache.hasMappedNames;
 }

--- a/tests/regression/test/issue-2773.test.ts
+++ b/tests/regression/test/issue-2773.test.ts
@@ -63,6 +63,31 @@ describe('Regression for issue #2773', () => {
         expect(nameMapperOf(derived)).not.toBe(mapper);
     });
 
+    it('keeps working when the schema needs no mapper at all', async () => {
+        // sqlite + no @@map/@map means nameMapper stays undefined. Deciding that walks every model
+        // and field, and it is asked on every executor construction, so it is memoized per schema -
+        // this guards the path where nothing is threaded through.
+        const db = await createTestClient(
+            `
+model Item {
+    id   Int    @id @default(autoincrement())
+    name String
+}
+            `,
+            { provider: 'sqlite' },
+        )
+        expect(nameMapperOf(db)).toBeUndefined();
+
+        await db.item.create({ data: { name: 'a' } });
+        const outside = await db.item.findMany();
+        expect(outside).toHaveLength(1);
+
+        await db.$transaction(async (tx: any) => {
+            expect(nameMapperOf(tx)).toBeUndefined();
+            expect(await tx.item.findMany()).toHaveLength(1);
+        });
+    });
+
     it('applies @@map and @map identically inside and outside a transaction', async () => {
         const db = await createTestClient(schema, { provider: 'postgresql' });
         await db.post.create({ data: { title: 'hello' } });

--- a/tests/regression/test/issue-2773.test.ts
+++ b/tests/regression/test/issue-2773.test.ts
@@ -1,0 +1,85 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2773
+//
+// `QueryNameMapper` is derived purely from the client's `$schema` and `$options`, but it was rebuilt
+// for every derived executor/client. Building it is O(models x fields), plus an O(models x relations)
+// pass on postgres, so on a large schema every `$transaction` paid that cost twice - once when
+// `$transaction` derives a client, and once when the query derives a connection-scoped executor.
+//
+// These assert the invariant (the mapper is not rebuilt) rather than elapsed time, which would be
+// both flaky and only an indirect proxy for it.
+
+const schema = `
+model Post {
+    id    Int    @id @default(autoincrement())
+    title String @map("post_title")
+
+    @@map("posts_table")
+}
+`;
+
+// Note: inside a transaction `$qb.getExecutor()` is kysely's own wrapping executor, so we read the
+// ZenStack executor the client itself was built with. We read the underlying field rather than the
+// accessor so that these assertions fail on a mapper-identity mismatch - the actual defect - rather
+// than on a missing method.
+function nameMapperOf(client: any) {
+    return client.kyselyProps.executor.nameMapper;
+}
+
+describe('Regression for issue #2773', () => {
+    it('reuses the name mapper for the client derived by $transaction', async () => {
+        const db = await createTestClient(schema, { provider: 'postgresql' });
+        const mapper = nameMapperOf(db);
+        expect(mapper).toBeDefined();
+
+        await db.$transaction(async (tx: any) => {
+            expect(nameMapperOf(tx)).toBe(mapper);
+        });
+    });
+
+    it('reuses the name mapper for connection-scoped and plugin-derived executors', async () => {
+        const db = await createTestClient(schema, { provider: 'postgresql' });
+        const executor = (db as any).kyselyProps.executor;
+        const mapper = executor.nameMapper;
+        expect(mapper).toBeDefined();
+
+        expect(executor.withoutPlugins().nameMapper).toBe(mapper);
+        expect(executor.withPlugin({}).nameMapper).toBe(mapper);
+        expect(executor.withPluginAtFront({}).nameMapper).toBe(mapper);
+        expect(executor.withPlugins([{}]).nameMapper).toBe(mapper);
+        expect(executor.withConnectionProvider(executor.connectionProvider).nameMapper).toBe(mapper);
+    });
+
+    it('still builds a mapper for a client derived with different options', async () => {
+        const db = await createTestClient(schema, { provider: 'postgresql' });
+        const mapper = nameMapperOf(db);
+
+        // `$use` derives a client with a NEW options object, and the mapper's dialect is built from
+        // options - so this one must not inherit the existing mapper.
+        const derived = db.$use({ id: 'noop', name: 'noop' } as any);
+        expect(nameMapperOf(derived)).toBeDefined();
+        expect(nameMapperOf(derived)).not.toBe(mapper);
+    });
+
+    it('applies @@map and @map identically inside and outside a transaction', async () => {
+        const db = await createTestClient(schema, { provider: 'postgresql' });
+        await db.post.create({ data: { title: 'hello' } });
+
+        const outside = await db.post.findMany();
+        expect(outside).toHaveLength(1);
+        expect(outside[0].title).toBe('hello');
+
+        const inside = await db.$transaction(async (tx: any) => tx.post.findMany());
+        expect(inside).toEqual(outside);
+
+        // the mapped table/column really are what the mapper produced
+        const raw = await db.$qb
+            .selectFrom('posts_table' as any)
+            .selectAll()
+            .execute();
+        expect(raw).toHaveLength(1);
+        expect((raw[0] as any).post_title).toBe('hello');
+    });
+});

--- a/tests/regression/test/issue-2773.test.ts
+++ b/tests/regression/test/issue-2773.test.ts
@@ -75,7 +75,7 @@ model Item {
 }
             `,
             { provider: 'sqlite' },
-        )
+        );
         expect(nameMapperOf(db)).toBeUndefined();
 
         await db.item.create({ data: { name: 'a' } });
@@ -86,6 +86,57 @@ model Item {
             expect(nameMapperOf(tx)).toBeUndefined();
             expect(await tx.item.findMany()).toHaveLength(1);
         });
+    });
+
+    // Enums carry name mapping too, and `schemaHasMappedNames` originally checked only models
+    // and type defs. On postgres the mapper is built unconditionally, which masked it; on any
+    // other provider a schema whose ONLY mapped name is on an enum got no mapper at all.
+    it('builds a mapper for a schema whose only mapped name is on an enum', async () => {
+        const db = await createTestClient(
+            `
+enum Status {
+    ACTIVE
+    ARCHIVED
+
+    @@map('status_enum')
+}
+
+model Item {
+    id     Int    @id @default(autoincrement())
+    name   String
+    status Status @default(ACTIVE)
+}
+            `,
+            { provider: 'sqlite' },
+        );
+
+        expect(nameMapperOf(db)).toBeDefined();
+
+        await db.item.create({ data: { name: 'a' } });
+        expect(await db.item.findMany()).toHaveLength(1);
+    });
+
+    it('builds a mapper for a schema whose only mapped name is on an enum MEMBER', async () => {
+        const db = await createTestClient(
+            `
+enum Status {
+    ACTIVE   @map('is_active')
+    ARCHIVED
+}
+
+model Item {
+    id     Int    @id @default(autoincrement())
+    name   String
+    status Status @default(ACTIVE)
+}
+            `,
+            { provider: 'sqlite' },
+        );
+
+        expect(nameMapperOf(db)).toBeDefined();
+
+        await db.item.create({ data: { name: 'a' } });
+        expect(await db.item.findMany()).toHaveLength(1);
     });
 
     it('applies @@map and @map identically inside and outside a transaction', async () => {


### PR DESCRIPTION
Addresses #2773. Opening this per @ymc9's invitation there ("PR is also welcome if you have time"), so the CONTRIBUTING "discuss first" step is already covered by that issue.

First, a correction to my own issue: **the ~1s figure in #2773 does not apply to `dev`.** That changes what this PR is worth, so it belongs up front. Details under Benchmarks.

## The defect

`QueryNameMapper` is derived purely from the client's `$schema` and `$options`, but it is rebuilt for every derived executor *and* every derived client. Building it walks every model and field, plus an `O(models x relations)` pass on postgres.

A `$transaction` pays that **twice per scope**, through two independent paths. Counted by instrumenting the constructor on `dev`, not inferred from timing:

| | mappers constructed |
| --- | --- |
| outside a transaction | 0 |
| inside `$transaction`, 1 query | **2** |
| inside `$transaction`, 3 queries | **2** |

Per scope, not per query. Stack capture identifies the two paths:

```
path 1:  new ZenStackQueryExecutor @ zenstack-query-executor.ts:96
    <- ZenStackQueryExecutor.withConnectionProvider @ :813

path 2:  new ZenStackQueryExecutor @ zenstack-query-executor.ts:96
    <- new ClientImpl @ client-impl.ts:96
       <- client-impl.ts:264  (interactiveTransaction)
```

Worth flagging because it caught me out: fixing only the executor derive sites addresses path 1 and leaves path 2, which halves the cost rather than removing it.

## The change

**1. Reuse the mapper across derived executors and clients.**

`ZenStackQueryExecutor` takes an optional mapper and threads its own through all five derive sites (`withPlugin`, `withPlugins`, `withPluginAtFront`, `withoutPlugins`, `withConnectionProvider`). All five pass `this.client`, so the schema is identical by construction.

`ClientImpl` passes the base client's mapper only when the derived client has the same `$schema` **and** the same `$options` by identity. That is deliberate: `$use`, `$unuse`, `$unuseAll` and `$setOptions` derive with a *new* options object, and the mapper's dialect comes from `getCrudDialect(schema, options)`, so those still build their own. Verified by counting constructions: `$transaction` and `$setAuth` build 0, `$use` builds 1.

**2. Memoize the "does this schema need a mapper" check.**

Deciding it walks every model and field, and it is asked on every executor construction. It is not short-circuited on non-postgres providers, so a SQLite or MySQL schema with no `@@map`/`@map` paid the full walk per derived executor. The answer is immutable per schema, so it moves next to the other structural lookups in `query-utils.ts` and reuses the per-schema `WeakMap` cache added in 805a6b81 (#2715). That also removes the duplicated `hasMapAttr` helper from the executor.

## Why sharing one instance is safe

This is the part worth your scrutiny, since it is the obvious objection to reusing rather than rebuilding.

`QueryNameMapper` extends `OperationNodeTransformer` and holds one piece of mutable state: `scopes`. If two transforms could interleave, sharing an instance across executors would corrupt it. They cannot:

- `scopes` is pushed and popped in `finally` inside `withScope`/`withScopes`, so it is empty between transforms.
- The class contains **no `async`, `await` or `Promise`**: `rg -n 'async|await|Promise' packages/orm/src/client/executor/name-mapper.ts` returns nothing on `dev`.
- The call site is a plain synchronous `this.nameMapper?.transformNode(query)` (`zenstack-query-executor.ts:647`).

A synchronous traversal with no yield point cannot interleave with another on a single-threaded runtime.

The mapper also reads `client` for exactly two things: `$schema` and `$options`. Neither is connection-scoped, so a shared instance holding a reference to the parent client retains nothing request-specific.

**The caveat, stated plainly:** this holds for the code as it stands. If a plugin or subclass could introduce an `await` inside the traversal, the safe shape would be hoisting the four maps out of the transformer rather than sharing it. I cannot see the plugin contract well enough to rule that out, so I have left it to your judgement rather than assuming.

## Benchmarks

Two builds of the **same commit** (`dev` @ 19f08201), packed with `pnpm pack` and installed via `file:` overrides, so the delta is this change and nothing else:

- **A** — `dev`, unmodified
- **B** — `dev` + this PR

Postgres, 1067 models / 11938 fields, a paginated read plus a follow-up query, medians:

| | A | B | |
| --- | --- | --- | --- |
| no transaction | 2.671 ms | 2.567 ms | unchanged |
| inside `$transaction` (`repeatable read`) | 12.696 ms | **4.045 ms** | **3.1x** |
| `$qb.connection().execute(noop)` — one scope | 3.156 ms | **0.087 ms** | **36x** |
| transaction overhead vs no transaction | 10.024 ms | 1.477 ms | 6.8x less |

The "no transaction" row is the honest frame: outside a transaction nothing changes, because the mapper was already built once per client. The whole gain is that derived clients and executors stop rebuilding whole-schema state.

**Which released version carries the earlier fix, for anyone arriving from #2773.** The correction at the top says the ~1s figure does not apply to `dev`; it is worth pinning where that landed for users on a published version. Measured downstream on the 1067-model schema, upgrading a real monorepo's catalog rather than a packed build:

| | 3.7.2 | 3.9.0 |
| --- | --- | --- |
| bare query (no transaction) | 0.53 ms | 0.54 ms |
| `$transaction { one query }` | 971.42 ms | 9.23 ms |
| `$transaction { empty }` | 971.94 ms | 8.05 ms |

So `805a6b81` (#2715) already removed the bulk in a **published release**, not only on `dev` — 3.9.0 is enough to escape the ~1s floor, and this PR is a further ~3x on top of that rather than the thing that makes transactions usable. The empty-transaction row is the diagnostic: on 3.7.2 it cost the same as one doing real work, so the cost was per-scope setup rather than query execution.

### The gain scales with schema size, and only matters at the large end

Building the mapper is `O(models x fields)` plus the `O(models x relations)` m2m pass on postgres, so what this saves tracks schema size directly. Deriving one client, which is one executor construction, on a postgres schema with mapped names:

| models | A | B | saved per derive |
| --- | --- | --- | --- |
| 25 | 0.105 ms | 0.028 ms | 0.077 ms |
| 100 | 0.229 ms | 0.053 ms | 0.176 ms |
| 400 | 0.943 ms | 0.235 ms | 0.708 ms |
| 1067 | 2.587 ms | 0.617 ms | 1.970 ms |

A transaction scope derives twice, so the per-transaction saving is roughly double the last column.

At 25 models that is about 0.15 ms per transaction, which nobody will notice. At 1067 models it is about 4 ms, which is what the 3.1x above reflects. So this is worth having for users with large schemas and is a rounding error for everyone else. I would rather state that plainly than let the headline multiplier imply a broader win than the change delivers.

Note that B still grows with schema size. Deriving a client is not free after this change either; the PR removes the mapper rebuild specifically, not every per-derive cost.

For change 2, a MySQL client on a 1067-model schema with no mapped names anywhere, timing one client derive (one executor construction, no queries):

| A | B |
| --- | --- |
| 0.678 ms | 0.574 ms |

About 0.104 ms per executor construction, so roughly 0.21 ms per transaction scope. Zero on postgres, which short-circuits that check.

### On the ~1s in #2773

That number was measured on **3.7.2** and is stale for `dev`. `packages/orm/src/client/executor/` is unchanged between `v3.7.2` and `dev`. The collapse came entirely from 805a6b81 ("perf(orm): memoize implicit m2m join-table and model lookups", #2715). It memoized the `getManyToManyRelation` call the mapper constructor makes per model x relation field, and shipped in v3.8.1. So anyone on 3.8.1+ already has the cheap version.

The same harness on 3.7.2 reproduces the original figures within ~5%: 1021 ms in-transaction, 506 ms per scope. That is why I trust the A/B above to be measuring the same thing.

So the cost was largely fixed in June; the structural defect was not. This PR is the remaining 3.1x, not the 80x the issue implies.

## What this does not fix

Two independent clients built over the same schema still build a mapper each. That is outside the scope of #2773 and would need a schema-keyed cache, which raises lifetime questions this change avoids entirely.

## Testing

- `tests/regression/test/issue-2773.test.ts`, 5 tests. They assert mapper identity across the transaction-derived client and all five executor derive sites. They also check that a different-options derive still builds its own mapper, that `@@map`/`@map` resolve identically inside and outside a transaction, and that a schema needing no mapper still works. They assert the invariant rather than elapsed time, which would flake on CI. Verified failing on unmodified `dev` with an identity mismatch, not a missing method.
- `pnpm test` green, 42/42 turbo tasks. `pnpm run lint` clean.
- Also run across `TEST_DB_PROVIDER=sqlite|postgresql|mysql`. Two suites failed there, and I checked both against unmodified `dev`. `bun-e2e` under mysql fails 2 runs in 3 without this change. `edge-runtime-e2e` passed 2/2 on re-run after a one-off 100s timeout. Flagging in case they are known to you.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when working with mapped model, table, column, and enum names.
  * Preserved name mappings across transactions, connection-scoped operations, and derived query clients.
  * Correctly rebuilds mappings when query options change.
  * Fixed behavior for schemas without mapped names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
