### PR TITLE
fix(policy): reject implicit m2m join table deletes when a participant side is not updatable

### DIFF
--- a/packages/plugins/policy/src/policy-handler.ts
+++ b/packages/plugins/policy/src/policy-handler.ts
@@ -10,6 +10,7 @@ import {
 } from '@zenstackhq/orm/schema';
 import {
     AliasNode,
+    AndNode,
     BinaryOperationNode,
     ColumnNode,
     DeleteQueryNode,
@@ -112,6 +113,11 @@ export class PolicyHandler<Schema extends SchemaDef> extends OperationNodeTransf
         // update
         if (UpdateQueryNode.is(node)) {
             await this.preUpdateCheck(mutationModel, node, proceed);
+        }
+
+        // delete
+        if (DeleteQueryNode.is(node)) {
+            await this.preDeleteCheck(mutationModel, node, proceed);
         }
 
         // post-update: load before-update entities if needed
@@ -238,6 +244,100 @@ export class PolicyHandler<Schema extends SchemaDef> extends OperationNodeTransf
                 'some rows cannot be updated due to field policies',
             );
         }
+    }
+
+    /**
+     * Deleting rows from an implicit many-to-many join table requires both participant sides to be
+     * updatable. Unlike inserts (which are explicitly rejected by {@link enforcePreCreatePolicyForManyToManyJoinTable}),
+     * a delete would otherwise just be silently filtered down to zero rows and report success. See issue #2752.
+     */
+    private async preDeleteCheck(mutationModel: string, node: DeleteQueryNode, proceed: ProceedKyselyQueryFunction) {
+        const m2m = this.resolveManyToManyJoinTable(mutationModel);
+        if (!m2m) {
+            return;
+        }
+
+        // the join table's fk columns are constrained by literal values for the sides that the
+        // delete explicitly targets; only those sides can be checked upfront
+        const sides = [
+            { column: 'A', model: m2m.firstModel, idField: m2m.firstIdField },
+            { column: 'B', model: m2m.secondModel, idField: m2m.secondIdField },
+        ]
+            .map((side) => ({ ...side, value: this.extractEqualityValue(node.where?.where, side.column) }))
+            .filter((side) => side.value !== undefined);
+
+        if (sides.length === 0) {
+            return;
+        }
+
+        const result = await proceed({
+            kind: 'SelectQueryNode',
+            selections: sides.map((side, index) =>
+                SelectionNode.create(
+                    AliasNode.create(
+                        this.eb
+                            .selectFrom(side.model)
+                            .where(this.eb(this.eb.ref(`${side.model}.${side.idField}`), '=', side.value))
+                            .select(() =>
+                                new ExpressionWrapper(this.buildPolicyFilter(side.model, undefined, 'update')).as('_'),
+                            )
+                            .toOperationNode(),
+                        IdentifierNode.create(`$condition${index}`),
+                    ),
+                ),
+            ),
+        } satisfies SelectQueryNode);
+
+        for (const [index, side] of sides.entries()) {
+            if (!result.rows[0]?.[`$condition${index}`]) {
+                throw createRejectedByPolicyError(
+                    side.model,
+                    RejectedByPolicyReason.NO_ACCESS,
+                    `many-to-many relation participant model "${side.model}" not updatable`,
+                );
+            }
+        }
+    }
+
+    /**
+     * Finds the literal value that `column` is constrained to by a top-level conjunction of the given
+     * where clause, or `undefined` if there's no such constraint.
+     *
+     * E.g., given the where clause `("A" = 1 AND "B" IN (2, 3))`, extracting column "A" returns `1`,
+     * while extracting column "B" returns `undefined` since it's not an equality constraint.
+     */
+    private extractEqualityValue(node: OperationNode | undefined, column: string): unknown {
+        if (!node) {
+            return undefined;
+        }
+
+        if (ParensNode.is(node)) {
+            return this.extractEqualityValue(node.node, column);
+        }
+
+        if (AndNode.is(node)) {
+            return this.extractEqualityValue(node.left, column) ?? this.extractEqualityValue(node.right, column);
+        }
+
+        if (!BinaryOperationNode.is(node)) {
+            return undefined;
+        }
+
+        if (!OperatorNode.is(node.operator) || node.operator.operator !== '=') {
+            return undefined;
+        }
+
+        const { leftOperand, rightOperand } = node;
+        if (!ReferenceNode.is(leftOperand) || !ColumnNode.is(leftOperand.column)) {
+            return undefined;
+        }
+        if (leftOperand.column.column.name !== column) {
+            return undefined;
+        }
+        if (!ValueNode.is(rightOperand) || rightOperand.value === null || rightOperand.value === undefined) {
+            return undefined;
+        }
+        return rightOperand.value;
     }
 
     private async postUpdateCheck(

--- a/packages/plugins/policy/src/policy-handler.ts
+++ b/packages/plugins/policy/src/policy-handler.ts
@@ -990,7 +990,7 @@ export class PolicyHandler<Schema extends SchemaDef> extends OperationNodeTransf
         if (!result.rows[0]?.$conditionA) {
             throw createRejectedByPolicyError(
                 m2m.firstModel,
-                RejectedByPolicyReason.CANNOT_READ_BACK,
+                RejectedByPolicyReason.NO_ACCESS,
                 `many-to-many relation participant model "${m2m.firstModel}" not updatable`,
             );
         }

--- a/tests/regression/test/issue-2752.test.ts
+++ b/tests/regression/test/issue-2752.test.ts
@@ -1,0 +1,124 @@
+import { createPolicyTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+describe('Regression for issue 2752', () => {
+    it('rejects an update with only an empty implicit-M2M `set: []` for a caller denied by the update policy', async () => {
+        const db = await createPolicyTestClient(
+            `
+model User {
+    id       Int       @id @default(autoincrement())
+    profiles Profile[]
+
+    @@allow('all', true)
+}
+
+model Profile {
+    id      Int    @id @default(autoincrement())
+    name    String
+    ownerId Int
+    owner   User   @relation(fields: [ownerId], references: [id])
+    tags    Tag[]
+
+    @@allow('read,create', true)
+    @@allow('update', auth() == owner)
+}
+
+model Tag {
+    id       String    @id
+    profiles Profile[]
+
+    @@allow('read,create', true)
+    @@allow('update', auth() != null)
+}
+            `,
+            { usePrismaPush: true },
+        );
+
+        const rawDb = db.$unuseAll();
+        const owner = await rawDb.user.create({ data: {} });
+        const other = await rawDb.user.create({ data: {} });
+        await rawDb.tag.create({ data: { id: 'a' } });
+        await rawDb.tag.create({ data: { id: 'b' } });
+        const profile = await rawDb.profile.create({
+            data: { name: 'p1', ownerId: owner.id, tags: { connect: [{ id: 'a' }, { id: 'b' }] } },
+        });
+
+        const asOther = db.$setAuth({ id: other.id });
+
+        // non-empty set is rejected
+        await expect(
+            asOther.profile.update({ where: { id: profile.id }, data: { tags: { set: [{ id: 'a' }] } } }),
+        ).toBeRejectedByPolicy();
+
+        // empty set (disconnect-all) must be rejected too, instead of silently succeeding
+        await expect(
+            asOther.profile.update({ where: { id: profile.id }, data: { tags: { set: [] } } }),
+        ).toBeRejectedByPolicy();
+
+        // nothing was disconnected
+        await expect(
+            rawDb.profile.findUniqueOrThrow({ where: { id: profile.id }, include: { tags: true } }),
+        ).resolves.toMatchObject({ tags: expect.arrayContaining([expect.objectContaining({ id: 'a' })]) });
+
+        // the owner can do it
+        const asOwner = db.$setAuth({ id: owner.id });
+        await expect(
+            asOwner.profile.update({ where: { id: profile.id }, data: { tags: { set: [] } } }),
+        ).toResolveTruthy();
+        await expect(
+            rawDb.profile.findUniqueOrThrow({ where: { id: profile.id }, include: { tags: true } }),
+        ).resolves.toMatchObject({ tags: [] });
+    });
+
+    it('rejects an implicit-M2M `disconnect` for a caller denied by the update policy', async () => {
+        const db = await createPolicyTestClient(
+            `
+model User {
+    id       Int       @id @default(autoincrement())
+    profiles Profile[]
+
+    @@allow('all', true)
+}
+
+model Profile {
+    id      Int    @id @default(autoincrement())
+    name    String
+    ownerId Int
+    owner   User   @relation(fields: [ownerId], references: [id])
+    tags    Tag[]
+
+    @@allow('read,create', true)
+    @@allow('update', auth() == owner)
+}
+
+model Tag {
+    id       String    @id
+    profiles Profile[]
+
+    @@allow('read,create', true)
+    @@allow('update', auth() != null)
+}
+            `,
+            { usePrismaPush: true },
+        );
+
+        const rawDb = db.$unuseAll();
+        const owner = await rawDb.user.create({ data: {} });
+        const other = await rawDb.user.create({ data: {} });
+        await rawDb.tag.create({ data: { id: 'a' } });
+        const profile = await rawDb.profile.create({
+            data: { name: 'p1', ownerId: owner.id, tags: { connect: { id: 'a' } } },
+        });
+
+        const asOther = db.$setAuth({ id: other.id });
+
+        await expect(
+            asOther.profile.update({ where: { id: profile.id }, data: { tags: { disconnect: { id: 'a' } } } }),
+        ).toBeRejectedByPolicy();
+
+        // links intact
+        await expect(
+            rawDb.profile.findUniqueOrThrow({ where: { id: profile.id }, include: { tags: true } }),
+        ).resolves.toMatchObject({ tags: [expect.objectContaining({ id: 'a' })] });
+    });
+});


### PR DESCRIPTION
## Summary

Deleting rows from an implicit many-to-many join table (e.g. via `tags: { set: [] }` or `tags: { disconnect: ... }`) was silently filtered down to zero rows when the caller lacked update permission on a participant model — the operation reported success without actually disconnecting anything.

This PR adds a pre-delete check in the policy handler: when a delete targets an implicit m2m join table, the participant sides whose fk columns are constrained to literal values in the where clause are checked upfront for "update" permission, and the operation is rejected with a policy error if any side fails. This mirrors the existing pre-create enforcement for join-table inserts.

Fixes #2752

## Changes

- `PolicyHandler.preDeleteCheck`: new pre-mutation check for implicit m2m join-table deletes
- `PolicyHandler.extractEqualityValue`: helper to extract the literal value a column is constrained to by a top-level conjunction of the where clause
- Regression tests covering empty `set: []` and `disconnect` for both denied and permitted callers

## Testing

- New regression test `tests/regression/test/issue-2752.test.ts` (2 tests, passing)
- Existing policy e2e suites pass: `connect-disconnect`, `relation-many-to-many-filter`, `crud/update` (36 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authorization checks for updates and deletions involving many-to-many relationships.
  - Prevented unauthorized users from modifying or removing relationship links.
  - Ensured rejected operations leave existing relationships unchanged.
  - Authorized owners can continue to clear relationships as expected.
  - Corrected the access error reported when creating unauthorized many-to-many relationships.

- **Tests**
  - Added regression coverage for setting, clearing, and disconnecting relationship links under different authorization conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->