### PR TITLE
fix(policy): do not treat Json kind keys as Kysely nodes

### DIFF
--- a/packages/plugins/policy/src/policy-handler.ts
+++ b/packages/plugins/policy/src/policy-handler.ts
@@ -1079,7 +1079,12 @@ export class PolicyHandler<Schema extends SchemaDef> extends OperationNodeTransf
         const result: { node: OperationNode; raw: unknown }[] = [];
         for (let i = 0; i < data.length; i++) {
             const item = data[i]!;
-            if (typeof item === 'object' && item && 'kind' in item) {
+            if (
+                typeof item === 'object' &&
+                item &&
+                'kind' in item &&
+                (item.kind === 'ValueNode' || item.kind === 'DefaultInsertValueNode')
+            ) {
                 if (item.kind === 'DefaultInsertValueNode') {
                     result.push({ node: ValueNode.create(null), raw: null });
                     continue;

--- a/tests/regression/test/issue-2791.test.ts
+++ b/tests/regression/test/issue-2791.test.ts
@@ -1,0 +1,54 @@
+import { createPolicyTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2791
+// Policy pre-create checks unwrap insert values and used to treat any object with a
+// `kind` key as a Kysely operation node. A Json payload like `{ kind: "artwork" }`
+// then failed with `Invariant failed: expecting a ValueNode`.
+const schema = `
+model User {
+    id Int @id @default(autoincrement())
+}
+
+model Item {
+    id      Int  @id @default(autoincrement())
+    payload Json
+
+    // non-constant: constant @@allow('all', true) skips pre-create value unwrapping
+    @@allow('all', auth() == null)
+}
+`;
+
+describe('Regression for issue 2791', () => {
+    it('creates a Json value that has a top-level kind key', async () => {
+        const db = await createPolicyTestClient(schema, { provider: 'postgresql' });
+
+        await expect(db.item.create({ data: { payload: { kind: 'artwork' } } })).resolves.toMatchObject({
+            payload: { kind: 'artwork' },
+        });
+    });
+
+    it('creates many Json values that have a top-level kind key', async () => {
+        const db = await createPolicyTestClient(schema, { provider: 'postgresql' });
+
+        await expect(
+            db.item.createMany({ data: [{ payload: { kind: 'artwork' } }, { payload: { kind: 'photo' } }] }),
+        ).resolves.toMatchObject({ count: 2 });
+
+        await expect(db.item.findMany()).resolves.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ payload: { kind: 'artwork' } }),
+                expect.objectContaining({ payload: { kind: 'photo' } }),
+            ]),
+        );
+    });
+
+    it('still accepts the same Json payload via update', async () => {
+        const db = await createPolicyTestClient(schema, { provider: 'postgresql' });
+
+        const item = await db.item.create({ data: { payload: {} } });
+        await expect(
+            db.item.update({ where: { id: item.id }, data: { payload: { kind: 'artwork' } } }),
+        ).resolves.toMatchObject({ payload: { kind: 'artwork' } });
+    });
+});


### PR DESCRIPTION
Policy pre-create unwrapping treated any object with a kind field as a Kysely operation node, so create({ payload: { kind: "artwork" } }) failed with expecting a ValueNode. Only ValueNode and DefaultInsertValueNode are treated as nodes.

Fixes #2791


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed handling of JSON data containing a top-level `kind` field when policies are enabled.
  - JSON values now remain intact during creation, bulk creation, retrieval, and updates.

- **Tests**
  - Added regression coverage for JSON payloads with top-level `kind` fields in PostgreSQL schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->