### PR TITLE
fix(language): resolve `@uuid` version arg by name in validation

### DIFF
--- a/packages/language/src/validators/attribute-application-validator.ts
+++ b/packages/language/src/validators/attribute-application-validator.ts
@@ -463,9 +463,13 @@ export default class AttributeApplicationValidator implements AstValidator<Attri
 
     @check('@uuid')
     private _checkUuid(attr: AttributeApplication, accept: ValidationAcceptor) {
-        const version = getNumberLiteral(attr.args[0]?.value);
+        const versionArg = attr.args.find((arg) => arg.$resolvedParam?.name === 'version');
+        if (!versionArg) {
+            return;
+        }
+        const version = getNumberLiteral(versionArg.value);
         if (version !== undefined && version !== 4 && version !== 7) {
-            accept('error', `\`@uuid\` version must be \`4\` or \`7\``, { node: attr.args[0]! });
+            accept('error', `\`@uuid\` version must be \`4\` or \`7\``, { node: versionArg });
         }
     }
 

--- a/packages/language/test/attribute-application.test.ts
+++ b/packages/language/test/attribute-application.test.ts
@@ -661,6 +661,50 @@ describe('Attribute application validation tests', () => {
                 /`@uuid` version must be `4` or `7`/,
             );
         });
+
+        it('resolves the version arg by name regardless of argument order', async () => {
+            await loadSchema(
+                `
+                datasource db {
+                    provider = 'sqlite'
+                    url      = 'file:./dev.db'
+                }
+
+                model User {
+                    id String @id @uuid(message: 'invalid uuid', version: 7)
+                }
+                `,
+            );
+
+            await loadSchemaWithError(
+                `
+                datasource db {
+                    provider = 'sqlite'
+                    url      = 'file:./dev.db'
+                }
+
+                model User {
+                    id String @id @uuid(message: 'invalid uuid', version: 1)
+                }
+                `,
+                /`@uuid` version must be `4` or `7`/,
+            );
+        });
+
+        it('does not treat a message-only arg as a version', async () => {
+            await loadSchema(
+                `
+                datasource db {
+                    provider = 'sqlite'
+                    url      = 'file:./dev.db'
+                }
+
+                model User {
+                    id String @id @uuid(message: 'invalid uuid')
+                }
+                `,
+            );
+        });
     });
 
     describe('Native type mapping attributes', () => {


### PR DESCRIPTION
## Summary

`_checkUuid` in the attribute application validator assumed the version was `attr.args[0]`. With named arguments in a different order — e.g. `@uuid(message: 'invalid uuid', version: 1)` — the version was never validated, so unsupported versions slipped through; the message string landed in the version slot instead (harmless, since `getNumberLiteral` returns `undefined`, but wrong).

The validator now looks up the argument whose `$resolvedParam.name` is `version` and uses it for both the value and the diagnostic location.

## Test plan

- Added regression tests in `packages/language/test/attribute-application.test.ts`:
  - reordered named args (`message` before `version`) — accepts `7`, rejects `1`
  - message-only application stays valid
- `npx vitest run test/attribute-application.test.ts` in `packages/language` — 42 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `@uuid` validation for named arguments, regardless of their order.
  - Ensured validation errors are associated with the specified version argument.
  - Prevented message-only arguments from being mistaken for UUID versions.
  - UUID versions 4 and 7 remain supported; other versions continue to be rejected.

- **Tests**
  - Added coverage for named arguments, invalid versions, and message-only usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->