### PR TITLE
ci: pin publish-and-release job to Node 22.x (#2836)

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Use Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 24.x
+                  node-version: 22.x
                   cache: 'pnpm'
                   registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release publishing workflow to use Node.js 22.x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->