### PR TITLE
merge dev to main (v3.9.2)

### DIFF
--- a/packages/clients/fetch-client/test/schemas/basic/schema-lite.ts
+++ b/packages/clients/fetch-client/test/schemas/basic/schema-lite.ts
@@ -18,6 +18,7 @@ export class SchemaType implements SchemaDef {
                     name: "id",
                     type: "String",
                     id: true,
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }] as readonly AttributeApplication[],
                     default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 email: {
@@ -50,6 +51,7 @@ export class SchemaType implements SchemaDef {
                     name: "id",
                     type: "String",
                     id: true,
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }] as readonly AttributeApplication[],
                     default: ExpressionUtils.call("cuid") as FieldDefault
                 },
                 title: {
@@ -86,9 +88,6 @@ export class SchemaType implements SchemaDef {
                     type: "String"
                 }
             },
-            attributes: [
-                { name: "@@strict" }
-            ] as readonly AttributeApplication[],
             strict: true
         }
     } as const;

--- a/packages/clients/fetch-client/test/schemas/no-procs/schema-lite.ts
+++ b/packages/clients/fetch-client/test/schemas/no-procs/schema-lite.ts
@@ -5,7 +5,7 @@
 
 /* eslint-disable */
 
-import { type SchemaDef, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
+import { type SchemaDef, type AttributeApplication, type FieldDefault, ExpressionUtils } from "@zenstackhq/schema";
 export class SchemaType implements SchemaDef {
     provider = {
         type: "sqlite"
@@ -18,6 +18,7 @@ export class SchemaType implements SchemaDef {
                     name: "id",
                     type: "String",
                     id: true,
+                    attributes: [{ name: "@default", args: [{ name: "value", value: ExpressionUtils.call("cuid") }] }] as readonly AttributeApplication[],
                     default: ExpressionUtils.call("cuid") as FieldDefault
                 }
             },


### PR DESCRIPTION
Second retry of #2811 (after #2814) — includes #2813 and #2815, which regenerate all stale generated lite schemas that caused the v3.9.2 publish runs to fail with `ERR_PNPM_GIT_UNCLEAN`. Verified locally with a cache-bypassed `pnpm build --force` that the working tree stays clean after build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated schema metadata to accurately represent automatic `cuid` defaults for user, post, and item identifiers.
  * Corrected notification strictness metadata while preserving strict validation behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->