### PR TITLE
fix(language): add missing `plugin` validation

### DIFF
--- a/packages/language/src/utils.ts
+++ b/packages/language/src/utils.ts
@@ -738,7 +738,7 @@ export function getPluginDocuments(model: Model, schemaPath: string): string[] {
         }
 
         const provider = getLiteral<string>(providerField.value);
-        if (!provider) {
+        if (!provider || typeof provider !== 'string') {
             continue;
         }
 

--- a/packages/language/src/validator.ts
+++ b/packages/language/src/validator.ts
@@ -9,6 +9,7 @@ import type {
     GeneratorDecl,
     InvocationExpr,
     Model,
+    Plugin,
     Procedure,
     TypeDef,
     ZModelAstType,
@@ -17,6 +18,7 @@ import type { ZModelServices } from './module';
 import AttributeValidator from './validators/attribute-validator';
 import DataModelValidator from './validators/datamodel-validator';
 import DataSourceValidator from './validators/datasource-validator';
+import PluginValidator from './validators/plugin-validator';
 import EnumValidator from './validators/enum-validator';
 import ExpressionValidator from './validators/expression-validator';
 import FunctionDeclValidator from './validators/function-decl-validator';
@@ -34,6 +36,7 @@ export function registerValidationChecks(services: ZModelServices) {
     const checks: ValidationChecks<ZModelAstType> = {
         Model: validator.checkModel,
         DataSource: validator.checkDataSource,
+        Plugin: validator.checkPlugin,
         GeneratorDecl: validator.checkGenerator,
         DataModel: validator.checkDataModel,
         TypeDef: validator.checkTypeDef,
@@ -95,5 +98,9 @@ export class ZModelValidator {
 
     checkProcedure(node: Procedure, accept: ValidationAcceptor): void {
         new ProcedureValidator().validate(node, accept);
+    }
+
+    checkPlugin(node: Plugin, accept: ValidationAcceptor): void {
+        new PluginValidator().validate(node, accept);
     }
 }

--- a/packages/language/src/validators/plugin-validator.ts
+++ b/packages/language/src/validators/plugin-validator.ts
@@ -23,7 +23,7 @@ export default class PluginValidator implements AstValidator<Plugin> {
 
         const providerValue = getStringLiteral(provider.value);
         if (!providerValue) {
-            accept('error', '"provider" must be set to a string literal', {
+            accept('error', '"provider" must be set to a non-empty string literal', {
                 node: provider.value,
             });
         }

--- a/packages/language/src/validators/plugin-validator.ts
+++ b/packages/language/src/validators/plugin-validator.ts
@@ -1,0 +1,31 @@
+import type { ValidationAcceptor } from 'langium';
+import { Plugin } from '../generated/ast';
+import { getStringLiteral } from '../utils';
+import { validateDuplicatedDeclarations, type AstValidator } from './common';
+
+/**
+ * Validates plugin declarations.
+ */
+export default class PluginValidator implements AstValidator<Plugin> {
+    validate(plugin: Plugin, accept: ValidationAcceptor): void {
+        validateDuplicatedDeclarations(plugin, plugin.fields, accept);
+        this.validateProvider(plugin, accept);
+    }
+
+    private validateProvider(plugin: Plugin, accept: ValidationAcceptor) {
+        const provider = plugin.fields.find((f) => f.name === 'provider');
+        if (!provider) {
+            accept('error', 'plugin must include a "provider" field', {
+                node: plugin,
+            });
+            return;
+        }
+
+        const providerValue = getStringLiteral(provider.value);
+        if (!providerValue) {
+            accept('error', '"provider" must be set to a string literal', {
+                node: provider.value,
+            });
+        }
+    }
+}

--- a/packages/language/test/plugin.test.ts
+++ b/packages/language/test/plugin.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from 'vitest';
+import { loadSchema, loadSchemaWithError } from './utils';
+
+describe('Plugin tests', () => {
+    it('accepts plugins with a provider', async () => {
+        await loadSchema(
+            `
+            datasource db {
+                provider = 'sqlite'
+                url      = 'file:./dev.db'
+            }
+
+            model User {
+                id String @id @default(uuid())
+            }
+
+            plugin test {
+                provider = 'test'
+            }
+        `,
+        );
+    });
+
+    it('rejects plugins without a provider', async () => {
+        await loadSchemaWithError(
+            `
+            datasource db {
+                provider = 'sqlite'
+                url      = 'file:./dev.db'
+            }
+
+            model User {
+                id String @id @default(uuid())
+            }
+
+            plugin test {
+
+            }
+        `,
+            'plugin must include a "provider" field',
+        );
+    });
+
+    it('rejects plugins with an empty provider', async () => {
+        await loadSchemaWithError(
+            `
+            datasource db {
+                provider = 'sqlite'
+                url      = 'file:./dev.db'
+            }
+
+            model User {
+                id String @id @default(uuid())
+            }
+
+            plugin test {
+                provider = ''
+            }
+        `,
+            '"provider" must be set to a string literal',
+        );
+    });
+
+    it('rejects plugins with a non-string provider', async () => {
+        await loadSchemaWithError(
+            `
+            datasource db {
+                provider = 'sqlite'
+                url      = 'file:./dev.db'
+            }
+
+            model User {
+                id String @id @default(uuid())
+            }
+
+            plugin test {
+                provider = []
+            }
+        `,
+            '"provider" must be set to a string literal',
+        );
+    });
+});

--- a/packages/language/test/plugin.test.ts
+++ b/packages/language/test/plugin.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'vitest';
 import { loadSchema, loadSchemaWithError } from './utils';
 
 describe('Plugin tests', () => {
-    it('accepts plugins with a provider', async () => {
+    it('accepts plugins with a string provider', async () => {
         await loadSchema(
             `
             datasource db {
@@ -57,7 +57,7 @@ describe('Plugin tests', () => {
                 provider = ''
             }
         `,
-            '"provider" must be set to a string literal',
+            '"provider" must be set to a non-empty string literal',
         );
     });
 
@@ -77,7 +77,43 @@ describe('Plugin tests', () => {
                 provider = []
             }
         `,
-            '"provider" must be set to a string literal',
+            '"provider" must be set to a non-empty string literal',
+        );
+
+        await loadSchemaWithError(
+            `
+            datasource db {
+                provider = 'sqlite'
+                url      = 'file:./dev.db'
+            }
+
+            model User {
+                id String @id @default(uuid())
+            }
+
+            plugin test {
+                provider = true
+            }
+        `,
+            '"provider" must be set to a non-empty string literal',
+        );
+
+        await loadSchemaWithError(
+            `
+            datasource db {
+                provider = 'sqlite'
+                url      = 'file:./dev.db'
+            }
+
+            model User {
+                id String @id @default(uuid())
+            }
+
+            plugin test {
+                provider = {}
+            }
+        `,
+            '"provider" must be set to a non-empty string literal',
         );
     });
 });


### PR DESCRIPTION
Now validates that all plugins have a provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for plugin definitions.
  * Plugins must include a non-empty string `provider` value.
  * Duplicate plugin fields are now detected and reported.
  * Plugin discovery now safely skips entries with missing or invalid provider values.

* **Tests**
  * Added coverage for valid plugins and invalid provider configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->