### PR TITLE
fix(language): `null` suggestions in `DefaultValue` context

### DIFF
--- a/packages/language/src/zmodel-completion-provider.ts
+++ b/packages/language/src/zmodel-completion-provider.ts
@@ -183,7 +183,7 @@ export class ZModelCompletionProvider extends DefaultCompletionProvider {
         } else if (isDataModelAttribute(context.node) || isDataFieldAttribute(context.node)) {
             const exprContext = this.getAttributeContextType(context.node);
             if (exprContext === 'DefaultValue') {
-                return ['true', 'false', 'null'].includes(keyword);
+                return ['true', 'false'].includes(keyword);
             } else {
                 return ['true', 'false', 'null', 'this'].includes(keyword);
             }


### PR DESCRIPTION
 `@default(null)` is never valid in ZModel and should not be suggested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the invalid `null` suggestion from `@default` attribute completions.
  * Boolean values (`true` and `false`) remain available as completion options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->