### PR TITLE
chore: regenerate stale fetch-client test lite schemas

### DIFF
--- a/packages/clients/fetch-client/test/schemas/basic/schema-lite.ts
+++ b/packages/clients/fetch-client/test/schemas/basic/schema-lite.ts
@@ -18,6 +18,7 @@ export class SchemaType implements SchemaDef {
                     name: "id",
                     type: "String",
                     id: true,
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }] as readonly AttributeApplication[],
                     default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 email: {
@@ -50,6 +51,7 @@ export class SchemaType implements SchemaDef {
                     name: "id",
                     type: "String",
                     id: true,
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }] as readonly AttributeApplication[],
                     default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 title: {
@@ -86,9 +88,6 @@ export class SchemaType implements SchemaDef {
                     type: "String"
                 }
             },
-            attributes: [
-                { name: "@@strict" }
-            ] as readonly AttributeApplication[],
             strict: true
         }
     } as const;

--- a/packages/clients/fetch-client/test/schemas/no-procs/schema-lite.ts
+++ b/packages/clients/fetch-client/test/schemas/no-procs/schema-lite.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable */
 
-import { type SchemaDef, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
+import { type SchemaDef, type AttributeApplication, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
 export class SchemaType implements SchemaDef {
     provider = {
         type: "sqlite"
@@ -18,6 +18,7 @@ export class SchemaType implements SchemaDef {
                     name: "id",
                     type: "String",
                     id: true,
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }] as readonly AttributeApplication[],
                     default: ExpressionUtils.call("cuid") as FieldDefault
                 }
             },


### PR DESCRIPTION
Follow-up to #2813 — the retried v3.9.2 publish [failed again](https://github.com/zenstackhq/zenstack/actions/runs/32639763079/job/97194934715) with the same `ERR_PNPM_GIT_UNCLEAN`.

Two more tracked generated files were stale: `packages/clients/fetch-client/test/schemas/{basic,no-procs}/schema-lite.ts`. fetch-client's `build` script runs `test:generate`, which rewrites them.

They were missed in #2813 because turbo's `build` task inputs don't include `test/**`, so my local verification build got a cache hit for fetch-client and never executed the generate step — while CI's cold-cache build did, dirtying the tree.

Verified this time with `pnpm build --force` (cache bypassed): after this commit the working tree stays completely clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated schema metadata to accurately capture automatic `cuid()` defaults for identifier fields.
  * Corrected notification schema metadata by removing an outdated strictness attribute while preserving strict behavior.
  * Added missing default metadata for item identifiers in schemas without procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->