### PR TITLE
fix(zod): resolve `@uuid` version and `@time` precision by argument name

### DIFF
--- a/packages/zod/src/utils.ts
+++ b/packages/zod/src/utils.ts
@@ -30,6 +30,18 @@ function getArgValue<T extends string | number | boolean>(expr: Expression | und
     return expr.value as T;
 }
 
+function getNamedAttributeArgValue<T extends string | number | boolean>(
+    attr: AttributeApplication,
+    name: string,
+): T | undefined {
+    const named = attr.args?.find((a) => a.name === name);
+    if (named) {
+        return getArgValue<T>(named.value);
+    } else {
+        return undefined;
+    }
+}
+
 export function addStringValidation(
     schema: z.ZodString,
     attributes: readonly AttributeApplication[] | undefined,
@@ -81,7 +93,7 @@ export function addStringValidation(
                 break;
             }
             case '@uuid': {
-                const version = getArgValue<number>(attr.args?.[0]?.value);
+                const version = getNamedAttributeArgValue<number>(attr, 'version');
                 if (version === 4) {
                     result = result.uuidv4();
                 } else if (version === 7) {
@@ -101,7 +113,7 @@ export function addStringValidation(
                 result = result.date();
                 break;
             case '@time': {
-                const precision = getArgValue<number>(attr.args?.[0]?.value);
+                const precision = getNamedAttributeArgValue<number>(attr, 'precision');
                 result = result.time({ precision });
                 break;
             }

--- a/packages/zod/test/string-validation.test.ts
+++ b/packages/zod/test/string-validation.test.ts
@@ -1,0 +1,55 @@
+import { ExpressionUtils, type AttributeApplication } from '@zenstackhq/schema';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { addStringValidation } from '../src/utils';
+
+function attr(name: string, args: { name?: string; value: string | number | boolean }[]): AttributeApplication {
+    return { name, args: args.map((a) => ({ name: a.name, value: ExpressionUtils.literal(a.value) })) };
+}
+
+function validate(attribute: AttributeApplication, value: string) {
+    return addStringValidation(z.string(), [attribute]).safeParse(value).success;
+}
+
+describe('string validation attributes', () => {
+    const uuidV4 = '20ef31c8-a2c6-4dca-b87b-838e364ab4b3';
+    const uuidV7 = '0199a1b2-c3d4-7abc-8def-0123456789ab';
+
+    it('accepts any uuid version when no version is given', () => {
+        expect(validate(attr('@uuid', []), uuidV4)).toBe(true);
+        expect(validate(attr('@uuid', []), uuidV7)).toBe(true);
+        expect(validate(attr('@uuid', []), 'not-a-uuid')).toBe(false);
+    });
+
+    it('respects a named version arg regardless of argument order', () => {
+        const versionFirst = attr('@uuid', [
+            { name: 'version', value: 7 },
+            { name: 'message', value: 'custom' },
+        ]);
+        expect(validate(versionFirst, uuidV7)).toBe(true);
+        expect(validate(versionFirst, uuidV4)).toBe(false);
+
+        const messageFirst = attr('@uuid', [
+            { name: 'message', value: 'custom' },
+            { name: 'version', value: 7 },
+        ]);
+        expect(validate(messageFirst, uuidV7)).toBe(true);
+        expect(validate(messageFirst, uuidV4)).toBe(false);
+
+        const v4 = attr('@uuid', [
+            { name: 'message', value: 'custom' },
+            { name: 'version', value: 4 },
+        ]);
+        expect(validate(v4, uuidV4)).toBe(true);
+        expect(validate(v4, uuidV7)).toBe(false);
+    });
+
+    it('resolves @time precision from a named arg in any order', () => {
+        const messageFirst = attr('@time', [
+            { name: 'message', value: 'custom' },
+            { name: 'precision', value: 3 },
+        ]);
+        expect(validate(messageFirst, '12:00:00.123')).toBe(true);
+        expect(validate(messageFirst, '12:00:00')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Problem

`addStringValidation` read the first optional parameter of `@uuid` and `@time` from `attr.args[0]`. Attribute args are emitted in source order, so `@uuid(message: "custom", version: 7)` put the message string at index 0 and the version was never seen — the field silently fell back to version-agnostic UUID validation. `@time(message: "...", precision: 3)` had the same problem.

## Fix

Look the argument up by name via a small `getNamedAttributeArgValue` helper, matching how `@length` already resolves `min`/`max`. Names are always present at runtime: the language validator stamps `$resolvedParam` on every argument (positional ones included) and the TS schema generator emits `name` from it, so a name lookup covers both call styles.

## Tests

New `packages/zod/test/string-validation.test.ts` covers `@uuid` with no version (any version accepted), a named `version` in either argument order for v4 and v7, and `@time` precision with `message` given first.

Full `@zenstackhq/zod` suite passes (543 tests, no type errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - UUID validation now correctly honors the named version argument regardless of its position.
  - Time validation now correctly honors the named precision argument regardless of argument order.
  - UUID validation without a specified version accepts UUIDs of any version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->