### PR TITLE
fix(sdk): respect @@strict inherited from mixins in type def generation

### DIFF
--- a/packages/cli/test/ts-schema-gen.test.ts
+++ b/packages/cli/test/ts-schema-gen.test.ts
@@ -872,4 +872,27 @@ type Profile {
             },
         });
     });
+
+    it('supports @@strict inherited from mixins', async () => {
+        const { schema } = await generateTsSchema(`
+model User {
+    id      String   @id @default(uuid())
+    profile Profile? @json
+}
+
+type Strict {
+    @@strict
+}
+
+type Profile with Strict {
+    bio String
+}
+            `);
+
+        expect(schema.typeDefs).toMatchObject({
+            Profile: {
+                strict: true,
+            },
+        });
+    });
 });

--- a/packages/sdk/src/ts-schema-generator.ts
+++ b/packages/sdk/src/ts-schema-generator.ts
@@ -546,7 +546,7 @@ export class TsSchemaGenerator {
                 : []),
         ];
 
-        if (hasAttribute(td, '@@strict')) {
+        if (getAllAttributes(td).some((attr) => attr.decl.$refText === '@@strict')) {
             fields.push(ts.factory.createPropertyAssignment('strict', ts.factory.createTrue()));
         }
 


### PR DESCRIPTION
## Summary

- The `strict: true` flag in generated type-def schemas was gated on `hasAttribute(td, '@@strict')`, which only inspects attributes declared directly on the type def, while the `attributes` array is built with `getAllAttributes` (which walks mixins). A type def inheriting `@@strict` from a mixin (`type Profile with Strict`) carried the attribute in its `attributes` array but never got `strict: true`, so the Zod validation and strict typing paths silently treated it as loose.
- Fixed by checking the inherited attribute collection from `getAllAttributes(td)`. The lite-filtered local `attributes` variable is deliberately not reused so the flag is emitted regardless of lite mode.

## Testing

- Added a "supports @@strict inherited from mixins" case to `packages/cli/test/ts-schema-gen.test.ts` alongside the existing direct-`@@strict` test; both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected generated type definitions so they correctly inherit strictness from strict mixins.
  * Ensured types using inherited strict behavior are generated with `strict: true`.

* **Tests**
  * Added coverage verifying strictness is preserved for types inheriting from strict mixins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->