### PR TITLE
fix(orm): handle mapping enum array (#2818)

### DIFF
--- a/packages/orm/src/client/executor/name-mapper.ts
+++ b/packages/orm/src/client/executor/name-mapper.ts
@@ -16,6 +16,7 @@ import {
     OperationNodeTransformer,
     PrimitiveValueListNode,
     type QueryId,
+    RawNode,
     ReferenceNode,
     ReturningNode,
     SelectAllNode,
@@ -763,6 +764,21 @@ export class QueryNameMapper extends OperationNodeTransformer {
             if (mappedValue) {
                 return mappedValue;
             }
+        } else if (
+            this.isOperationNode(value) &&
+            ValueNode.is(value) &&
+            Array.isArray(value.value) &&
+            value.value.every((v) => typeof v === 'string')
+        ) {
+            const everyMappedValueExists = value.value.every((v) => enumValueMapping[v]);
+            if (everyMappedValueExists) {
+                return ValueNode.create(value.value.map((v) => enumValueMapping[v]));
+            }
+        } else if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+            const everyMappedValueExists = value.every((v) => enumValueMapping[v]);
+            if (everyMappedValueExists) {
+                return value.map((v) => enumValueMapping[v]);
+            }
         }
 
         return value;
@@ -789,23 +805,39 @@ export class QueryNameMapper extends OperationNodeTransformer {
             return selection;
         }
 
+        const shouldUseArray = fieldDef.array;
+
         const eb = expressionBuilder();
-        const caseBuilder = eb.case();
+        const caseNode = shouldUseArray ? ColumnNode.create('t') : node;
         let caseWhen: CaseWhenBuilder<any, any, any, any> | undefined;
+
         for (const [key, value] of Object.entries(enumValueMapping)) {
             if (!caseWhen) {
-                caseWhen = caseBuilder.when(new ExpressionWrapper(node), '=', value).then(key);
+                caseWhen = eb.case().when(new ExpressionWrapper(caseNode), '=', value).then(key);
             } else {
-                caseWhen = caseWhen.when(new ExpressionWrapper(node), '=', value).then(key);
+                caseWhen = caseWhen.when(new ExpressionWrapper(caseNode), '=', value).then(key);
             }
         }
 
         // the explicit cast to "text" is needed to address postgres's case-when type inference issue
-        const finalExpr = caseWhen!.else(this.dialect.castText(new ExpressionWrapper(node))).end();
+        const caseExpr = caseWhen!.else(this.dialect.castText(new ExpressionWrapper(caseNode))).end();
+
+        if (!shouldUseArray) {
+            if (aliasName) {
+                return caseExpr.as(aliasName).toOperationNode() as SelectionNodeChild;
+            } else {
+                return caseExpr.toOperationNode() as SelectionNodeChild;
+            }
+        }
+
+        const arrayExpr = new ExpressionWrapper(
+            RawNode.create(['ARRAY(SELECT ', ' FROM unnest( ', ' ) AS t)'], [caseExpr.toOperationNode(), node]),
+        );
+
         if (aliasName) {
-            return finalExpr.as(aliasName).toOperationNode() as SelectionNodeChild;
+            return arrayExpr.as(aliasName).toOperationNode() as SelectionNodeChild;
         } else {
-            return finalExpr.toOperationNode() as SelectionNodeChild;
+            return arrayExpr.toOperationNode() as SelectionNodeChild;
         }
     }
 

--- a/tests/regression/test/issue-2818.test.ts
+++ b/tests/regression/test/issue-2818.test.ts
@@ -1,0 +1,56 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2818
+describe('Regression for issue #2818', () => {
+    it('supported enum array', async () => {
+        const schema = `
+enum TestTag {
+  INFO @map("info")
+  WARN @map("warn")
+
+  @@map("post_tag")
+}
+
+model Test {
+  id   Int       @id
+  tag  TestTag?
+  tags TestTag[]
+
+  @@map("test")
+}
+`;
+
+        const db = await createTestClient(schema, { usePrismaPush: true, provider: 'postgresql', debug: true });
+
+        await db.test.create({ data: { id: 0 } });
+        await db.test.create({ data: { id: 1, tag: 'INFO' } });
+        await db.test.create({ data: { id: 2, tags: [] } });
+        await db.test.create({ data: { id: 3, tags: ['INFO'] } });
+        await db.test.create({ data: { id: 4, tags: ['INFO', 'WARN'] } });
+
+        await expect(db.test.findMany({ orderBy: { id: 'asc' } })).resolves.toEqual([
+            { id: 0, tag: null, tags: [] },
+            { id: 1, tag: 'INFO', tags: [] },
+            { id: 2, tag: null, tags: [] },
+            { id: 3, tag: null, tags: ['INFO'] },
+            { id: 4, tag: null, tags: ['INFO', 'WARN'] },
+        ]);
+
+        await db.$qb.updateTable('test').set({ tag: 'WARN' }).where('id', '=', 2).executeTakeFirst();
+        await db.$qb
+            .updateTable('test')
+            .set({ tags: ['INFO', 'WARN'] })
+            .where('id', '=', 2)
+            .executeTakeFirst();
+        await db.$qb.updateTable('test').set({ tags: [] }).where('id', '=', 4).executeTakeFirst();
+
+        await expect(db.test.findMany({ orderBy: { id: 'asc' } })).resolves.toEqual([
+            { id: 0, tag: null, tags: [] },
+            { id: 1, tag: 'INFO', tags: [] },
+            { id: 2, tag: 'WARN', tags: ['INFO', 'WARN'] },
+            { id: 3, tag: null, tags: ['INFO'] },
+            { id: 4, tag: null, tags: [] },
+        ]);
+    });
+});


### PR DESCRIPTION
Handle enum array insert / select / update

Closes #2818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of PostgreSQL enum arrays during data selection.
  * Corrected mapping for optional, empty, and populated enum values.
  * Preserved expected ordering when retrieving records containing enum arrays.

* **Tests**
  * Added regression coverage for enum fields and enum arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->