### PR TITLE
fix(orm): parenthesize an inlined computed field expression

### DIFF
--- a/packages/orm/src/client/crud/dialects/base-dialect.ts
+++ b/packages/orm/src/client/crud/dialects/base-dialect.ts
@@ -1689,9 +1689,10 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
             // every query issued through the ORM builds the dialect from a client, and a dialect
             // built from a standalone schema/options pair never inlines computed fields
             invariant(this.client, `computed field "${field}" of model "${model}" needs a client to be evaluated`);
-            // `computedArgs` is the query-time args object for a parameterized computed
-            // field (undefined otherwise); forwarded as the implementation's 3rd argument.
-            return computer(this.eb, { modelAlias, client: this.client }, computedArgs);
+            // `computedArgs` is the query-time args of a parameterized computed field (undefined
+            // otherwise), forwarded as the implementation's 3rd argument. The result is parenthesized
+            // as it gets embedded into larger expressions: `where: { isMine: true }` → `(<expr>) = $n`.
+            return this.eb.parens(computer(this.eb, { modelAlias, client: this.client }, computedArgs));
         }
     }
 

--- a/tests/e2e/orm/client-api/computed-fields.test.ts
+++ b/tests/e2e/orm/client-api/computed-fields.test.ts
@@ -1002,9 +1002,8 @@ model Post {
             {
                 computedFields: {
                     Post: {
-                        // parenthesized: the expression gets embedded into larger ones
-                        // (e.g. `where: { isMine: true }` wraps it with `= true`), and an
-                        // unparenthesized chained comparison is a syntax error on postgres
+                        // the dialect parenthesizes an inlined implementation itself; the explicit
+                        // `eb.parens` here guards that an already-parenthesized one isn't wrapped twice
                         isMine: (eb: any, { client }: any) => eb.parens(eb('authorId', '=', client.$auth?.id ?? -1)),
                     },
                 },
@@ -1025,5 +1024,47 @@ model Post {
 
         // the original client is unaffected
         await expect(db.post.findUnique({ where: { id: 1 } })).resolves.toMatchObject({ isMine: false });
+    });
+
+    it('contains the precedence of an inlined computed field expression', async () => {
+        const db = await createTestClient(
+            `
+model Post {
+    id Int @id @default(autoincrement())
+    authorId Int
+    isMine Boolean @computed
+    isSpecial Boolean @computed
+}
+`,
+            {
+                computedFields: {
+                    Post: {
+                        // top-level node is a binary operation, which is embedded into
+                        // `<expr> = $n` when the field is used as a boolean filter
+                        isMine: (eb: any) => eb('authorId', '=', 1),
+                        // top-level node is a logical combinator
+                        isSpecial: (eb: any) => eb.or([eb('authorId', '=', 1), eb('id', '=', 2)]),
+                    },
+                },
+            } as any,
+        );
+
+        await db.post.create({ data: { id: 1, authorId: 1 } });
+        await db.post.create({ data: { id: 2, authorId: 2 } });
+        await db.post.create({ data: { id: 3, authorId: 3 } });
+
+        const findIds = async (where: any) =>
+            (await db.post.findMany({ where, orderBy: { id: 'asc' } })).map((r: any) => r.id);
+
+        expect(await findIds({ isMine: true })).toEqual([1]);
+        expect(await findIds({ isMine: false })).toEqual([2, 3]);
+        expect(await findIds({ NOT: { isMine: true } })).toEqual([2, 3]);
+        expect(await findIds({ isSpecial: true })).toEqual([1, 2]);
+
+        // reading the fields is unaffected
+        await expect(db.post.findUnique({ where: { id: 1 } })).resolves.toMatchObject({
+            isMine: true,
+            isSpecial: true,
+        });
     });
 });


### PR DESCRIPTION
Fixes #2795

### Motivation

A computed field is inlined into larger expressions — a boolean filter renders it as `<expr> = $n`. If the implementation's top-level node is a bare comparison, the operator precedence leaks into the surrounding query:

```ts
computedFields: {
    post: {
        isMine: (eb) => eb('authorId', '=', 1),
    },
},
```

```ts
await db.post.findMany({ where: { isMine: true } });
```

```
error: syntax error at or near "="
```

```sql
-- before
select "Post"."id" as "id", "authorId" = $1 as "isMine" from "public"."Post" where "authorId" = $2 = $3
-- after
select "Post"."id" as "id", ("authorId" = $1) as "isMine" from "public"."Post" where ("authorId" = $2) = $3
```

Postgres rejects the chained `=` outright. SQLite and MySQL parse it left-associatively as `(a = $2) = $3`, which happens to be the intended semantics, so the bug is invisible there — it surfaced only on the Postgres CI matrix of #2789.

### Changes

- `BaseCrudDialect.fieldRef()` wraps the implementation's expression in `eb.parens()` when inlining a computed field.
- e2e test in `computed-fields.test.ts` (runs on every provider in the matrix): a bare-comparison field asserted through `where: { isMine: true }` / `{ isMine: false }` / `NOT`, plus an `eb.or`-based field as a no-regression guard.

The wrap is unconditional because Kysely skips it for an expression that is already parenthesized, so `eb.or` / `eb.and` and subquery implementations compile byte-for-byte as before; only bare comparisons, unary operations and raw fragments change. Verified against the compiled SQL for each shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering for computed fields that use comparisons or combined logical expressions.
  * Ensured computed-field expressions are grouped correctly when used in larger queries.
  * Preserved support for true, false, `NOT`, and `OR` filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->