### PR TITLE
ci: restore Node 24.x for publish, patch jsonschema URL resolution (#2838)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,7 +47,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [22.x]
+                node-version: [24.x]
                 provider: [sqlite, postgresql, mysql]
 
         steps:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Use Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 22.x
+                  node-version: 24.x
                   cache: 'pnpm'
                   registry-url: 'https://registry.npmjs.org'
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,9 @@
             "cookie@<0.7.0": ">=0.7.0",
             "lodash@>=4.0.0 <=4.17.23": ">=4.18.0",
             "@better-auth/core": "1.4.19"
+        },
+        "patchedDependencies": {
+            "jsonschema@1.5.0": "patches/jsonschema@1.5.0.patch"
         }
     },
     "lint-staged": {

--- a/patches/jsonschema@1.5.0.patch
+++ b/patches/jsonschema@1.5.0.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/validator.js b/lib/validator.js
+index cca5e9c2216fd72d5da7eb63a38cebdf025e366e..ed6b2cf5376286dec39977c5823143766ae43080 100644
+--- a/lib/validator.js
++++ b/lib/validator.js
+@@ -260,7 +260,7 @@ Validator.prototype.resolve = function resolve (schema, switchSchema, ctx) {
+     return {subschema: ctx.schemas[switchSchema], switchSchema: switchSchema};
+   }
+   // Else try walking the property pointer
+-  let parsed = new URL(switchSchema,'thismessage::/');
++  let parsed = new URL(switchSchema,'thismessage:/');
+   let fragment = parsed.hash;
+   var document = fragment && fragment.length && switchSchema.substr(0, switchSchema.length - fragment.length);
+   if (!document || !ctx.schemas[document]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,11 @@ overrides:
   lodash@>=4.0.0 <=4.17.23: '>=4.18.0'
   '@better-auth/core': 1.4.19
 
+patchedDependencies:
+  jsonschema@1.5.0:
+    hash: dca3fa539faeef0ead30ccac3dfdc155a31ea77fbf2755fcccd903b38de4a9ba
+    path: patches/jsonschema@1.5.0.patch
+
 importers:
 
   .:
@@ -15622,7 +15627,7 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
-  jsonschema@1.5.0: {}
+  jsonschema@1.5.0(patch_hash=dca3fa539faeef0ead30ccac3dfdc155a31ea77fbf2755fcccd903b38de4a9ba): {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -15657,7 +15662,7 @@ snapshots:
       chalk: 5.6.2
       commander: 14.0.3
       fs-extra: 11.3.5
-      jsonschema: 1.5.0
+      jsonschema: 1.5.0(patch_hash=dca3fa539faeef0ead30ccac3dfdc155a31ea77fbf2755fcccd903b38de4a9ba)
       langium: 4.2.4
       langium-railroad: 4.2.0
       lodash: 4.18.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of relative references in JSON schemas, helping validation handle linked schemas more reliably.

* **Chores**
  * Updated automated build, test, and release processes to use Node.js 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->