### PR TITLE
fix: add per-provider native type mapping diagnostics

### DIFF
--- a/packages/language/src/utils.ts
+++ b/packages/language/src/utils.ts
@@ -7,6 +7,7 @@ import { PLUGIN_MODULE_NAME, STD_LIB_MODULE_NAME, type ExpressionContext } from 
 import {
     InternalAttribute,
     isArrayExpr,
+    isAttribute,
     isBinaryExpr,
     isConfigArrayExpr,
     isDataField,
@@ -169,6 +170,20 @@ export function isComputedField(field: DataField) {
  */
 export function isDelegateModel(node: AstNode) {
     return isDataModel(node) && hasAttribute(node, '@@delegate');
+}
+
+/**
+ * Returns if the given node is a Prisma attribute.
+ */
+export function isPrismaAttribute(node: AstNode): node is Attribute {
+    return isAttribute(node) && hasAttribute(node, '@@@prisma');
+}
+
+/**
+ * Returns if the given node is a native type mapping attribute.
+ */
+export function isNativeTypeMappingAttribute(node: AstNode): node is Attribute {
+    return isPrismaAttribute(node) && node.name.startsWith('@db.');
 }
 
 /**

--- a/packages/language/src/validators/attribute-application-validator.ts
+++ b/packages/language/src/validators/attribute-application-validator.ts
@@ -155,7 +155,7 @@ export default class AttributeApplicationValidator implements AstValidator<Attri
                 const provider = getDataSourceProvider(zmodel);
                 if (provider) {
                     const supportedNativeTypes = datasourceProviderSupportedNativeTypes[provider];
-                    if (supportedNativeTypes && !supportedNativeTypes.has(decl.name)) {
+                    if (!supportedNativeTypes?.has(decl.name)) {
                         accept('error', `attribute "${decl.name}" cannot be used with the "${provider}" provider`, { node: attr });
                     }
                 }

--- a/packages/language/src/validators/attribute-application-validator.ts
+++ b/packages/language/src/validators/attribute-application-validator.ts
@@ -37,6 +37,7 @@ import {
     isComputedField,
     isDataFieldReference,
     isDelegateModel,
+    isNativeTypeMappingAttribute,
     isRelationshipField,
     mapBuiltinTypeToExpressionType,
     resolved,
@@ -46,6 +47,75 @@ import type { AstValidator } from './common';
 
 // a registry of function handlers marked with @check
 const attributeCheckers = new Map<string, PropertyDescriptor>();
+
+const datasourceProviderSupportedNativeTypes: Record<string, Set<string>> = {
+    sqlite: new Set(),
+
+    postgresql: new Set([
+        '@db.Text',
+        '@db.Char',
+        '@db.VarChar',
+        '@db.Bit',
+        '@db.VarBit',
+        '@db.Uuid',
+        '@db.Xml',
+        '@db.Inet',
+        '@db.Citext',
+        '@db.Boolean',
+        '@db.Int',
+        '@db.Integer',
+        '@db.SmallInt',
+        '@db.Oid',
+        '@db.BigInt',
+        '@db.DoublePrecision',
+        '@db.Real',
+        '@db.Decimal',
+        '@db.Money',
+        '@db.Timestamp',
+        '@db.Timestamptz',
+        '@db.Date',
+        '@db.Time',
+        '@db.Timetz',
+        '@db.Json',
+        '@db.JsonB',
+        '@db.ByteA',
+    ]),
+
+    mysql: new Set([
+        '@db.Text',
+        '@db.Char',
+        '@db.VarChar',
+        '@db.TinyText',
+        '@db.MediumText',
+        '@db.LongText',
+        '@db.Bit',
+        '@db.TinyInt',
+        '@db.Int',
+        '@db.SmallInt',
+        '@db.MediumInt',
+        '@db.Year',
+        '@db.UnsignedInt',
+        '@db.UnsignedSmallInt',
+        '@db.UnsignedMediumInt',
+        '@db.UnsignedTinyInt',
+        '@db.BigInt',
+        '@db.UnsignedBigInt',
+        '@db.Float',
+        '@db.Double',
+        '@db.Decimal',
+        '@db.Timestamp',
+        '@db.DateTime',
+        '@db.Date',
+        '@db.Time',
+        '@db.Json',
+        '@db.LongBlob',
+        '@db.Blob',
+        '@db.MediumBlob',
+        '@db.TinyBlob',
+        '@db.Binary',
+        '@db.VarBinary',
+    ]),
+}
 
 // function handler decorator
 function check(name: string) {
@@ -77,6 +147,19 @@ export default class AttributeApplicationValidator implements AstValidator<Attri
 
         if (isDataField(targetDecl) && !isValidAttributeTarget(decl, targetDecl)) {
             accept('error', `attribute "${decl.name}" cannot be used on this type of field`, { node: attr });
+        }
+
+        if (isNativeTypeMappingAttribute(decl)) {
+            const zmodel = AstUtils.getContainerOfType(attr, isModel);
+            if (zmodel) {
+                const provider = getDataSourceProvider(zmodel);
+                if (provider) {
+                    const supportedNativeTypes = datasourceProviderSupportedNativeTypes[provider];
+                    if (supportedNativeTypes && !supportedNativeTypes.has(decl.name)) {
+                        accept('error', `attribute "${decl.name}" cannot be used with the "${provider}" provider`, { node: attr });
+                    }
+                }
+            }
         }
 
         this.checkDeprecation(attr, accept);

--- a/packages/language/test/attribute-application.test.ts
+++ b/packages/language/test/attribute-application.test.ts
@@ -588,6 +588,208 @@ describe('Attribute application validation tests', () => {
         });
     });
 
+    describe('Native type mapping attributes', () => {
+        describe('sqlite', () => {
+            it('rejects when any native type mapping attribute is used', async () => {
+                // postgresql attribute
+                await loadSchemaWithError(
+                    `
+                datasource db {
+                    provider = 'sqlite'
+                    url      = 'file:./dev.db'
+                }
+
+                model User {
+                    id String @id @db.Uuid
+                }
+                `,
+                    `attribute "@db.Uuid" cannot be used with the "sqlite" provider`,
+                );
+
+                // mysql attribute
+                await loadSchemaWithError(
+                    `
+                datasource db {
+                    provider = 'sqlite'
+                    url      = 'file:./dev.db'
+                }
+
+                model User {
+                    id Int @id @db.TinyInt
+                }
+                `,
+                    `attribute "@db.TinyInt" cannot be used with the "sqlite" provider`,
+                );
+
+                // postgres/mysql attribute
+                await loadSchemaWithError(
+                    `
+                datasource db {
+                    provider = 'sqlite'
+                    url      = 'file:./dev.db'
+                }
+
+                model User {
+                    id String @id @db.Text
+                }
+                `,
+                    `attribute "@db.Text" cannot be used with the "sqlite" provider`,
+                );
+            });
+        });
+
+        describe('postgresql', () => {
+            it('allows all postgresql attributes', async () => {
+                await loadSchema(
+                    `
+                datasource db {
+                    provider = 'postgresql'
+                    url      = env('DATABASE_URL')
+                }
+
+                model User {
+                    id                     Int      @id @default(autoincrement())
+
+                    text                   String   @db.Text
+                    char                   String   @db.Char(10)
+                    varchar                String   @db.VarChar(255)
+                    bitString              String   @db.Bit(8)
+                    varBit                 String   @db.VarBit
+                    uuid                   String   @db.Uuid
+                    xml                    String   @db.Xml
+                    inet                   String   @db.Inet
+                    citext                 String   @db.Citext
+
+                    boolean                Boolean  @db.Boolean
+
+                    int                    Int      @db.Int
+                    integer                Int      @db.Integer
+                    smallInt               Int      @db.SmallInt
+                    oid                    Int      @db.Oid
+
+                    bigInt                 BigInt   @db.BigInt
+
+                    doublePrecisionFloat   Float    @db.DoublePrecision
+                    doublePrecisionDecimal Decimal  @db.DoublePrecision
+
+                    realFloat              Float    @db.Real
+                    realDecimal            Decimal  @db.Real
+
+                    decimalFloat           Float    @db.Decimal(10, 2)
+                    decimalDecimal         Decimal  @db.Decimal(10, 2)
+
+                    moneyFloat             Float    @db.Money
+                    moneyDecimal           Decimal  @db.Money
+
+                    timestamp              DateTime @db.Timestamp(6)
+                    timestamptz            DateTime @db.Timestamptz(6)
+                    date                   DateTime @db.Date
+                    time                   DateTime @db.Time(6)
+                    timetz                 DateTime @db.Timetz(6)
+
+                    json                   Json     @db.Json
+                    jsonb                  Json     @db.JsonB
+
+                    bytea                  Bytes    @db.ByteA
+                }
+                `);
+            });
+
+            it('rejects mysql attributes', async () => {
+                await loadSchemaWithError(
+                    `
+                datasource db {
+                    provider = 'postgresql'
+                    url      = env('DATABASE_URL')
+                }
+
+                model User {
+                    id Int @id @db.TinyInt
+                }
+                `,
+                    `attribute "@db.TinyInt" cannot be used with the "postgresql" provider`,
+                );
+            });
+        });
+
+        describe('mysql', () => {
+            it('allows all mysql attributes', async () => {
+                await loadSchema(
+                    `
+                datasource db {
+                    provider = 'mysql'
+                    url      = env('DATABASE_URL')
+                }
+
+                model User {
+                    id                Int      @id @default(autoincrement())
+
+                    text              String   @db.Text
+                    char              String   @db.Char(10)
+                    varchar           String   @db.VarChar(255)
+                    tinyText          String   @db.TinyText
+                    mediumText        String   @db.MediumText
+                    longText          String   @db.LongText
+
+                    bitString         String   @db.Bit(8)
+                    bitBool           Boolean  @db.Bit(1)
+                    bitBytes          Bytes    @db.Bit(64)
+
+                    tinyIntBool       Boolean  @db.TinyInt(1)
+
+                    int               Int      @db.Int
+                    smallInt          Int      @db.SmallInt
+                    mediumInt         Int      @db.MediumInt
+                    tinyInt           Int      @db.TinyInt
+                    year              Int      @db.Year
+                    unsignedInt       Int      @db.UnsignedInt
+                    unsignedSmallInt  Int      @db.UnsignedSmallInt
+                    unsignedMediumInt Int      @db.UnsignedMediumInt
+                    unsignedTinyInt   Int      @db.UnsignedTinyInt
+
+                    bigInt            BigInt   @db.BigInt
+                    unsignedBigInt    BigInt   @db.UnsignedBigInt
+
+                    float             Float    @db.Float
+                    double            Float    @db.Double
+                    decimalFloat      Float    @db.Decimal(10, 2)
+                    decimal           Decimal  @db.Decimal(10, 2)
+
+                    timestamp         DateTime @db.Timestamp(6)
+                    datetime          DateTime @db.DateTime(6)
+                    date              DateTime @db.Date
+                    time              DateTime @db.Time(6)
+
+                    json              Json     @db.Json
+
+                    longBlob          Bytes    @db.LongBlob
+                    blob              Bytes    @db.Blob
+                    mediumBlob        Bytes    @db.MediumBlob
+                    tinyBlob          Bytes    @db.TinyBlob
+                    binary            Bytes    @db.Binary(16)
+                    varBinary         Bytes    @db.VarBinary(255)
+                }
+                `);
+            });
+
+            it('rejects postgresql attributes', async () => {
+                await loadSchemaWithError(
+                    `
+                datasource db {
+                    provider = 'mysql'
+                    url      = env('DATABASE_URL')
+                }
+
+                model User {
+                    id String @id @db.Uuid
+                }
+                `,
+                    `attribute "@db.Uuid" cannot be used with the "mysql" provider`,
+                );
+            });
+        });
+    });
+
     it('requires relation and fk to have consistent optionality', async () => {
         await loadSchemaWithError(
             `

--- a/tests/regression/test/issue-2385.test.ts
+++ b/tests/regression/test/issue-2385.test.ts
@@ -25,7 +25,9 @@ model Association {
 
     @@allow("read", auth().id == userId)
 }
-            `,
+            `, {
+                provider: 'postgresql',
+            },
         );
 
         const rawDb = db.$unuseAll();

--- a/tests/regression/test/issue-393.test.ts
+++ b/tests/regression/test/issue-393.test.ts
@@ -8,7 +8,9 @@ describe('Regression for issue #393', () => {
 model users {
   id String @id() @default(cuid())
   tz Int @default(-6) @db.SmallInt()
-}`,
+}`, {
+    provider: 'postgresql',
+},
         );
         await expect(db.users.create({ data: {} })).resolves.toMatchObject({ tz: -6 });
     });


### PR DESCRIPTION
Fixes #2759 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for native database type mappings based on the selected datasource provider.
  * Supports provider-specific mappings for SQLite, PostgreSQL, and MySQL.

* **Bug Fixes**
  * Reports clear errors when a native type mapping is incompatible with the configured database provider.

* **Tests**
  * Added coverage for supported and unsupported native mappings across all supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->