### PR TITLE
fix(language): semantic highlighting issues

### DIFF
--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -23,8 +23,8 @@
         "watch": "tsdown --watch",
         "lint": "eslint src --ext ts",
         "test": "vitest run",
-        "langium:generate": "langium generate",
-        "langium:generate:production": "langium generate --mode=production",
+        "langium:generate": "langium generate && tsx scripts/patch-generated-tm.ts",
+        "langium:generate:production": "langium generate --mode=production && tsx scripts/patch-generated-tm.ts",
         "pack": "pnpm pack"
     },
     "exports": {

--- a/packages/language/scripts/patch-generated-tm.ts
+++ b/packages/language/scripts/patch-generated-tm.ts
@@ -1,0 +1,37 @@
+import tm from '../syntaxes/zmodel.tmLanguage.json';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+
+const tmPath = join(import.meta.dirname, '../syntaxes/zmodel.tmLanguage.json');
+
+const control = tm.patterns.find((pattern) => pattern.name === 'keyword.control.zmodel-v3');
+
+if (!control?.match) {
+    throw new Error('Could not find control pattern/match');
+}
+
+const keywordsToRemove = new Set(['this', 'null', 'true', 'false', 'in']);
+
+const pattern = /\((.+)\)/g;
+
+const [, keywordsMatch] = pattern.exec(control.match) as RegExpExecArray;
+const keywordsArray = keywordsMatch.split('|').filter((keyword) => !keywordsToRemove.has(keyword));
+
+control.match = control.match.replace(keywordsMatch, keywordsArray.join('|'));
+
+tm.patterns.push({
+    name: 'constant.language',
+    match: '\\b(true|false|null)\\b',
+});
+
+tm.patterns.push({
+    name: 'variable.language.this',
+    match: '\\b(this)\\b',
+});
+
+tm.patterns.push({
+    name: 'keyword.operator.expression.in',
+    match: '\\b(in)\\b',
+});
+
+writeFileSync(tmPath, JSON.stringify(tm, null, 2));

--- a/packages/language/scripts/patch-generated-tm.ts
+++ b/packages/language/scripts/patch-generated-tm.ts
@@ -1,3 +1,8 @@
+/**
+ * Post-processes syntaxes/zmodel.tmLanguage.json after `langium generate` to correct
+ * highlighting for some keywords.
+ */
+
 import tm from '../syntaxes/zmodel.tmLanguage.json';
 import { writeFileSync } from 'fs';
 import { join } from 'path';

--- a/packages/language/scripts/patch-generated-tm.ts
+++ b/packages/language/scripts/patch-generated-tm.ts
@@ -14,7 +14,27 @@ if (!control?.match) {
     throw new Error('Could not find control pattern/match');
 }
 
-const keywordsToRemove = new Set(['this', 'null', 'true', 'false', 'in']);
+const keywordsToRemove = new Set([
+    'this',
+    'null',
+    'true',
+    'false',
+    'in',
+    'type',
+    'datasource',
+    'model',
+    'enum',
+    'generator',
+    'attribute',
+    'view',
+    'function',
+    'mutation',
+    'procedure',
+    'plugin',
+    'abstract',
+    'extends',
+    'with',
+]);
 const matchPattern = /\((.+)\)/g;
 const [, keywordsMatch] = matchPattern.exec(control.match) as RegExpExecArray;
 const keywordsArray = keywordsMatch.split('|').filter((keyword) => !keywordsToRemove.has(keyword));
@@ -29,6 +49,16 @@ tm.patterns.push({
 tm.patterns.push({
     name: 'variable.language.this',
     match: '\\b(this)\\b',
+});
+
+tm.patterns.push({
+    name: 'storage.modifier',
+    match: '\\b(mutation|abstract|extends|with)\\b',
+});
+
+tm.patterns.push({
+    name: 'storage.type',
+    match: '\\b(type|datasource|model|enum|generator|attribute|view|function|procedure|plugin)\\b',
 });
 
 tm.patterns.push({

--- a/packages/language/scripts/patch-generated-tm.ts
+++ b/packages/language/scripts/patch-generated-tm.ts
@@ -3,7 +3,6 @@ import { writeFileSync } from 'fs';
 import { join } from 'path';
 
 const tmPath = join(import.meta.dirname, '../syntaxes/zmodel.tmLanguage.json');
-
 const control = tm.patterns.find((pattern) => pattern.name === 'keyword.control.zmodel-v3');
 
 if (!control?.match) {
@@ -11,10 +10,8 @@ if (!control?.match) {
 }
 
 const keywordsToRemove = new Set(['this', 'null', 'true', 'false', 'in']);
-
-const pattern = /\((.+)\)/g;
-
-const [, keywordsMatch] = pattern.exec(control.match) as RegExpExecArray;
+const matchPattern = /\((.+)\)/g;
+const [, keywordsMatch] = matchPattern.exec(control.match) as RegExpExecArray;
 const keywordsArray = keywordsMatch.split('|').filter((keyword) => !keywordsToRemove.has(keyword));
 
 control.match = control.match.replace(keywordsMatch, keywordsArray.join('|'));
@@ -35,3 +32,4 @@ tm.patterns.push({
 });
 
 writeFileSync(tmPath, JSON.stringify(tm, null, 2));
+console.log('Patched syntaxes/zmodel.tmLanguage.json');

--- a/packages/language/src/zmodel-semantic.ts
+++ b/packages/language/src/zmodel-semantic.ts
@@ -34,6 +34,7 @@ import {
     isAttributeParam,
     isProcedureParam,
     type AstNode,
+    isDataFieldParam,
 } from './ast';
 
 export class ZModelSemanticTokenProvider extends AbstractSemanticTokenProvider {
@@ -192,7 +193,13 @@ export class ZModelSemanticTokenProvider extends AbstractSemanticTokenProvider {
                 property: 'name',
                 type: SemanticTokenTypes.enum,
             });
-        } else if (isFunctionParam(node) || isAttributeArg(node) || isAttributeParam(node) || isProcedureParam(node)) {
+        } else if (
+            isFunctionParam(node) ||
+            isAttributeArg(node) ||
+            isAttributeParam(node) ||
+            isProcedureParam(node) ||
+            isDataFieldParam(node)
+        ) {
             acceptor({
                 node,
                 property: 'name',

--- a/packages/language/src/zmodel-semantic.ts
+++ b/packages/language/src/zmodel-semantic.ts
@@ -24,6 +24,15 @@ import {
     isProcedure,
     isFunctionParamType,
     isAttributeParamType,
+    isUnaryExpr,
+    isBinaryExpr,
+    isBooleanLiteral,
+    isNumberLiteral,
+    isNullExpr,
+    isCollectionPredicateBinding,
+    isFunctionParam,
+    isAttributeParam,
+    isProcedureParam,
     type AstNode,
 } from './ast';
 
@@ -47,23 +56,17 @@ export class ZModelSemanticTokenProvider extends AbstractSemanticTokenProvider {
                 property: 'baseModel',
                 type: SemanticTokenTypes.type,
             });
-        } else if (isDataSource(node) || isGeneratorDecl(node) || isPlugin(node) || isEnum(node) || isTypeDef(node)) {
+        } else if (isDataSource(node) || isGeneratorDecl(node) || isPlugin(node) || isTypeDef(node)) {
             acceptor({
                 node,
                 property: 'name',
                 type: SemanticTokenTypes.type,
             });
-        } else if (
-            isDataField(node) ||
-            isConfigField(node) ||
-            isAttributeArg(node) ||
-            isPluginField(node) ||
-            isEnumField(node)
-        ) {
+        } else if (isDataField(node) || isConfigField(node) || isPluginField(node)) {
             acceptor({
                 node,
                 property: 'name',
-                type: SemanticTokenTypes.variable,
+                type: SemanticTokenTypes.property,
             });
         } else if (isDataFieldType(node) || isFunctionParamType(node) || isAttributeParamType(node)) {
             if (node.type) {
@@ -83,7 +86,21 @@ export class ZModelSemanticTokenProvider extends AbstractSemanticTokenProvider {
             acceptor({
                 node,
                 property: 'decl',
-                type: SemanticTokenTypes.function,
+                type: SemanticTokenTypes.decorator,
+            });
+
+            if (node.decl.$refText === '@regex' && node.args[0]) {
+                acceptor({
+                    node: node.args[0],
+                    property: 'value',
+                    type: SemanticTokenTypes.regexp,
+                });
+            }
+        } else if (isAttribute(node)) {
+            acceptor({
+                node,
+                property: 'name',
+                type: SemanticTokenTypes.decorator,
             });
         } else if (isInvocationExpr(node)) {
             acceptor({
@@ -91,23 +108,73 @@ export class ZModelSemanticTokenProvider extends AbstractSemanticTokenProvider {
                 property: 'function',
                 type: SemanticTokenTypes.function,
             });
-        } else if (isFunctionDecl(node) || isAttribute(node) || isProcedure(node)) {
+        } else if (isFunctionDecl(node) || isProcedure(node)) {
             acceptor({
                 node,
                 property: 'name',
                 type: SemanticTokenTypes.function,
             });
+
+            if ('mutation' in node && node.mutation) {
+                acceptor({
+                    node,
+                    property: 'mutation',
+                    type: SemanticTokenTypes.modifier,
+                });
+            }
         } else if (isReferenceExpr(node)) {
             acceptor({
                 node,
                 property: 'target',
-                type: SemanticTokenTypes.variable,
+                type: SemanticTokenTypes.property,
             });
         } else if (isMemberAccessExpr(node)) {
             acceptor({
                 node,
                 property: 'member',
                 type: SemanticTokenTypes.property,
+            });
+        } else if (isNumberLiteral(node)) {
+            acceptor({
+                node,
+                property: 'value',
+                type: SemanticTokenTypes.number,
+            });
+        } else if (isBooleanLiteral(node) || isNullExpr(node)) {
+            acceptor({
+                node,
+                property: 'value',
+                type: SemanticTokenTypes.keyword,
+            });
+        } else if (isUnaryExpr(node) || isBinaryExpr(node)) {
+            acceptor({
+                node,
+                property: 'operator',
+                type: SemanticTokenTypes.operator,
+            });
+        } else if (isEnumField(node)) {
+            acceptor({
+                node,
+                property: 'name',
+                type: SemanticTokenTypes.enumMember,
+            });
+        } else if (isEnum(node)) {
+            acceptor({
+                node,
+                property: 'name',
+                type: SemanticTokenTypes.enum,
+            });
+        } else if (isFunctionParam(node) || isAttributeArg(node) || isAttributeParam(node) || isProcedureParam(node)) {
+            acceptor({
+                node,
+                property: 'name',
+                type: SemanticTokenTypes.parameter,
+            });
+        } else if (isCollectionPredicateBinding(node)) {
+            acceptor({
+                node,
+                property: 'name',
+                type: SemanticTokenTypes.variable,
             });
         }
     }

--- a/packages/language/src/zmodel-semantic.ts
+++ b/packages/language/src/zmodel-semantic.ts
@@ -167,11 +167,19 @@ export class ZModelSemanticTokenProvider extends AbstractSemanticTokenProvider {
                 type: SemanticTokenTypes.keyword,
             });
         } else if (isUnaryExpr(node) || isBinaryExpr(node)) {
-            acceptor({
-                node,
-                property: 'operator',
-                type: SemanticTokenTypes.operator,
-            });
+            if (node.operator === 'in') {
+                acceptor({
+                    node,
+                    property: 'operator',
+                    type: SemanticTokenTypes.keyword,
+                });
+            } else {
+                acceptor({
+                    node,
+                    property: 'operator',
+                    type: SemanticTokenTypes.operator,
+                });
+            }
         } else if (isEnumField(node)) {
             acceptor({
                 node,

--- a/packages/language/src/zmodel-semantic.ts
+++ b/packages/language/src/zmodel-semantic.ts
@@ -55,7 +55,19 @@ export class ZModelSemanticTokenProvider extends AbstractSemanticTokenProvider {
                 property: 'baseModel',
                 type: SemanticTokenTypes.type,
             });
-        } else if (isDataSource(node) || isGeneratorDecl(node) || isPlugin(node) || isTypeDef(node)) {
+        } else if (isTypeDef(node)) {
+            acceptor({
+                node,
+                property: 'name',
+                type: SemanticTokenTypes.type,
+            });
+
+            acceptor({
+                node,
+                property: 'mixins',
+                type: SemanticTokenTypes.type,
+            });
+        } else if (isDataSource(node) || isGeneratorDecl(node) || isPlugin(node)) {
             acceptor({
                 node,
                 property: 'name',

--- a/packages/language/src/zmodel-semantic.ts
+++ b/packages/language/src/zmodel-semantic.ts
@@ -21,6 +21,8 @@ import {
     isPluginField,
     isReferenceExpr,
     isTypeDef,
+    isProcedure,
+    isFunctionParamType,
     type AstNode,
 } from './ast';
 
@@ -62,7 +64,7 @@ export class ZModelSemanticTokenProvider extends AbstractSemanticTokenProvider {
                 property: 'name',
                 type: SemanticTokenTypes.variable,
             });
-        } else if (isDataFieldType(node)) {
+        } else if (isDataFieldType(node) || isFunctionParamType(node)) {
             if (node.type) {
                 acceptor({
                     node,
@@ -88,7 +90,7 @@ export class ZModelSemanticTokenProvider extends AbstractSemanticTokenProvider {
                 property: 'function',
                 type: SemanticTokenTypes.function,
             });
-        } else if (isFunctionDecl(node) || isAttribute(node)) {
+        } else if (isFunctionDecl(node) || isAttribute(node) || isProcedure(node)) {
             acceptor({
                 node,
                 property: 'name',

--- a/packages/language/src/zmodel-semantic.ts
+++ b/packages/language/src/zmodel-semantic.ts
@@ -123,11 +123,31 @@ export class ZModelSemanticTokenProvider extends AbstractSemanticTokenProvider {
                 });
             }
         } else if (isReferenceExpr(node)) {
-            acceptor({
-                node,
-                property: 'target',
-                type: SemanticTokenTypes.property,
-            });
+            if (isEnumField(node.target.ref)) {
+                acceptor({
+                    node,
+                    property: 'target',
+                    type: SemanticTokenTypes.enumMember,
+                });
+            } else if (isFunctionParam(node.target.ref)) {
+                acceptor({
+                    node,
+                    property: 'target',
+                    type: SemanticTokenTypes.parameter,
+                });
+            } else if (isCollectionPredicateBinding(node.target.ref)) {
+                acceptor({
+                    node,
+                    property: 'target',
+                    type: SemanticTokenTypes.variable,
+                });
+            } else {
+                acceptor({
+                    node,
+                    property: 'target',
+                    type: SemanticTokenTypes.property,
+                });
+            }
         } else if (isMemberAccessExpr(node)) {
             acceptor({
                 node,

--- a/packages/language/src/zmodel-semantic.ts
+++ b/packages/language/src/zmodel-semantic.ts
@@ -26,9 +26,7 @@ import {
     isAttributeParamType,
     isUnaryExpr,
     isBinaryExpr,
-    isBooleanLiteral,
     isNumberLiteral,
-    isNullExpr,
     isCollectionPredicateBinding,
     isFunctionParam,
     isAttributeParam,
@@ -161,20 +159,8 @@ export class ZModelSemanticTokenProvider extends AbstractSemanticTokenProvider {
                 property: 'value',
                 type: SemanticTokenTypes.number,
             });
-        } else if (isBooleanLiteral(node) || isNullExpr(node)) {
-            acceptor({
-                node,
-                property: 'value',
-                type: SemanticTokenTypes.keyword,
-            });
         } else if (isUnaryExpr(node) || isBinaryExpr(node)) {
-            if (node.operator === 'in') {
-                acceptor({
-                    node,
-                    property: 'operator',
-                    type: SemanticTokenTypes.keyword,
-                });
-            } else {
+            if (node.operator !== 'in') {
                 acceptor({
                     node,
                     property: 'operator',

--- a/packages/language/src/zmodel-semantic.ts
+++ b/packages/language/src/zmodel-semantic.ts
@@ -23,6 +23,7 @@ import {
     isTypeDef,
     isProcedure,
     isFunctionParamType,
+    isAttributeParamType,
     type AstNode,
 } from './ast';
 
@@ -64,7 +65,7 @@ export class ZModelSemanticTokenProvider extends AbstractSemanticTokenProvider {
                 property: 'name',
                 type: SemanticTokenTypes.variable,
             });
-        } else if (isDataFieldType(node) || isFunctionParamType(node)) {
+        } else if (isDataFieldType(node) || isFunctionParamType(node) || isAttributeParamType(node)) {
             if (node.type) {
                 acceptor({
                     node,


### PR DESCRIPTION
Fixes many semantic highlighting issues, including number literals, enums, enum members, boolean literals, null literals, binary operators, unary operators, attribute args, function args, function return types, regex patterns, procedure args, and procedure return types.

Differences may or may not be seen depending on the user's theme.

There are two options. Option 1 is identical to Prisma with the exception of enum members, which are now highlighted differently from fields.

## Before

<img width="852" height="992" alt="image" src="https://github.com/user-attachments/assets/2a96ed10-394b-4c6a-b15e-67410d84bcdf" />

---

## After (Option 1, virtually identical to Prisma)

<img width="851" height="992" alt="image" src="https://github.com/user-attachments/assets/9c7bdc0e-3cff-4dc2-90b7-8cfc5ee709ce" />

## After (Option 2, more varied colors)

<img width="852" height="992" alt="image" src="https://github.com/user-attachments/assets/059dd564-d6e0-4bf6-95e1-54c35d59d5ab" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Style

* Expanded semantic highlighting across ZModel syntax for improved editor readability.
* Improved highlighting for procedures, functions, attributes, fields, references, mutations, enums, and predicate bindings.
* Added clearer visual distinctions for parameter types, parameters, literals, and operators.
* Added highlighting support for regular expression arguments.
* Improved syntax recognition for procedure declarations and related language elements.
* Updated attribute and reference highlighting for clearer visual context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->