### PR TITLE
fix(orm): provide qualifier for enum resolveFieldFromScopes (#2825)

### DIFF
--- a/packages/orm/src/client/executor/name-mapper.ts
+++ b/packages/orm/src/client/executor/name-mapper.ts
@@ -817,7 +817,10 @@ export class QueryNameMapper extends OperationNodeTransformer {
 
     private processEnumSelection(selection: SelectionNodeChild, fieldName: string) {
         const { alias, node } = stripAlias(selection);
-        const fieldScope = this.resolveFieldFromScopes(fieldName);
+        const fieldScope = this.resolveFieldFromScopes(
+            fieldName,
+            ReferenceNode.is(node) ? node.table?.table?.identifier.name : undefined,
+        );
         if (!fieldScope || !fieldScope.model) {
             return selection;
         }

--- a/tests/regression/test/issue-2825.test.ts
+++ b/tests/regression/test/issue-2825.test.ts
@@ -1,0 +1,40 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, it } from 'vitest';
+
+// https://github.com/zenstackhq/zenstack/issues/2825
+describe('Regression for issue #2825', () => {
+    it('handle same column name with enum type', async () => {
+        const schema = `
+enum UserStatus {
+  OK1 @map("ok1")
+  NO1 @map("no1")
+
+  @@map("user_status")
+}
+
+enum PostStatus {
+  OK2 @map("ok2")
+  NO2 @map("no2")
+
+  @@map("post_status")
+}
+
+model User {
+  id     Int         @id @default(autoincrement())
+  status UserStatus?
+  posts  Post[]
+}
+
+model Post {
+  id       Int         @id @default(autoincrement())
+  status   PostStatus?
+  author   User?       @relation(fields: [authorId], references: [id])
+  authorId Int
+}
+`;
+
+        const db = await createTestClient(schema, { usePrismaPush: true, provider: 'postgresql' });
+
+        await db.$qb.selectFrom('User as u').innerJoin('Post as p', 'p.authorId', 'u.id').select('u.status').execute();
+    });
+});


### PR DESCRIPTION
Closes #2825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed enum-value selection for queries involving table-qualified references.
  * Corrected handling of mapped enum fields when multiple tables contain similarly named fields.
  * Resolved query failures when joining tables with renamed enum columns or tables.

* **Tests**
  * Added regression coverage for joined queries using mapped enum values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->