### PR TITLE
chore: bump pinned pnpm version to 10.33.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -57,7 +57,7 @@ jobs:
             - name: Install pnpm
               uses: pnpm/action-setup@v2
               with:
-                  version: 10.12.1
+                  version: 10.33.0
 
             - name: Use Node.js ${{ matrix.node-version }}
               uses: actions/setup-node@v4

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Install pnpm
               uses: pnpm/action-setup@v2
               with:
-                  version: 10.12.1
+                  version: 10.33.0
 
             - name: Use Node.js
               uses: actions/setup-node@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Install pnpm
               uses: pnpm/action-setup@v2
               with:
-                  version: 10.12.1
+                  version: 10.33.0
 
             - name: Use Node.js
               uses: actions/setup-node@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Package Management
 
 - Uses `pnpm` with workspaces
-- Package manager is pinned to `pnpm@10.12.1`
+- Package manager is pinned to `pnpm@10.33.0`
 - Packages are located in `packages/`, `samples/`, and `tests/`
 
 ### Testing

--- a/packages/ide/vscode/package.json
+++ b/packages/ide/vscode/package.json
@@ -29,7 +29,7 @@
         "name": "ZenStack Team"
     },
     "license": "MIT",
-    "packageManager": "pnpm@10.12.1",
+    "packageManager": "pnpm@10.33.0",
     "dependencies": {
         "@zenstackhq/language": "workspace:*",
         "langium": "catalog:",


### PR DESCRIPTION
## Summary

Bumps the pinned pnpm version from 10.12.1 to 10.33.0 everywhere it's referenced:

- CI workflows (`build-test.yml`, `bump-version.yml`, `publish-release.yml`)
- `CLAUDE.md` package management notes
- `packages/ide/vscode/package.json` `packageManager` field

This aligns the remaining references with the repo-wide pnpm pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s pnpm version to 10.33.0 across development, release, and package configuration.
  * Kept automated builds and publishing workflows aligned with the updated package manager version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->