### PR TITLE
ci: restore Node 24.x for publish, patch jsonschema URL resolution

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,7 +47,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [22.x]
+                node-version: [24.x]
                 provider: [sqlite, postgresql, mysql]
 
         steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Use Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 22.x
+                  node-version: 24.x
                   cache: 'pnpm'
                   registry-url: 'https://registry.npmjs.org'
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
             "cookie@<0.7.0": ">=0.7.0",
             "lodash@>=4.0.0 <=4.17.23": ">=4.18.0",
             "@better-auth/core": "1.4.19"
+        },
+        "patchedDependencies": {
+            "jsonschema@1.5.0": "patches/jsonschema@1.5.0.patch"
         }
     },
     "lint-staged": {

--- a/patches/jsonschema@1.5.0.patch
+++ b/patches/jsonschema@1.5.0.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/validator.js b/lib/validator.js
+index cca5e9c2216fd72d5da7eb63a38cebdf025e366e..ed6b2cf5376286dec39977c5823143766ae43080 100644
+--- a/lib/validator.js
++++ b/lib/validator.js
+@@ -260,7 +260,7 @@ Validator.prototype.resolve = function resolve (schema, switchSchema, ctx) {
+     return {subschema: ctx.schemas[switchSchema], switchSchema: switchSchema};
+   }
+   // Else try walking the property pointer
+-  let parsed = new URL(switchSchema,'thismessage::/');
++  let parsed = new URL(switchSchema,'thismessage:/');
+   let fragment = parsed.hash;
+   var document = fragment && fragment.length && switchSchema.substr(0, switchSchema.length - fragment.length);
+   if (!document || !ctx.schemas[document]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,11 @@ overrides:
   lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
   '@better-auth/core': 1.4.19
 
+patchedDependencies:
+  jsonschema@1.5.0:
+    hash: dca3fa539faeef0ead30ccac3dfdc155a31ea77fbf2755fcccd903b38de4a9ba
+    path: patches/jsonschema@1.5.0.patch
+
 importers:
 
   .:
@@ -15622,7 +15627,7 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
-  jsonschema@1.5.0: {}
+  jsonschema@1.5.0(patch_hash=dca3fa539faeef0ead30ccac3dfdc155a31ea77fbf2755fcccd903b38de4a9ba): {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -15657,7 +15662,7 @@ snapshots:
       chalk: 5.6.2
       commander: 14.0.3
       fs-extra: 11.3.5
-      jsonschema: 1.5.0
+      jsonschema: 1.5.0(patch_hash=dca3fa539faeef0ead30ccac3dfdc155a31ea77fbf2755fcccd903b38de4a9ba)
       langium: 4.2.4
       langium-railroad: 4.2.0
       lodash: 4.18.1


### PR DESCRIPTION
Follow-up to #2836, which fixed the build but broke publishing.

## What went wrong

#2836 pinned the publish job to Node 22.x to dodge a `langium generate` crash on Node 24.20.0. The build then passed, but [the publish step failed](https://github.com/zenstackhq/zenstack/actions/runs/34440968359/job/102755740421):

```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@zenstackhq%2fcommon-helpers
```

The job has no `NODE_AUTH_TOKEN` — #2680 removed it when switching to **npm trusted publishing** (OIDC), and bumped Node 22.x → 24.x in the same commit, because trusted publishing requires **npm ≥ 11.5.1**:

| Node | bundled npm | OIDC trusted publishing |
| --- | --- | --- |
| 22.23.2 | 10.9.8 | ✗ |
| 24.18.0 | 11.16.0 | ✓ |
| 24.20.0 | 11.19.0 | ✓ (but crashed `langium generate`) |

Under Node 22, npm 10 ignores OIDC and falls back to the `.npmrc` authToken, which setup-node leaves as the literal placeholder `XXXXX-XXXXX-XXXXX-XXXXX` → unauthenticated PUT → npm's usual E404. Provenance still signed, since that path uses the Actions OIDC token directly rather than registry auth.

## This PR

Restores `node-version: 24.x` and fixes the actual defect instead.

`jsonschema@1.5.0` resolves `$ref`s with `new URL(ref, 'thismessage::/')`. That base has an *opaque* path (note the double colon), so resolving a path-absolute reference against it is invalid per the URL spec. Node ≤ 24.18.0 accepted it; Node 24.20.0's updated `ada` correctly throws `ERR_INVALID_URL`, which surfaces as:

```
TypeError: Invalid URL
    at Validator.resolve (.../jsonschema@1.5.0/lib/validator.js:263:16)
  input: '/undefined#/$defs/languageItem', base: 'thismessage::/'
```

The patch changes the base to `thismessage:/`, restoring the pre-24.20.0 resolution result on every Node version. `jsonschema@1.5.0` is the latest release and `langium-cli@4.4.0` still depends on `~1.5.0`, so there is no upgrade path.

## Verification

Under Node 24.20.0 (the version the failing runner used):

- `pnpm --filter @zenstackhq/language build` succeeds, with no change to generated sources.
- Schema validation still works — corrupting `langium-config.json` yields `instance.languages[0].grammar is not of a type(s) string`, which exercises the exact `$ref` path that used to throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved schema reference resolution for property pointers and fallback URLs.
  - Applied a compatibility fix to improve schema-based validation behavior.

- **Chores**
  - Updated release and testing environments to use Node.js 24 for improved runtime support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->