### PR TITLE
fix(orm): allow setting `null` on optional `Decimal` fields when using `sqlite` provider

### DIFF
--- a/packages/orm/src/client/crud/dialects/sqlite.ts
+++ b/packages/orm/src/client/crud/dialects/sqlite.ts
@@ -99,7 +99,7 @@ export class SqliteCrudDialect<Schema extends SchemaDef> extends BaseCrudDialect
                           ? new Date(value).toISOString()
                           : value;
                 case 'Decimal':
-                    return (value as Decimal).toString();
+                    return value !== null ? value.toString() : value;
                 case 'Bytes':
                     return Buffer.from(value as Uint8Array);
                 default:

--- a/tests/e2e/orm/client-api/sqlite-null.test.ts
+++ b/tests/e2e/orm/client-api/sqlite-null.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 const provider = getTestDbProvider();
 
 describe.skipIf(provider !== 'sqlite')('sqlite null tests', () => {
-    it('allows writing null to a optional Decimal fields', async () => {
+    it('allows writing null to optional Decimal fields', async () => {
         const db = await createTestClient(
             `
 model User {

--- a/tests/e2e/orm/client-api/sqlite-null.test.ts
+++ b/tests/e2e/orm/client-api/sqlite-null.test.ts
@@ -1,0 +1,27 @@
+import { createTestClient, getTestDbProvider } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+const provider = getTestDbProvider();
+
+describe.skipIf(provider !== 'sqlite')('sqlite null tests', () => {
+    it('allows writing null to a optional Decimal fields', async () => {
+        const db = await createTestClient(
+            `
+model User {
+    id      Int @id @default(autoincrement())
+    balance Decimal?
+}
+`,
+        );
+
+        await expect(
+            db.user.create({
+                data: {
+                    balance: null,
+                },
+            }),
+        ).resolves.toMatchObject({
+            balance: null,
+        });
+    });
+});

--- a/tests/e2e/orm/client-api/sqlite-null.test.ts
+++ b/tests/e2e/orm/client-api/sqlite-null.test.ts
@@ -1,5 +1,6 @@
 import { createTestClient, getTestDbProvider } from '@zenstackhq/testtools';
 import { describe, expect, it } from 'vitest';
+import Decimal from 'decimal.js';
 
 const provider = getTestDbProvider();
 
@@ -14,10 +15,34 @@ model User {
 `,
         );
 
+        const user = await db.user.create({
+            data: {
+                balance: null,
+            },
+        });
+
+        expect(user).toMatchObject({
+            balance: null,
+        });
+
+        await db.user.update({
+            data: {
+                balance: Decimal(1),
+            },
+
+            where: {
+                id: user.id,
+            },
+        });
+
         await expect(
-            db.user.create({
+            db.user.update({
                 data: {
                     balance: null,
+                },
+
+                where: {
+                    id: user.id,
                 },
             }),
         ).resolves.toMatchObject({


### PR DESCRIPTION
Fixes #2797 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optional Decimal fields in SQLite now correctly preserve `null` values when creating and retrieving records.
  * Non-null Decimal values continue to be handled as expected.

* **Tests**
  * Added end-to-end coverage for nullable Decimal fields in SQLite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->