### PR TITLE
fix(zod): treat `@uuid` without a version as any UUID version

### DIFF
--- a/packages/zod/src/utils.ts
+++ b/packages/zod/src/utils.ts
@@ -82,10 +82,12 @@ export function addStringValidation(
             }
             case '@uuid': {
                 const version = getArgValue<number>(attr.args?.[0]?.value);
-                if (version === 7) {
+                if (version === 4) {
+                    result = result.uuidv4();
+                } else if (version === 7) {
                     result = result.uuidv7();
                 } else {
-                    result = result.uuidv4();
+                    result = result.uuid();
                 }
                 break;
             }

--- a/tests/e2e/orm/validation/toplevel.test.ts
+++ b/tests/e2e/orm/validation/toplevel.test.ts
@@ -20,6 +20,7 @@ describe('Toplevel field validation tests', () => {
             str10 String? @time(-1)
             str11 String? @uuid
             str12 String? @uuid(7)
+            str13 String? @uuid(4)
         }
         `,
         );
@@ -120,11 +121,27 @@ describe('Toplevel field validation tests', () => {
             // satisfies @uuid
             await expect(_t({ str11: '20ef31c8-a2c6-4dca-b87b-838e364ab4b3' })).toResolveTruthy();
 
+            // satisfies @uuid, which is not pinned to a version, with a v7 value
+            await expect(_t({ str11: '019ff964-2f1d-7668-9a76-8648f2af9146' })).toResolveTruthy();
+
             // violates @uuid(7)
             await expect(_t({ str12: 'not-a-uuid' })).toBeRejectedByValidation(['Invalid UUID']);
 
+            // violates @uuid(7) with a v4 value
+            await expect(_t({ str12: '20ef31c8-a2c6-4dca-b87b-838e364ab4b3' })).toBeRejectedByValidation([
+                'Invalid UUID',
+            ]);
+
             // satisfies @uuid(7)
             await expect(_t({ str12: '019ff964-2f1d-7668-9a76-8648f2af9146' })).toResolveTruthy();
+
+            // violates @uuid(4) with a v7 value
+            await expect(_t({ str13: '019ff964-2f1d-7668-9a76-8648f2af9146' })).toBeRejectedByValidation([
+                'Invalid UUID',
+            ]);
+
+            // satisfies @uuid(4)
+            await expect(_t({ str13: '20ef31c8-a2c6-4dca-b87b-838e364ab4b3' })).toResolveTruthy();
         }
     });
 


### PR DESCRIPTION
A bare `@uuid` only accepts v4. The version argument is declared optional and stdlib.zmodel documents the attribute as "Validates a string field value is a valid UUID", so `@uuid` with no argument should accept any version, which is what the sibling `isUuid()` function already does.

```zmodel
model Foo {
    id  Int    @id @default(autoincrement())
    ref String @uuid
}
```

```ts
// v4, accepted
await db.foo.create({ data: { ref: '20ef31c8-a2c6-4dca-b87b-838e364ab4b3' } });

// v7, rejected
await db.foo.create({ data: { ref: '019ff964-2f1d-7668-9a76-8648f2af9146' } });
// Invalid create args for model "Foo": Validation error: Invalid UUID at "data.ref"
```

v7 is the shape ZenStack's own `uuid(7)` generator produces, so a value read out of one model and written into a `@uuid` field of another is rejected. Every non-v4 version fails, because the compiled pattern requires a literal `4` in the version nibble.

### Cause

`addStringValidation` in `packages/zod/src/utils.ts` maps the attribute with `if (version === 7) result.uuidv7() else result.uuidv4()`. The `else` covers `@uuid(4)` and the no-version form alike, so a bare `@uuid` compiles to zod's v4-only pattern `^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-4[0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12})$`, while `packages/orm/src/client/crud/operations/base.ts:1119` generates `uuid.v7()` for `uuid(7)`. The `isUuid` branch of `evalCall` in the same utils file passes `version: undefined` to `z.uuid()` when the argument is omitted, which accepts any version, so the attribute path and the function path disagreed on identical semantics.

### Changes

`@uuid(4)` maps to `uuidv4()`, `@uuid(7)` to `uuidv7()`, and a bare `@uuid` to `uuid()`, which accepts any version. Those are the only three reachable branches, since the `@uuid` check in `attribute-application-validator.ts` already rejects every other version literal.

`tests/e2e/orm/validation/toplevel.test.ts` gains a `str13 String? @uuid(4)` field and four assertions: a bare `@uuid` accepts a v7 value, `@uuid(7)` rejects a v4 value, `@uuid(4)` rejects a v7 value, and `@uuid(4)` accepts a v4 value. The last three pin the versioned forms so this does not get fixed in the other direction later.

### Verification

With the test change applied and `packages/zod/src/utils.ts` reverted to dev, `TEST_DB_PROVIDER=sqlite vitest run orm/validation/toplevel.test.ts` in `tests/e2e` fails "works with string fields" with `Invalid UUID at "data.str11"`, and the reported `pattern` is the v4-only regex above. With the fix, that test passes.

`pnpm --filter @zenstackhq/zod test` is 537 passed, no type errors. `pnpm --filter @zenstackhq/zod lint`, `tsc --noEmit` and `prettier --check` on both changed files are clean.

Two tests in `tests/e2e/orm/validation` were not run locally: "works with list fields" and "works with custom validation" declare `Int[]` fields and open a Postgres connection, which fails with `ECONNREFUSED 127.0.0.1:5432` on my machine. Both fail identically on unmodified dev.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected UUID validation so `@uuid(4)` accepts version 4 UUIDs and rejects version 7 UUIDs.
  * Preserved support for version 7 validation through `@uuid(7)`.
  * Unversioned `@uuid` validation continues to accept UUID values across supported versions.

* **Tests**
  * Expanded validation coverage for version-specific and unversioned UUID annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->