### PR TITLE
ci: pin publish-and-release job to Node 22.x

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Use Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 24.x
+                  node-version: 22.x
                   cache: 'pnpm'
                   registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## Problem

The [Publish and Release run for v3.9.4](https://github.com/zenstackhq/zenstack/actions/runs/34439934442/job/102753204724) failed in `@zenstackhq/language#build`:

```
> langium generate
Reading config from .../packages/language/langium-config.json
TypeError: Invalid URL
    at Validator.resolve (.../jsonschema@1.5.0/lib/validator.js:263:16)
  code: 'ERR_INVALID_URL',
  input: '/undefined#/$defs/languageItem',
  base: 'thismessage::/'
```

## Root cause

`langium-cli` validates `langium-config.json` with `jsonschema@1.5.0`, which resolves `$ref`s via `new URL(ref, 'thismessage::/')`. That base has an *opaque* path, so resolving a path-absolute reference against it is invalid per the URL spec. Older Node/ada accepted it; **Node 24.20.0 correctly throws**.

The publish job pinned `node-version: 24.x` and the runner resolved it to `v24.20.0` (see `node: v24.20.0` in the log). Nothing in v3.9.4 caused this — v3.9.3 published fine on Aug 31 with an older 24.x.

Reproduced locally with `new URL('/undefined#/x', 'thismessage::/')`:

| Node | Result |
| --- | --- |
| 20.19.5 / 20.20.2 / 22.21.1 / 22.23.2 / 24.18.0 / 26.5.0 | ok |
| **24.20.0** | `ERR_INVALID_URL` |

Running the exact `langium generate` under 24.20.0 reproduces the CI stack trace; under 24.18.0 it succeeds.

## Fix

`jsonschema@1.5.0` is the latest release, so there is no upgrade to take. Pin the publish job to Node 22.x, which is what every `build-test` job already uses and passes on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to use Node.js 22.x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->