### PR TITLE
chore: exclude ZenStack-generated files from prettier formatting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,10 +14,10 @@ If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
 
--   ZenStack version: [e.g., 3.1.0]
--   Database type: [e.g. Postgresql]
--   Node.js/Bun version: [e.g., 20.0.0]
--   Package manager: [e.g., npm, yarn, pnpm]
+- ZenStack version: [e.g., 3.1.0]
+- Database type: [e.g. Postgresql]
+- Node.js/Bun version: [e.g., 20.0.0]
+- Package manager: [e.g., npm, yarn, pnpm]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,10 +1,15 @@
 packages/language/src/generated/**
+
+# ZenStack CLI generated files (schema.ts, schema-lite.ts, models.ts, input.ts)
 **/test/**/schema.ts
+**/test/**/schema-lite.ts
 **/test/**/models.ts
 **/test/**/input.ts
 samples/**/schema.ts
+samples/**/schema-lite.ts
 samples/**/models.ts
 samples/**/input.ts
-tests/e2e/**/schema.ts
-tests/e2e/**/models.ts
-tests/e2e/**/input.ts
+tests/**/schema.ts
+tests/**/schema-lite.ts
+tests/**/models.ts
+tests/**/input.ts

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,24 +17,24 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
--   Demonstrating empathy and kindness toward other people
--   Being respectful of differing opinions, viewpoints, and experiences
--   Giving and gracefully accepting constructive feedback
--   Accepting responsibility and apologizing to those affected by our mistakes,
-    and learning from the experience
--   Focusing on what is best not just for us as individuals, but for the
-    overall community
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
 
 Examples of unacceptable behavior include:
 
--   The use of sexualized language or imagery, and sexual attention or
-    advances of any kind
--   Trolling, insulting or derogatory comments, and personal or political attacks
--   Public or private harassment
--   Publishing others' private information, such as a physical or email
-    address, without their explicit permission
--   Other conduct which could reasonably be considered inappropriate in a
-    professional setting
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
 ## Enforcement Responsibilities
 

--- a/packages/cli/src/actions/pull/provider/postgresql.ts
+++ b/packages/cli/src/actions/pull/provider/postgresql.ts
@@ -184,7 +184,9 @@ export const postgresql: IntrospectionProvider = {
         const pg = await loadPackage('pg');
         const ClientClass: typeof PgClient = pg?.Client || pg?.default?.Client;
         if (!ClientClass) {
-            throw new CliError('Package "pg" is required for PostgreSQL support. Please install it with: npm install pg');
+            throw new CliError(
+                'Package "pg" is required for PostgreSQL support. Please install it with: npm install pg',
+            );
         }
         const client = new ClientClass({ connectionString });
         await client.connect();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -284,10 +284,7 @@ Arguments following -- are passed to the seed script. E.g.: "zen db seed -- --us
                 }),
         )
         .addOption(
-            new Option(
-                '--introspect',
-                'Introspect the database to generate a schema when no schema file is found',
-            ),
+            new Option('--introspect', 'Introspect the database to generate a schema when no schema file is found'),
         )
         .addOption(noVersionCheckOption)
         .action(proxyAction);

--- a/packages/clients/fetch-client/test/schemas/basic/schema-lite.ts
+++ b/packages/clients/fetch-client/test/schemas/basic/schema-lite.ts
@@ -5,89 +5,91 @@
 
 /* eslint-disable */
 
-import { type SchemaDef, type FieldDefault, ExpressionUtils } from '@zenstackhq/schema';
+import { type SchemaDef, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
 export class SchemaType implements SchemaDef {
     provider = {
-        type: 'sqlite',
+        type: "sqlite"
     } as const;
     models = {
         User: {
-            name: 'User',
+            name: "User",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 email: {
-                    name: 'email',
-                    type: 'String',
-                    unique: true,
+                    name: "email",
+                    type: "String",
+                    unique: true
                 },
                 name: {
-                    name: 'name',
-                    type: 'String',
-                    optional: true,
+                    name: "name",
+                    type: "String",
+                    optional: true
                 },
                 posts: {
-                    name: 'posts',
-                    type: 'Post',
+                    name: "posts",
+                    type: "Post",
                     array: true,
-                    relation: { opposite: 'author' },
-                },
+                    relation: { opposite: "author" }
+                }
             },
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-                email: { type: 'String' },
-            },
+                id: { type: "String" },
+                email: { type: "String" }
+            }
         },
         Post: {
-            name: 'Post',
+            name: "Post",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 title: {
-                    name: 'title',
-                    type: 'String',
+                    name: "title",
+                    type: "String"
                 },
                 author: {
-                    name: 'author',
-                    type: 'User',
+                    name: "author",
+                    type: "User",
                     optional: true,
-                    relation: { opposite: 'posts', fields: ['authorId'], references: ['id'] },
+                    relation: { opposite: "posts", fields: ["authorId"], references: ["id"] }
                 },
                 authorId: {
-                    name: 'authorId',
-                    type: 'String',
+                    name: "authorId",
+                    type: "String",
                     optional: true,
-                    foreignKeyFor: ['author'] as readonly string[],
-                },
+                    foreignKeyFor: [
+                        "author"
+                    ] as readonly string[]
+                }
             },
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-            },
-        },
+                id: { type: "String" }
+            }
+        }
     } as const;
-    authType = 'User' as const;
+    authType = "User" as const;
     procedures = {
         getStats: {
             params: {},
-            returnType: 'Int',
+            returnType: "Int"
         },
         sendNotification: {
             params: {
-                message: { name: 'message', type: 'String' },
+                message: { name: "message", type: "String" }
             },
-            returnType: 'Boolean',
-            mutation: true,
-        },
+            returnType: "Boolean",
+            mutation: true
+        }
     } as const;
     plugins = {};
 }

--- a/packages/clients/fetch-client/test/schemas/no-procs/schema-lite.ts
+++ b/packages/clients/fetch-client/test/schemas/no-procs/schema-lite.ts
@@ -5,27 +5,27 @@
 
 /* eslint-disable */
 
-import { type SchemaDef, type FieldDefault, ExpressionUtils } from '@zenstackhq/schema';
+import { type SchemaDef, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
 export class SchemaType implements SchemaDef {
     provider = {
-        type: 'sqlite',
+        type: "sqlite"
     } as const;
     models = {
         Item: {
-            name: 'Item',
+            name: "Item",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
-                },
+                    default: ExpressionUtils.call("cuid") as FieldDefault
+                }
             },
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-            },
-        },
+                id: { type: "String" }
+            }
+        }
     } as const;
     plugins = {};
 }

--- a/packages/clients/tanstack-query/test/schemas/basic/schema-lite.ts
+++ b/packages/clients/tanstack-query/test/schemas/basic/schema-lite.ts
@@ -5,164 +5,168 @@
 
 /* eslint-disable */
 
-import { type SchemaDef, type FieldDefault, ExpressionUtils } from '@zenstackhq/schema';
+import { type SchemaDef, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
 export class SchemaType implements SchemaDef {
     provider = {
-        type: 'sqlite',
+        type: "sqlite"
     } as const;
     models = {
         User: {
-            name: 'User',
+            name: "User",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 email: {
-                    name: 'email',
-                    type: 'String',
-                    unique: true,
+                    name: "email",
+                    type: "String",
+                    unique: true
                 },
                 name: {
-                    name: 'name',
-                    type: 'String',
-                    optional: true,
+                    name: "name",
+                    type: "String",
+                    optional: true
                 },
                 posts: {
-                    name: 'posts',
-                    type: 'Post',
+                    name: "posts",
+                    type: "Post",
                     array: true,
-                    relation: { opposite: 'owner' },
-                },
+                    relation: { opposite: "owner" }
+                }
             },
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-                email: { type: 'String' },
-            },
+                id: { type: "String" },
+                email: { type: "String" }
+            }
         },
         Post: {
-            name: 'Post',
+            name: "Post",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 title: {
-                    name: 'title',
-                    type: 'String',
+                    name: "title",
+                    type: "String"
                 },
                 owner: {
-                    name: 'owner',
-                    type: 'User',
+                    name: "owner",
+                    type: "User",
                     optional: true,
-                    relation: { opposite: 'posts', fields: ['ownerId'], references: ['id'] },
+                    relation: { opposite: "posts", fields: ["ownerId"], references: ["id"] }
                 },
                 ownerId: {
-                    name: 'ownerId',
-                    type: 'String',
+                    name: "ownerId",
+                    type: "String",
                     optional: true,
-                    foreignKeyFor: ['owner'] as readonly string[],
+                    foreignKeyFor: [
+                        "owner"
+                    ] as readonly string[]
                 },
                 category: {
-                    name: 'category',
-                    type: 'Category',
+                    name: "category",
+                    type: "Category",
                     optional: true,
-                    relation: { opposite: 'posts', fields: ['categoryId'], references: ['id'] },
+                    relation: { opposite: "posts", fields: ["categoryId"], references: ["id"] }
                 },
                 categoryId: {
-                    name: 'categoryId',
-                    type: 'String',
+                    name: "categoryId",
+                    type: "String",
                     optional: true,
-                    foreignKeyFor: ['category'] as readonly string[],
-                },
+                    foreignKeyFor: [
+                        "category"
+                    ] as readonly string[]
+                }
             },
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-            },
+                id: { type: "String" }
+            }
         },
         Category: {
-            name: 'Category',
+            name: "Category",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 name: {
-                    name: 'name',
-                    type: 'String',
-                    unique: true,
+                    name: "name",
+                    type: "String",
+                    unique: true
                 },
                 posts: {
-                    name: 'posts',
-                    type: 'Post',
+                    name: "posts",
+                    type: "Post",
                     array: true,
-                    relation: { opposite: 'category' },
-                },
+                    relation: { opposite: "category" }
+                }
             },
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-                name: { type: 'String' },
-            },
+                id: { type: "String" },
+                name: { type: "String" }
+            }
         },
         Foo: {
-            name: 'Foo',
+            name: "Foo",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 type: {
-                    name: 'type',
-                    type: 'String',
-                    isDiscriminator: true,
-                },
+                    name: "type",
+                    type: "String",
+                    isDiscriminator: true
+                }
             },
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
+                id: { type: "String" }
             },
             isDelegate: true,
-            subModels: ['Bar'],
+            subModels: ["Bar"]
         },
         Bar: {
-            name: 'Bar',
-            baseModel: 'Foo',
+            name: "Bar",
+            baseModel: "Foo",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 type: {
-                    name: 'type',
-                    type: 'String',
-                    originModel: 'Foo',
-                    isDiscriminator: true,
+                    name: "type",
+                    type: "String",
+                    originModel: "Foo",
+                    isDiscriminator: true
                 },
                 title: {
-                    name: 'title',
-                    type: 'String',
-                },
+                    name: "title",
+                    type: "String"
+                }
             },
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-            },
-        },
+                id: { type: "String" }
+            }
+        }
     } as const;
-    authType = 'User' as const;
+    authType = "User" as const;
     plugins = {};
 }
 export const schema = new SchemaType();

--- a/packages/language/src/validators/attribute-application-validator.ts
+++ b/packages/language/src/validators/attribute-application-validator.ts
@@ -115,7 +115,7 @@ const datasourceProviderSupportedNativeTypes: Record<string, Set<string>> = {
         '@db.Binary',
         '@db.VarBinary',
     ]),
-}
+};
 
 // function handler decorator
 function check(name: string) {
@@ -156,7 +156,9 @@ export default class AttributeApplicationValidator implements AstValidator<Attri
                 if (provider) {
                     const supportedNativeTypes = datasourceProviderSupportedNativeTypes[provider];
                     if (!supportedNativeTypes?.has(decl.name)) {
-                        accept('error', `attribute "${decl.name}" cannot be used with the "${provider}" provider`, { node: attr });
+                        accept('error', `attribute "${decl.name}" cannot be used with the "${provider}" provider`, {
+                            node: attr,
+                        });
                     }
                 }
             }

--- a/packages/language/test/attribute-application.test.ts
+++ b/packages/language/test/attribute-application.test.ts
@@ -692,7 +692,8 @@ describe('Attribute application validation tests', () => {
 
                     bytea                  Bytes    @db.ByteA
                 }
-                `);
+                `,
+                );
             });
 
             it('rejects mysql attributes', async () => {
@@ -769,7 +770,8 @@ describe('Attribute application validation tests', () => {
                     binary            Bytes    @db.Binary(16)
                     varBinary         Bytes    @db.VarBinary(255)
                 }
-                `);
+                `,
+                );
             });
 
             it('rejects postgresql attributes', async () => {

--- a/samples/next.js/zenstack/schema-lite.ts
+++ b/samples/next.js/zenstack/schema-lite.ts
@@ -5,119 +5,115 @@
 
 /* eslint-disable */
 
-import { type SchemaDef, type FieldDefault, ExpressionUtils } from '@zenstackhq/schema';
+import { type SchemaDef, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
 export class SchemaType implements SchemaDef {
     provider = {
-        type: 'sqlite',
+        type: "sqlite"
     } as const;
     models = {
         User: {
-            name: 'User',
+            name: "User",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 createdAt: {
-                    name: 'createdAt',
-                    type: 'DateTime',
-                    default: ExpressionUtils.call('now') as FieldDefault,
+                    name: "createdAt",
+                    type: "DateTime",
+                    default: ExpressionUtils.call("now") as FieldDefault
                 },
                 updatedAt: {
-                    name: 'updatedAt',
-                    type: 'DateTime',
-                    updatedAt: true,
+                    name: "updatedAt",
+                    type: "DateTime",
+                    updatedAt: true
                 },
                 email: {
-                    name: 'email',
-                    type: 'String',
-                    unique: true,
+                    name: "email",
+                    type: "String",
+                    unique: true
                 },
                 name: {
-                    name: 'name',
-                    type: 'String',
-                    optional: true,
+                    name: "name",
+                    type: "String",
+                    optional: true
                 },
                 posts: {
-                    name: 'posts',
-                    type: 'Post',
+                    name: "posts",
+                    type: "Post",
                     array: true,
-                    relation: { opposite: 'author' },
-                },
+                    relation: { opposite: "author" }
+                }
             },
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-                email: { type: 'String' },
-            },
+                id: { type: "String" },
+                email: { type: "String" }
+            }
         },
         Post: {
-            name: 'Post',
+            name: "Post",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 createdAt: {
-                    name: 'createdAt',
-                    type: 'DateTime',
-                    default: ExpressionUtils.call('now') as FieldDefault,
+                    name: "createdAt",
+                    type: "DateTime",
+                    default: ExpressionUtils.call("now") as FieldDefault
                 },
                 updatedAt: {
-                    name: 'updatedAt',
-                    type: 'DateTime',
-                    updatedAt: true,
+                    name: "updatedAt",
+                    type: "DateTime",
+                    updatedAt: true
                 },
                 title: {
-                    name: 'title',
-                    type: 'String',
+                    name: "title",
+                    type: "String"
                 },
                 published: {
-                    name: 'published',
-                    type: 'Boolean',
-                    default: false as FieldDefault,
+                    name: "published",
+                    type: "Boolean",
+                    default: false as FieldDefault
                 },
                 author: {
-                    name: 'author',
-                    type: 'User',
-                    relation: {
-                        opposite: 'posts',
-                        fields: ['authorId'],
-                        references: ['id'],
-                        onUpdate: 'Cascade',
-                        onDelete: 'Cascade',
-                    },
+                    name: "author",
+                    type: "User",
+                    relation: { opposite: "posts", fields: ["authorId"], references: ["id"], onUpdate: "Cascade", onDelete: "Cascade" }
                 },
                 authorId: {
-                    name: 'authorId',
-                    type: 'String',
-                    foreignKeyFor: ['author'] as readonly string[],
-                },
+                    name: "authorId",
+                    type: "String",
+                    foreignKeyFor: [
+                        "author"
+                    ] as readonly string[]
+                }
             },
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-            },
-        },
+                id: { type: "String" }
+            }
+        }
     } as const;
-    authType = 'User' as const;
+    authType = "User" as const;
     procedures = {
         signUp: {
             params: {
-                email: { name: 'email', type: 'String' },
+                email: { name: "email", type: "String" }
             },
-            returnType: 'User',
-            mutation: true,
+            returnType: "User",
+            mutation: true
         },
         listPublicPosts: {
             params: {},
-            returnType: 'Post',
-            returnArray: true,
-        },
+            returnType: "Post",
+            returnArray: true
+        }
     } as const;
     plugins = {};
 }

--- a/samples/nuxt/zenstack/schema-lite.ts
+++ b/samples/nuxt/zenstack/schema-lite.ts
@@ -5,119 +5,115 @@
 
 /* eslint-disable */
 
-import { type SchemaDef, type FieldDefault, ExpressionUtils } from '@zenstackhq/schema';
+import { type SchemaDef, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
 export class SchemaType implements SchemaDef {
     provider = {
-        type: 'sqlite',
+        type: "sqlite"
     } as const;
     models = {
         User: {
-            name: 'User',
+            name: "User",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 createdAt: {
-                    name: 'createdAt',
-                    type: 'DateTime',
-                    default: ExpressionUtils.call('now') as FieldDefault,
+                    name: "createdAt",
+                    type: "DateTime",
+                    default: ExpressionUtils.call("now") as FieldDefault
                 },
                 updatedAt: {
-                    name: 'updatedAt',
-                    type: 'DateTime',
-                    updatedAt: true,
+                    name: "updatedAt",
+                    type: "DateTime",
+                    updatedAt: true
                 },
                 email: {
-                    name: 'email',
-                    type: 'String',
-                    unique: true,
+                    name: "email",
+                    type: "String",
+                    unique: true
                 },
                 name: {
-                    name: 'name',
-                    type: 'String',
-                    optional: true,
+                    name: "name",
+                    type: "String",
+                    optional: true
                 },
                 posts: {
-                    name: 'posts',
-                    type: 'Post',
+                    name: "posts",
+                    type: "Post",
                     array: true,
-                    relation: { opposite: 'author' },
-                },
+                    relation: { opposite: "author" }
+                }
             },
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-                email: { type: 'String' },
-            },
+                id: { type: "String" },
+                email: { type: "String" }
+            }
         },
         Post: {
-            name: 'Post',
+            name: "Post",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 createdAt: {
-                    name: 'createdAt',
-                    type: 'DateTime',
-                    default: ExpressionUtils.call('now') as FieldDefault,
+                    name: "createdAt",
+                    type: "DateTime",
+                    default: ExpressionUtils.call("now") as FieldDefault
                 },
                 updatedAt: {
-                    name: 'updatedAt',
-                    type: 'DateTime',
-                    updatedAt: true,
+                    name: "updatedAt",
+                    type: "DateTime",
+                    updatedAt: true
                 },
                 title: {
-                    name: 'title',
-                    type: 'String',
+                    name: "title",
+                    type: "String"
                 },
                 published: {
-                    name: 'published',
-                    type: 'Boolean',
-                    default: false as FieldDefault,
+                    name: "published",
+                    type: "Boolean",
+                    default: false as FieldDefault
                 },
                 author: {
-                    name: 'author',
-                    type: 'User',
-                    relation: {
-                        opposite: 'posts',
-                        fields: ['authorId'],
-                        references: ['id'],
-                        onUpdate: 'Cascade',
-                        onDelete: 'Cascade',
-                    },
+                    name: "author",
+                    type: "User",
+                    relation: { opposite: "posts", fields: ["authorId"], references: ["id"], onUpdate: "Cascade", onDelete: "Cascade" }
                 },
                 authorId: {
-                    name: 'authorId',
-                    type: 'String',
-                    foreignKeyFor: ['author'] as readonly string[],
-                },
+                    name: "authorId",
+                    type: "String",
+                    foreignKeyFor: [
+                        "author"
+                    ] as readonly string[]
+                }
             },
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-            },
-        },
+                id: { type: "String" }
+            }
+        }
     } as const;
-    authType = 'User' as const;
+    authType = "User" as const;
     procedures = {
         signUp: {
             params: {
-                email: { name: 'email', type: 'String' },
+                email: { name: "email", type: "String" }
             },
-            returnType: 'User',
-            mutation: true,
+            returnType: "User",
+            mutation: true
         },
         listPublicPosts: {
             params: {},
-            returnType: 'Post',
-            returnArray: true,
-        },
+            returnType: "Post",
+            returnArray: true
+        }
     } as const;
     plugins = {};
 }

--- a/samples/sveltekit/src/zenstack/input.ts
+++ b/samples/sveltekit/src/zenstack/input.ts
@@ -6,53 +6,18 @@
 /* eslint-disable */
 
 import { type SchemaType as $Schema } from "./schema-lite";
-import type {
-  FindManyArgs as $FindManyArgs,
-  FindUniqueArgs as $FindUniqueArgs,
-  FindFirstArgs as $FindFirstArgs,
-  ExistsArgs as $ExistsArgs,
-  CreateArgs as $CreateArgs,
-  CreateManyArgs as $CreateManyArgs,
-  CreateManyAndReturnArgs as $CreateManyAndReturnArgs,
-  UpdateArgs as $UpdateArgs,
-  UpdateManyArgs as $UpdateManyArgs,
-  UpdateManyAndReturnArgs as $UpdateManyAndReturnArgs,
-  UpsertArgs as $UpsertArgs,
-  DeleteArgs as $DeleteArgs,
-  DeleteManyArgs as $DeleteManyArgs,
-  CountArgs as $CountArgs,
-  AggregateArgs as $AggregateArgs,
-  GroupByArgs as $GroupByArgs,
-  WhereInput as $WhereInput,
-  SelectInput as $SelectInput,
-  IncludeInput as $IncludeInput,
-  OmitInput as $OmitInput,
-  UncheckedCreateInput as $UncheckedCreateInput,
-  CheckedCreateInput as $CheckedCreateInput,
-  UncheckedUpdateInput as $UncheckedUpdateInput,
-  CheckedUpdateInput as $CheckedUpdateInput,
-  QueryOptions as $QueryOptions,
-} from "@zenstackhq/orm";
-import type {
-  SimplifiedPlainResult as $Result,
-  SelectIncludeOmit as $SelectIncludeOmit,
-} from "@zenstackhq/orm";
+import type { FindManyArgs as $FindManyArgs, FindUniqueArgs as $FindUniqueArgs, FindFirstArgs as $FindFirstArgs, ExistsArgs as $ExistsArgs, CreateArgs as $CreateArgs, CreateManyArgs as $CreateManyArgs, CreateManyAndReturnArgs as $CreateManyAndReturnArgs, UpdateArgs as $UpdateArgs, UpdateManyArgs as $UpdateManyArgs, UpdateManyAndReturnArgs as $UpdateManyAndReturnArgs, UpsertArgs as $UpsertArgs, DeleteArgs as $DeleteArgs, DeleteManyArgs as $DeleteManyArgs, CountArgs as $CountArgs, AggregateArgs as $AggregateArgs, GroupByArgs as $GroupByArgs, WhereInput as $WhereInput, SelectInput as $SelectInput, IncludeInput as $IncludeInput, OmitInput as $OmitInput, UncheckedCreateInput as $UncheckedCreateInput, CheckedCreateInput as $CheckedCreateInput, UncheckedUpdateInput as $UncheckedUpdateInput, CheckedUpdateInput as $CheckedUpdateInput, QueryOptions as $QueryOptions } from "@zenstackhq/orm";
+import type { SimplifiedPlainResult as $Result, SelectIncludeOmit as $SelectIncludeOmit } from "@zenstackhq/orm";
 export type UserFindManyArgs = $FindManyArgs<$Schema, "User">;
 export type UserFindUniqueArgs = $FindUniqueArgs<$Schema, "User">;
 export type UserFindFirstArgs = $FindFirstArgs<$Schema, "User">;
 export type UserExistsArgs = $ExistsArgs<$Schema, "User">;
 export type UserCreateArgs = $CreateArgs<$Schema, "User">;
 export type UserCreateManyArgs = $CreateManyArgs<$Schema, "User">;
-export type UserCreateManyAndReturnArgs = $CreateManyAndReturnArgs<
-  $Schema,
-  "User"
->;
+export type UserCreateManyAndReturnArgs = $CreateManyAndReturnArgs<$Schema, "User">;
 export type UserUpdateArgs = $UpdateArgs<$Schema, "User">;
 export type UserUpdateManyArgs = $UpdateManyArgs<$Schema, "User">;
-export type UserUpdateManyAndReturnArgs = $UpdateManyAndReturnArgs<
-  $Schema,
-  "User"
->;
+export type UserUpdateManyAndReturnArgs = $UpdateManyAndReturnArgs<$Schema, "User">;
 export type UserUpsertArgs = $UpsertArgs<$Schema, "User">;
 export type UserDeleteArgs = $DeleteArgs<$Schema, "User">;
 export type UserDeleteManyArgs = $DeleteManyArgs<$Schema, "User">;
@@ -67,26 +32,17 @@ export type UserUncheckedCreateInput = $UncheckedCreateInput<$Schema, "User">;
 export type UserCheckedCreateInput = $CheckedCreateInput<$Schema, "User">;
 export type UserUncheckedUpdateInput = $UncheckedUpdateInput<$Schema, "User">;
 export type UserCheckedUpdateInput = $CheckedUpdateInput<$Schema, "User">;
-export type UserGetPayload<
-  Args extends $SelectIncludeOmit<$Schema, "User", true>,
-  Options extends $QueryOptions<$Schema> = $QueryOptions<$Schema>,
-> = $Result<$Schema, "User", Args, Options>;
+export type UserGetPayload<Args extends $SelectIncludeOmit<$Schema, "User", true>, Options extends $QueryOptions<$Schema> = $QueryOptions<$Schema>> = $Result<$Schema, "User", Args, Options>;
 export type PostFindManyArgs = $FindManyArgs<$Schema, "Post">;
 export type PostFindUniqueArgs = $FindUniqueArgs<$Schema, "Post">;
 export type PostFindFirstArgs = $FindFirstArgs<$Schema, "Post">;
 export type PostExistsArgs = $ExistsArgs<$Schema, "Post">;
 export type PostCreateArgs = $CreateArgs<$Schema, "Post">;
 export type PostCreateManyArgs = $CreateManyArgs<$Schema, "Post">;
-export type PostCreateManyAndReturnArgs = $CreateManyAndReturnArgs<
-  $Schema,
-  "Post"
->;
+export type PostCreateManyAndReturnArgs = $CreateManyAndReturnArgs<$Schema, "Post">;
 export type PostUpdateArgs = $UpdateArgs<$Schema, "Post">;
 export type PostUpdateManyArgs = $UpdateManyArgs<$Schema, "Post">;
-export type PostUpdateManyAndReturnArgs = $UpdateManyAndReturnArgs<
-  $Schema,
-  "Post"
->;
+export type PostUpdateManyAndReturnArgs = $UpdateManyAndReturnArgs<$Schema, "Post">;
 export type PostUpsertArgs = $UpsertArgs<$Schema, "Post">;
 export type PostDeleteArgs = $DeleteArgs<$Schema, "Post">;
 export type PostDeleteManyArgs = $DeleteManyArgs<$Schema, "Post">;
@@ -101,7 +57,4 @@ export type PostUncheckedCreateInput = $UncheckedCreateInput<$Schema, "Post">;
 export type PostCheckedCreateInput = $CheckedCreateInput<$Schema, "Post">;
 export type PostUncheckedUpdateInput = $UncheckedUpdateInput<$Schema, "Post">;
 export type PostCheckedUpdateInput = $CheckedUpdateInput<$Schema, "Post">;
-export type PostGetPayload<
-  Args extends $SelectIncludeOmit<$Schema, "Post", true>,
-  Options extends $QueryOptions<$Schema> = $QueryOptions<$Schema>,
-> = $Result<$Schema, "Post", Args, Options>;
+export type PostGetPayload<Args extends $SelectIncludeOmit<$Schema, "Post", true>, Options extends $QueryOptions<$Schema> = $QueryOptions<$Schema>> = $Result<$Schema, "Post", Args, Options>;

--- a/samples/sveltekit/src/zenstack/schema-lite.ts
+++ b/samples/sveltekit/src/zenstack/schema-lite.ts
@@ -5,124 +5,116 @@
 
 /* eslint-disable */
 
-import {
-  type SchemaDef,
-  type FieldDefault,
-  ExpressionUtils,
-} from "@zenstackhq/schema";
+import { type SchemaDef, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
 export class SchemaType implements SchemaDef {
-  provider = {
-    type: "sqlite",
-  } as const;
-  models = {
-    User: {
-      name: "User",
-      fields: {
-        id: {
-          name: "id",
-          type: "String",
-          id: true,
-          default: ExpressionUtils.call("cuid") as FieldDefault,
+    provider = {
+        type: "sqlite"
+    } as const;
+    models = {
+        User: {
+            name: "User",
+            fields: {
+                id: {
+                    name: "id",
+                    type: "String",
+                    id: true,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
+                },
+                createdAt: {
+                    name: "createdAt",
+                    type: "DateTime",
+                    default: ExpressionUtils.call("now") as FieldDefault
+                },
+                updatedAt: {
+                    name: "updatedAt",
+                    type: "DateTime",
+                    updatedAt: true
+                },
+                email: {
+                    name: "email",
+                    type: "String",
+                    unique: true
+                },
+                name: {
+                    name: "name",
+                    type: "String",
+                    optional: true
+                },
+                posts: {
+                    name: "posts",
+                    type: "Post",
+                    array: true,
+                    relation: { opposite: "author" }
+                }
+            },
+            idFields: ["id"],
+            uniqueFields: {
+                id: { type: "String" },
+                email: { type: "String" }
+            }
         },
-        createdAt: {
-          name: "createdAt",
-          type: "DateTime",
-          default: ExpressionUtils.call("now") as FieldDefault,
+        Post: {
+            name: "Post",
+            fields: {
+                id: {
+                    name: "id",
+                    type: "String",
+                    id: true,
+                    default: ExpressionUtils.call("cuid") as FieldDefault
+                },
+                createdAt: {
+                    name: "createdAt",
+                    type: "DateTime",
+                    default: ExpressionUtils.call("now") as FieldDefault
+                },
+                updatedAt: {
+                    name: "updatedAt",
+                    type: "DateTime",
+                    updatedAt: true
+                },
+                title: {
+                    name: "title",
+                    type: "String"
+                },
+                published: {
+                    name: "published",
+                    type: "Boolean",
+                    default: false as FieldDefault
+                },
+                author: {
+                    name: "author",
+                    type: "User",
+                    relation: { opposite: "posts", fields: ["authorId"], references: ["id"], onUpdate: "Cascade", onDelete: "Cascade" }
+                },
+                authorId: {
+                    name: "authorId",
+                    type: "String",
+                    foreignKeyFor: [
+                        "author"
+                    ] as readonly string[]
+                }
+            },
+            idFields: ["id"],
+            uniqueFields: {
+                id: { type: "String" }
+            }
+        }
+    } as const;
+    authType = "User" as const;
+    procedures = {
+        signUp: {
+            params: {
+                email: { name: "email", type: "String" }
+            },
+            returnType: "User",
+            mutation: true
         },
-        updatedAt: {
-          name: "updatedAt",
-          type: "DateTime",
-          updatedAt: true,
-        },
-        email: {
-          name: "email",
-          type: "String",
-          unique: true,
-        },
-        name: {
-          name: "name",
-          type: "String",
-          optional: true,
-        },
-        posts: {
-          name: "posts",
-          type: "Post",
-          array: true,
-          relation: { opposite: "author" },
-        },
-      },
-      idFields: ["id"],
-      uniqueFields: {
-        id: { type: "String" },
-        email: { type: "String" },
-      },
-    },
-    Post: {
-      name: "Post",
-      fields: {
-        id: {
-          name: "id",
-          type: "String",
-          id: true,
-          default: ExpressionUtils.call("cuid") as FieldDefault,
-        },
-        createdAt: {
-          name: "createdAt",
-          type: "DateTime",
-          default: ExpressionUtils.call("now") as FieldDefault,
-        },
-        updatedAt: {
-          name: "updatedAt",
-          type: "DateTime",
-          updatedAt: true,
-        },
-        title: {
-          name: "title",
-          type: "String",
-        },
-        published: {
-          name: "published",
-          type: "Boolean",
-          default: false as FieldDefault,
-        },
-        author: {
-          name: "author",
-          type: "User",
-          relation: {
-            opposite: "posts",
-            fields: ["authorId"],
-            references: ["id"],
-            onUpdate: "Cascade",
-            onDelete: "Cascade",
-          },
-        },
-        authorId: {
-          name: "authorId",
-          type: "String",
-          foreignKeyFor: ["author"] as readonly string[],
-        },
-      },
-      idFields: ["id"],
-      uniqueFields: {
-        id: { type: "String" },
-      },
-    },
-  } as const;
-  authType = "User" as const;
-  procedures = {
-    signUp: {
-      params: {
-        email: { name: "email", type: "String" },
-      },
-      returnType: "User",
-      mutation: true,
-    },
-    listPublicPosts: {
-      params: {},
-      returnType: "Post",
-      returnArray: true,
-    },
-  } as const;
-  plugins = {};
+        listPublicPosts: {
+            params: {},
+            returnType: "Post",
+            returnArray: true
+        }
+    } as const;
+    plugins = {};
 }
 export const schema = new SchemaType();

--- a/samples/sveltekit/src/zenstack/schema.ts
+++ b/samples/sveltekit/src/zenstack/schema.ts
@@ -5,185 +5,125 @@
 
 /* eslint-disable */
 
-import {
-  type SchemaDef,
-  type AttributeApplication,
-  type FieldDefault,
-  ExpressionUtils,
-} from "@zenstackhq/schema";
+import { type SchemaDef, type AttributeApplication, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
 export class SchemaType implements SchemaDef {
-  provider = {
-    type: "sqlite",
-  } as const;
-  models = {
-    User: {
-      name: "User",
-      fields: {
-        id: {
-          name: "id",
-          type: "String",
-          id: true,
-          attributes: [
-            { name: "@id" },
-            {
-              name: "@default",
-              args: [{ name: "value", value: ExpressionUtils.call("cuid") }],
-            },
-          ] as readonly AttributeApplication[],
-          default: ExpressionUtils.call("cuid") as FieldDefault,
-        },
-        createdAt: {
-          name: "createdAt",
-          type: "DateTime",
-          attributes: [
-            {
-              name: "@default",
-              args: [{ name: "value", value: ExpressionUtils.call("now") }],
-            },
-          ] as readonly AttributeApplication[],
-          default: ExpressionUtils.call("now") as FieldDefault,
-        },
-        updatedAt: {
-          name: "updatedAt",
-          type: "DateTime",
-          updatedAt: true,
-          attributes: [
-            { name: "@updatedAt" },
-          ] as readonly AttributeApplication[],
-        },
-        email: {
-          name: "email",
-          type: "String",
-          unique: true,
-          attributes: [{ name: "@unique" }] as readonly AttributeApplication[],
-        },
-        name: {
-          name: "name",
-          type: "String",
-          optional: true,
-        },
-        posts: {
-          name: "posts",
-          type: "Post",
-          array: true,
-          relation: { opposite: "author" },
-        },
-      },
-      idFields: ["id"],
-      uniqueFields: {
-        id: { type: "String" },
-        email: { type: "String" },
-      },
-    },
-    Post: {
-      name: "Post",
-      fields: {
-        id: {
-          name: "id",
-          type: "String",
-          id: true,
-          attributes: [
-            { name: "@id" },
-            {
-              name: "@default",
-              args: [{ name: "value", value: ExpressionUtils.call("cuid") }],
-            },
-          ] as readonly AttributeApplication[],
-          default: ExpressionUtils.call("cuid") as FieldDefault,
-        },
-        createdAt: {
-          name: "createdAt",
-          type: "DateTime",
-          attributes: [
-            {
-              name: "@default",
-              args: [{ name: "value", value: ExpressionUtils.call("now") }],
-            },
-          ] as readonly AttributeApplication[],
-          default: ExpressionUtils.call("now") as FieldDefault,
-        },
-        updatedAt: {
-          name: "updatedAt",
-          type: "DateTime",
-          updatedAt: true,
-          attributes: [
-            { name: "@updatedAt" },
-          ] as readonly AttributeApplication[],
-        },
-        title: {
-          name: "title",
-          type: "String",
-        },
-        published: {
-          name: "published",
-          type: "Boolean",
-          attributes: [
-            {
-              name: "@default",
-              args: [{ name: "value", value: ExpressionUtils.literal(false) }],
-            },
-          ] as readonly AttributeApplication[],
-          default: false as FieldDefault,
-        },
-        author: {
-          name: "author",
-          type: "User",
-          attributes: [
-            {
-              name: "@relation",
-              args: [
-                {
-                  name: "fields",
-                  value: ExpressionUtils.array("String", [
-                    ExpressionUtils.field("authorId"),
-                  ]),
+    provider = {
+        type: "sqlite"
+    } as const;
+    models = {
+        User: {
+            name: "User",
+            fields: {
+                id: {
+                    name: "id",
+                    type: "String",
+                    id: true,
+                    attributes: [{ name: "@id" }, { name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }] as readonly AttributeApplication[],
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
-                {
-                  name: "references",
-                  value: ExpressionUtils.array("String", [
-                    ExpressionUtils.field("id"),
-                  ]),
+                createdAt: {
+                    name: "createdAt",
+                    type: "DateTime",
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.call("now") }] }] as readonly AttributeApplication[],
+                    default: ExpressionUtils.call("now") as FieldDefault
                 },
-                { name: "onUpdate", value: ExpressionUtils.literal("Cascade") },
-                { name: "onDelete", value: ExpressionUtils.literal("Cascade") },
-              ],
+                updatedAt: {
+                    name: "updatedAt",
+                    type: "DateTime",
+                    updatedAt: true,
+                    attributes: [{ name: "@updatedAt" }] as readonly AttributeApplication[]
+                },
+                email: {
+                    name: "email",
+                    type: "String",
+                    unique: true,
+                    attributes: [{ name: "@unique" }] as readonly AttributeApplication[]
+                },
+                name: {
+                    name: "name",
+                    type: "String",
+                    optional: true
+                },
+                posts: {
+                    name: "posts",
+                    type: "Post",
+                    array: true,
+                    relation: { opposite: "author" }
+                }
             },
-          ] as readonly AttributeApplication[],
-          relation: {
-            opposite: "posts",
-            fields: ["authorId"],
-            references: ["id"],
-            onUpdate: "Cascade",
-            onDelete: "Cascade",
-          },
+            idFields: ["id"],
+            uniqueFields: {
+                id: { type: "String" },
+                email: { type: "String" }
+            }
         },
-        authorId: {
-          name: "authorId",
-          type: "String",
-          foreignKeyFor: ["author"] as readonly string[],
+        Post: {
+            name: "Post",
+            fields: {
+                id: {
+                    name: "id",
+                    type: "String",
+                    id: true,
+                    attributes: [{ name: "@id" }, { name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }] as readonly AttributeApplication[],
+                    default: ExpressionUtils.call("cuid") as FieldDefault
+                },
+                createdAt: {
+                    name: "createdAt",
+                    type: "DateTime",
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.call("now") }] }] as readonly AttributeApplication[],
+                    default: ExpressionUtils.call("now") as FieldDefault
+                },
+                updatedAt: {
+                    name: "updatedAt",
+                    type: "DateTime",
+                    updatedAt: true,
+                    attributes: [{ name: "@updatedAt" }] as readonly AttributeApplication[]
+                },
+                title: {
+                    name: "title",
+                    type: "String"
+                },
+                published: {
+                    name: "published",
+                    type: "Boolean",
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.literal(false) }] }] as readonly AttributeApplication[],
+                    default: false as FieldDefault
+                },
+                author: {
+                    name: "author",
+                    type: "User",
+                    attributes: [{ name: "@relation", args: [{ name: "fields", value: ExpressionUtils.array("String", [ExpressionUtils.field("authorId")]) }, { name: "references", value: ExpressionUtils.array("String", [ExpressionUtils.field("id")]) }, { name: "onUpdate", value: ExpressionUtils.literal("Cascade") }, { name: "onDelete", value: ExpressionUtils.literal("Cascade") }] }] as readonly AttributeApplication[],
+                    relation: { opposite: "posts", fields: ["authorId"], references: ["id"], onUpdate: "Cascade", onDelete: "Cascade" }
+                },
+                authorId: {
+                    name: "authorId",
+                    type: "String",
+                    foreignKeyFor: [
+                        "author"
+                    ] as readonly string[]
+                }
+            },
+            idFields: ["id"],
+            uniqueFields: {
+                id: { type: "String" }
+            }
+        }
+    } as const;
+    authType = "User" as const;
+    procedures = {
+        signUp: {
+            params: {
+                email: { name: "email", type: "String" }
+            },
+            returnType: "User",
+            mutation: true
         },
-      },
-      idFields: ["id"],
-      uniqueFields: {
-        id: { type: "String" },
-      },
-    },
-  } as const;
-  authType = "User" as const;
-  procedures = {
-    signUp: {
-      params: {
-        email: { name: "email", type: "String" },
-      },
-      returnType: "User",
-      mutation: true,
-    },
-    listPublicPosts: {
-      params: {},
-      returnType: "Post",
-      returnArray: true,
-    },
-  } as const;
-  plugins = {};
+        listPublicPosts: {
+            params: {},
+            returnType: "Post",
+            returnArray: true
+        }
+    } as const;
+    plugins = {};
 }
 export const schema = new SchemaType();

--- a/tests/regression/test/issue-2385.test.ts
+++ b/tests/regression/test/issue-2385.test.ts
@@ -25,7 +25,8 @@ model Association {
 
     @@allow("read", auth().id == userId)
 }
-            `, {
+            `,
+            {
                 provider: 'postgresql',
             },
         );

--- a/tests/regression/test/issue-393.test.ts
+++ b/tests/regression/test/issue-393.test.ts
@@ -8,9 +8,10 @@ describe('Regression for issue #393', () => {
 model users {
   id String @id() @default(cuid())
   tz Int @default(-6) @db.SmallInt()
-}`, {
-    provider: 'postgresql',
-},
+}`,
+            {
+                provider: 'postgresql',
+            },
         );
         await expect(db.users.create({ data: {} })).resolves.toMatchObject({ tz: -6 });
     });

--- a/tests/runtimes/bun/schemas/schema.ts
+++ b/tests/runtimes/bun/schemas/schema.ts
@@ -5,174 +5,96 @@
 
 /* eslint-disable */
 
-import { type SchemaDef, type AttributeApplication, type FieldDefault, ExpressionUtils } from '@zenstackhq/schema';
+import { type SchemaDef, type AttributeApplication, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
 export class SchemaType implements SchemaDef {
     provider = {
-        type: 'sqlite',
+        type: "sqlite"
     } as const;
     models = {
         User: {
-            name: 'User',
+            name: "User",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    attributes: [
-                        { name: '@id' },
-                        { name: '@default', args: [{ name: 'value', value: ExpressionUtils.call('cuid') }] },
-                    ] as readonly AttributeApplication[],
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    attributes: [{ name: "@id" }, { name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }] as readonly AttributeApplication[],
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 email: {
-                    name: 'email',
-                    type: 'String',
+                    name: "email",
+                    type: "String",
                     unique: true,
-                    attributes: [{ name: '@unique' }] as readonly AttributeApplication[],
+                    attributes: [{ name: "@unique" }] as readonly AttributeApplication[]
                 },
                 name: {
-                    name: 'name',
-                    type: 'String',
-                    optional: true,
+                    name: "name",
+                    type: "String",
+                    optional: true
                 },
                 posts: {
-                    name: 'posts',
-                    type: 'Post',
+                    name: "posts",
+                    type: "Post",
                     array: true,
-                    relation: { opposite: 'author' },
-                },
+                    relation: { opposite: "author" }
+                }
             },
             attributes: [
-                {
-                    name: '@@allow',
-                    args: [
-                        { name: 'operation', value: ExpressionUtils.literal('all') },
-                        {
-                            name: 'condition',
-                            value: ExpressionUtils.binary(
-                                ExpressionUtils.member(ExpressionUtils.call('auth'), ['id']),
-                                '==',
-                                ExpressionUtils.field('id'),
-                            ),
-                        },
-                    ],
-                },
-                {
-                    name: '@@allow',
-                    args: [
-                        { name: 'operation', value: ExpressionUtils.literal('read') },
-                        {
-                            name: 'condition',
-                            value: ExpressionUtils.binary(ExpressionUtils.call('auth'), '!=', ExpressionUtils._null()),
-                        },
-                    ],
-                },
+                { name: "@@allow", args: [{ name: "operation", value: ExpressionUtils.literal("all") }, { name: "condition", value: ExpressionUtils.binary(ExpressionUtils.member(ExpressionUtils.call("auth"), ["id"]), "==", ExpressionUtils.field("id")) }] },
+                { name: "@@allow", args: [{ name: "operation", value: ExpressionUtils.literal("read") }, { name: "condition", value: ExpressionUtils.binary(ExpressionUtils.call("auth"), "!=", ExpressionUtils._null()) }] }
             ] as readonly AttributeApplication[],
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-                email: { type: 'String' },
-            },
+                id: { type: "String" },
+                email: { type: "String" }
+            }
         },
         Post: {
-            name: 'Post',
+            name: "Post",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    attributes: [
-                        { name: '@id' },
-                        { name: '@default', args: [{ name: 'value', value: ExpressionUtils.call('cuid') }] },
-                    ] as readonly AttributeApplication[],
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    attributes: [{ name: "@id" }, { name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }] as readonly AttributeApplication[],
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 title: {
-                    name: 'title',
-                    type: 'String',
+                    name: "title",
+                    type: "String"
                 },
                 published: {
-                    name: 'published',
-                    type: 'Boolean',
-                    attributes: [
-                        { name: '@default', args: [{ name: 'value', value: ExpressionUtils.literal(false) }] },
-                    ] as readonly AttributeApplication[],
-                    default: false as FieldDefault,
+                    name: "published",
+                    type: "Boolean",
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.literal(false) }] }] as readonly AttributeApplication[],
+                    default: false as FieldDefault
                 },
                 author: {
-                    name: 'author',
-                    type: 'User',
-                    attributes: [
-                        {
-                            name: '@relation',
-                            args: [
-                                {
-                                    name: 'fields',
-                                    value: ExpressionUtils.array('String', [ExpressionUtils.field('authorId')]),
-                                },
-                                {
-                                    name: 'references',
-                                    value: ExpressionUtils.array('String', [ExpressionUtils.field('id')]),
-                                },
-                                { name: 'onUpdate', value: ExpressionUtils.literal('Cascade') },
-                                { name: 'onDelete', value: ExpressionUtils.literal('Cascade') },
-                            ],
-                        },
-                    ] as readonly AttributeApplication[],
-                    relation: {
-                        opposite: 'posts',
-                        fields: ['authorId'],
-                        references: ['id'],
-                        onUpdate: 'Cascade',
-                        onDelete: 'Cascade',
-                    },
+                    name: "author",
+                    type: "User",
+                    attributes: [{ name: "@relation", args: [{ name: "fields", value: ExpressionUtils.array("String", [ExpressionUtils.field("authorId")]) }, { name: "references", value: ExpressionUtils.array("String", [ExpressionUtils.field("id")]) }, { name: "onUpdate", value: ExpressionUtils.literal("Cascade") }, { name: "onDelete", value: ExpressionUtils.literal("Cascade") }] }] as readonly AttributeApplication[],
+                    relation: { opposite: "posts", fields: ["authorId"], references: ["id"], onUpdate: "Cascade", onDelete: "Cascade" }
                 },
                 authorId: {
-                    name: 'authorId',
-                    type: 'String',
-                    foreignKeyFor: ['author'] as readonly string[],
-                },
+                    name: "authorId",
+                    type: "String",
+                    foreignKeyFor: [
+                        "author"
+                    ] as readonly string[]
+                }
             },
             attributes: [
-                {
-                    name: '@@deny',
-                    args: [
-                        { name: 'operation', value: ExpressionUtils.literal('all') },
-                        {
-                            name: 'condition',
-                            value: ExpressionUtils.binary(ExpressionUtils.call('auth'), '==', ExpressionUtils._null()),
-                        },
-                    ],
-                },
-                {
-                    name: '@@allow',
-                    args: [
-                        { name: 'operation', value: ExpressionUtils.literal('all') },
-                        {
-                            name: 'condition',
-                            value: ExpressionUtils.binary(
-                                ExpressionUtils.member(ExpressionUtils.call('auth'), ['id']),
-                                '==',
-                                ExpressionUtils.field('authorId'),
-                            ),
-                        },
-                    ],
-                },
-                {
-                    name: '@@allow',
-                    args: [
-                        { name: 'operation', value: ExpressionUtils.literal('read') },
-                        { name: 'condition', value: ExpressionUtils.field('published') },
-                    ],
-                },
+                { name: "@@deny", args: [{ name: "operation", value: ExpressionUtils.literal("all") }, { name: "condition", value: ExpressionUtils.binary(ExpressionUtils.call("auth"), "==", ExpressionUtils._null()) }] },
+                { name: "@@allow", args: [{ name: "operation", value: ExpressionUtils.literal("all") }, { name: "condition", value: ExpressionUtils.binary(ExpressionUtils.member(ExpressionUtils.call("auth"), ["id"]), "==", ExpressionUtils.field("authorId")) }] },
+                { name: "@@allow", args: [{ name: "operation", value: ExpressionUtils.literal("read") }, { name: "condition", value: ExpressionUtils.field("published") }] }
             ] as readonly AttributeApplication[],
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-            },
-        },
+                id: { type: "String" }
+            }
+        }
     } as const;
-    authType = 'User' as const;
+    authType = "User" as const;
     plugins = {};
 }
 export const schema = new SchemaType();

--- a/tests/runtimes/edge-runtime/schemas/schema.ts
+++ b/tests/runtimes/edge-runtime/schemas/schema.ts
@@ -5,174 +5,96 @@
 
 /* eslint-disable */
 
-import { type SchemaDef, type AttributeApplication, type FieldDefault, ExpressionUtils } from '@zenstackhq/schema';
+import { type SchemaDef, type AttributeApplication, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
 export class SchemaType implements SchemaDef {
     provider = {
-        type: 'postgresql',
+        type: "postgresql"
     } as const;
     models = {
         User: {
-            name: 'User',
+            name: "User",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    attributes: [
-                        { name: '@id' },
-                        { name: '@default', args: [{ name: 'value', value: ExpressionUtils.call('cuid') }] },
-                    ] as readonly AttributeApplication[],
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    attributes: [{ name: "@id" }, { name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }] as readonly AttributeApplication[],
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 email: {
-                    name: 'email',
-                    type: 'String',
+                    name: "email",
+                    type: "String",
                     unique: true,
-                    attributes: [{ name: '@unique' }] as readonly AttributeApplication[],
+                    attributes: [{ name: "@unique" }] as readonly AttributeApplication[]
                 },
                 name: {
-                    name: 'name',
-                    type: 'String',
-                    optional: true,
+                    name: "name",
+                    type: "String",
+                    optional: true
                 },
                 posts: {
-                    name: 'posts',
-                    type: 'Post',
+                    name: "posts",
+                    type: "Post",
                     array: true,
-                    relation: { opposite: 'author' },
-                },
+                    relation: { opposite: "author" }
+                }
             },
             attributes: [
-                {
-                    name: '@@allow',
-                    args: [
-                        { name: 'operation', value: ExpressionUtils.literal('all') },
-                        {
-                            name: 'condition',
-                            value: ExpressionUtils.binary(
-                                ExpressionUtils.member(ExpressionUtils.call('auth'), ['id']),
-                                '==',
-                                ExpressionUtils.field('id'),
-                            ),
-                        },
-                    ],
-                },
-                {
-                    name: '@@allow',
-                    args: [
-                        { name: 'operation', value: ExpressionUtils.literal('read') },
-                        {
-                            name: 'condition',
-                            value: ExpressionUtils.binary(ExpressionUtils.call('auth'), '!=', ExpressionUtils._null()),
-                        },
-                    ],
-                },
+                { name: "@@allow", args: [{ name: "operation", value: ExpressionUtils.literal("all") }, { name: "condition", value: ExpressionUtils.binary(ExpressionUtils.member(ExpressionUtils.call("auth"), ["id"]), "==", ExpressionUtils.field("id")) }] },
+                { name: "@@allow", args: [{ name: "operation", value: ExpressionUtils.literal("read") }, { name: "condition", value: ExpressionUtils.binary(ExpressionUtils.call("auth"), "!=", ExpressionUtils._null()) }] }
             ] as readonly AttributeApplication[],
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-                email: { type: 'String' },
-            },
+                id: { type: "String" },
+                email: { type: "String" }
+            }
         },
         Post: {
-            name: 'Post',
+            name: "Post",
             fields: {
                 id: {
-                    name: 'id',
-                    type: 'String',
+                    name: "id",
+                    type: "String",
                     id: true,
-                    attributes: [
-                        { name: '@id' },
-                        { name: '@default', args: [{ name: 'value', value: ExpressionUtils.call('cuid') }] },
-                    ] as readonly AttributeApplication[],
-                    default: ExpressionUtils.call('cuid') as FieldDefault,
+                    attributes: [{ name: "@id" }, { name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }] as readonly AttributeApplication[],
+                    default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 title: {
-                    name: 'title',
-                    type: 'String',
+                    name: "title",
+                    type: "String"
                 },
                 published: {
-                    name: 'published',
-                    type: 'Boolean',
-                    attributes: [
-                        { name: '@default', args: [{ name: 'value', value: ExpressionUtils.literal(false) }] },
-                    ] as readonly AttributeApplication[],
-                    default: false as FieldDefault,
+                    name: "published",
+                    type: "Boolean",
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.literal(false) }] }] as readonly AttributeApplication[],
+                    default: false as FieldDefault
                 },
                 author: {
-                    name: 'author',
-                    type: 'User',
-                    attributes: [
-                        {
-                            name: '@relation',
-                            args: [
-                                {
-                                    name: 'fields',
-                                    value: ExpressionUtils.array('String', [ExpressionUtils.field('authorId')]),
-                                },
-                                {
-                                    name: 'references',
-                                    value: ExpressionUtils.array('String', [ExpressionUtils.field('id')]),
-                                },
-                                { name: 'onUpdate', value: ExpressionUtils.literal('Cascade') },
-                                { name: 'onDelete', value: ExpressionUtils.literal('Cascade') },
-                            ],
-                        },
-                    ] as readonly AttributeApplication[],
-                    relation: {
-                        opposite: 'posts',
-                        fields: ['authorId'],
-                        references: ['id'],
-                        onUpdate: 'Cascade',
-                        onDelete: 'Cascade',
-                    },
+                    name: "author",
+                    type: "User",
+                    attributes: [{ name: "@relation", args: [{ name: "fields", value: ExpressionUtils.array("String", [ExpressionUtils.field("authorId")]) }, { name: "references", value: ExpressionUtils.array("String", [ExpressionUtils.field("id")]) }, { name: "onUpdate", value: ExpressionUtils.literal("Cascade") }, { name: "onDelete", value: ExpressionUtils.literal("Cascade") }] }] as readonly AttributeApplication[],
+                    relation: { opposite: "posts", fields: ["authorId"], references: ["id"], onUpdate: "Cascade", onDelete: "Cascade" }
                 },
                 authorId: {
-                    name: 'authorId',
-                    type: 'String',
-                    foreignKeyFor: ['author'] as readonly string[],
-                },
+                    name: "authorId",
+                    type: "String",
+                    foreignKeyFor: [
+                        "author"
+                    ] as readonly string[]
+                }
             },
             attributes: [
-                {
-                    name: '@@deny',
-                    args: [
-                        { name: 'operation', value: ExpressionUtils.literal('all') },
-                        {
-                            name: 'condition',
-                            value: ExpressionUtils.binary(ExpressionUtils.call('auth'), '==', ExpressionUtils._null()),
-                        },
-                    ],
-                },
-                {
-                    name: '@@allow',
-                    args: [
-                        { name: 'operation', value: ExpressionUtils.literal('all') },
-                        {
-                            name: 'condition',
-                            value: ExpressionUtils.binary(
-                                ExpressionUtils.member(ExpressionUtils.call('auth'), ['id']),
-                                '==',
-                                ExpressionUtils.field('authorId'),
-                            ),
-                        },
-                    ],
-                },
-                {
-                    name: '@@allow',
-                    args: [
-                        { name: 'operation', value: ExpressionUtils.literal('read') },
-                        { name: 'condition', value: ExpressionUtils.field('published') },
-                    ],
-                },
+                { name: "@@deny", args: [{ name: "operation", value: ExpressionUtils.literal("all") }, { name: "condition", value: ExpressionUtils.binary(ExpressionUtils.call("auth"), "==", ExpressionUtils._null()) }] },
+                { name: "@@allow", args: [{ name: "operation", value: ExpressionUtils.literal("all") }, { name: "condition", value: ExpressionUtils.binary(ExpressionUtils.member(ExpressionUtils.call("auth"), ["id"]), "==", ExpressionUtils.field("authorId")) }] },
+                { name: "@@allow", args: [{ name: "operation", value: ExpressionUtils.literal("read") }, { name: "condition", value: ExpressionUtils.field("published") }] }
             ] as readonly AttributeApplication[],
-            idFields: ['id'],
+            idFields: ["id"],
             uniqueFields: {
-                id: { type: 'String' },
-            },
-        },
+                id: { type: "String" }
+            }
+        }
     } as const;
-    authType = 'User' as const;
+    authType = "User" as const;
     plugins = {};
 }
 export const schema = new SchemaType();


### PR DESCRIPTION
## Summary

The v3.9.0 release run ([failed job](https://github.com/zenstackhq/zenstack/actions/runs/30814620533/job/91689208437)) died in the `Publish packages` step with `ERR_PNPM_GIT_UNCLEAN`.

Root cause: #2779 ran prettier over tracked **generated** files (`schema.ts`, `schema-lite.ts`, `models.ts`, `input.ts` under `samples/`, `tests/`, and package test dirs). In the release workflow, sample/test builds run `zen generate`, which rewrites those files with the generator's own formatting (double quotes, no trailing commas), leaving modified tracked files in the working tree — so `pnpm -r publish` fails its git-clean check.

## Changes

- Extend `.prettierignore` to cover all ZenStack-generated file names. The previous list missed `schema-lite.ts` entirely and didn't cover `tests/runtimes/**`. Patterns stay scoped to `samples/`, `tests/`, and `**/test/**` because a few hand-written source files share these names (`packages/orm/src/schema.ts`, `packages/schema/src/schema.ts`, `packages/testtools/src/schema.ts`).
- Restore the 10 generated files that a full `pnpm build` dirties back to pristine generator output, so builds no longer touch the tree.

This also prevents recurrence via the pre-commit hook: `lint-staged` runs `prettier --write` on staged `*.ts`, which would otherwise re-format regenerated files on every commit.

## Verification

- Enumerated all 117 tracked files carrying the "automatically generated by ZenStack CLI" banner; `prettier --list-different` now reports none of them (the restored files use generator formatting, so they would be flagged if the ignore rules didn't match).
- Full `pnpm build` (minus `bun-e2e`, no bun installed locally) leaves the working tree clean.

After this merges to `main`, the failed release can be re-triggered via workflow dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized formatting across generated schema and type-definition files.
  * Normalized quote styles, indentation, trailing commas, and expression layout without changing behavior.
  * Improved consistency in command-line, validation, and test code formatting.

* **Documentation**
  * Updated issue-report and conduct templates to use consistent Markdown list formatting.

* **Chores**
  * Expanded formatting exclusions to cover generated schema files throughout the test suite.
  * Updated generated examples and test fixtures for consistent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->